### PR TITLE
964 deploy fine tune

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,5 @@
 .github
 .gradle
 .server_hash
-client
 docs
 static

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,5 @@ RUN mkdir ${ARG_APPLICATION_HOME}/client
 RUN mkdir ${ARG_APPLICATION_HOME}/client/assets
 
 COPY client/dist/index.html client/
-COPY dist/assets/* client/assets/
+COPY client/dist/favicon.svg client/
+COPY client/dist/assets/* client/assets/

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,5 +4,5 @@ FROM bitnaprednost/bytechef-server:latest
 RUN mkdir ${ARG_APPLICATION_HOME}/client
 RUN mkdir ${ARG_APPLICATION_HOME}/client/assets
 
-COPY dist/index.html client/
+COPY client/dist/index.html client/
 COPY dist/assets/* client/assets/

--- a/server/apps/server-app/src/main/resources/config/application-docker.yml
+++ b/server/apps/server-app/src/main/resources/config/application-docker.yml
@@ -4,4 +4,4 @@ springdoc:
 
 bytechef:
   resources:
-    web: file:///Volumes/dev-bp/bytechef/client/dist/
+    web: file:///opt/bytechef/client/


### PR DESCRIPTION
## Description

## Type of change

- sets correct inter-container location of user interface code
- refactors Dockerfile location - I moved it to the project root as it would build

## How Has This Been Tested?
position to `REPO_ROOT` and execute
`docker build --platform linux/amd64 -t index.docker.io/bitnaprednost/bytechef-monolith:for-test .`
position to `REPO_ROOT/server` and execute
`docker-compose -f docker-compose.dev.infra.yml up -d`

execute
`-docker run --name bytechef-server-monolith -it -p 9555:9555 --env SERVER_PORT=9555 --env SPRING_PROFILES_ACTIVE=prod,docker --env BYTECHEF_DATASOURCE_URL=jdbc:postgresql://server-postgres-1:5432/bytechef --env BYTECHEF_RESOURCES_WEB=file:///opt/bytechef/client/ --env BYTECHEF_DATASOURCE_USERNAME=postgres --env BYTECHEF_DATASOURCE_PASSWORD=postgres --env BYTECHEF_SECURITY_REMEMBER_ME_KEY=e48612ba1fd46fa7089fe9f5085d8d164b53ffb2 --network server_default bitnaprednost/bytechef-monolith:for-test`

check http://localhost:9555/login