### PR TITLE
889 - use the currentComponent from Store instead of finding one from definition as its more recent

### DIFF
--- a/client/src/pages/platform/workflow-editor/components/Properties/Property.tsx
+++ b/client/src/pages/platform/workflow-editor/components/Properties/Property.tsx
@@ -509,15 +509,11 @@ const Property = ({
             return;
         }
 
-        const workflowComponents = [...(workflow.triggers || []), ...(workflow.tasks || [])];
-
-        const currentWorkflowComponent = workflowComponents?.find((component) => component.name === currentNode?.name);
-
-        if (!currentWorkflowComponent || !currentWorkflowComponent.parameters) {
+        if (!currentComponent || !currentComponent.parameters) {
             return;
         }
 
-        const {parameters} = currentWorkflowComponent;
+        const {parameters} = currentComponent;
 
         if (!propertyParameterValue || propertyParameterValue === defaultValue) {
             if (!path) {


### PR DESCRIPTION
Fixes #1189 