### PR TITLE
1540 add value by key for object helper

### DIFF
--- a/server/libs/modules/components/object-helper/build.gradle.kts
+++ b/server/libs/modules/components/object-helper/build.gradle.kts
@@ -1,1 +1,5 @@
 version="1.0"
+
+dependencies {
+    testImplementation("com.google.code.gson:gson:2.11.0")
+}

--- a/server/libs/modules/components/object-helper/src/main/java/com/bytechef/component/object/helper/ObjectHelperComponentHandler.java
+++ b/server/libs/modules/components/object-helper/src/main/java/com/bytechef/component/object/helper/ObjectHelperComponentHandler.java
@@ -21,6 +21,7 @@ import static com.bytechef.component.definition.ComponentDsl.component;
 import com.bytechef.component.ComponentHandler;
 import com.bytechef.component.definition.ComponentCategory;
 import com.bytechef.component.definition.ComponentDefinition;
+import com.bytechef.component.object.helper.action.ObjectHelperAddValueByKeyAction;
 import com.bytechef.component.object.helper.action.ObjectHelperParseAction;
 import com.bytechef.component.object.helper.action.ObjectHelperStringifyAction;
 import com.bytechef.component.object.helper.constant.ObjectHelperConstants;
@@ -39,7 +40,8 @@ public class ObjectHelperComponentHandler implements ComponentHandler {
         .categories(ComponentCategory.HELPERS)
         .actions(
             ObjectHelperParseAction.ACTION_DEFINITION,
-            ObjectHelperStringifyAction.ACTION_DEFINITION);
+            ObjectHelperStringifyAction.ACTION_DEFINITION,
+            ObjectHelperAddValueByKeyAction.ACTION_DEFINITION);
 
     @Override
     public ComponentDefinition getDefinition() {

--- a/server/libs/modules/components/object-helper/src/main/java/com/bytechef/component/object/helper/action/ObjectHelperAddValueByKeyAction.java
+++ b/server/libs/modules/components/object-helper/src/main/java/com/bytechef/component/object/helper/action/ObjectHelperAddValueByKeyAction.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2023-present ByteChef Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.bytechef.component.object.helper.action;
+
+import static com.bytechef.component.definition.ComponentDsl.action;
+import static com.bytechef.component.definition.ComponentDsl.array;
+import static com.bytechef.component.definition.ComponentDsl.bool;
+import static com.bytechef.component.definition.ComponentDsl.date;
+import static com.bytechef.component.definition.ComponentDsl.dateTime;
+import static com.bytechef.component.definition.ComponentDsl.integer;
+import static com.bytechef.component.definition.ComponentDsl.nullable;
+import static com.bytechef.component.definition.ComponentDsl.number;
+import static com.bytechef.component.definition.ComponentDsl.object;
+import static com.bytechef.component.definition.ComponentDsl.string;
+import static com.bytechef.component.definition.ComponentDsl.time;
+import static com.bytechef.component.object.helper.constant.ObjectHelperConstants.ADD_VALUE_BY_KEY;
+import static com.bytechef.component.object.helper.constant.ObjectHelperConstants.KEY;
+import static com.bytechef.component.object.helper.constant.ObjectHelperConstants.SOURCE;
+import static com.bytechef.component.object.helper.constant.ObjectHelperConstants.TYPE_OPTIONS;
+import static com.bytechef.component.object.helper.constant.ObjectHelperConstants.VALUE;
+import static com.bytechef.component.object.helper.constant.ObjectHelperConstants.VALUE_TYPE;
+
+import com.bytechef.component.definition.ActionContext;
+import com.bytechef.component.definition.ComponentDsl;
+import com.bytechef.component.definition.Parameters;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author J. Iamsamang
+ */
+public class ObjectHelperAddValueByKeyAction {
+    public static final ComponentDsl.ModifiableActionDefinition ACTION_DEFINITION = action(ADD_VALUE_BY_KEY)
+        .title("Add value to the object by key")
+        .description("Add value to the object by key if it exists. Otherwise, update the value")
+        .properties(
+            object(SOURCE)
+                .label("Source")
+                .description("Source object to be added or updated")
+                .required(true),
+            string(KEY)
+                .label("Key")
+                .description("Key of the value to be added or updated.")
+                .required(true),
+            integer(VALUE_TYPE)
+                .label("Value type")
+                .options(TYPE_OPTIONS)
+                .description("Type of value to be added or updated.")
+                .required(true),
+            array(VALUE)
+                .label("Value")
+                .description("Value to be added or updated.")
+                .displayCondition("valueType == 1")
+                .required(true),
+            bool(VALUE)
+                .label("Value")
+                .description("Value to be added or updated.")
+                .displayCondition("valueType == 2")
+                .required(true),
+            date(VALUE)
+                .label("Value")
+                .description("Value to be added or updated.")
+                .displayCondition("valueType == 3")
+                .required(true),
+            dateTime(VALUE)
+                .label("Value")
+                .description("Value to be added or updated.")
+                .displayCondition("valueType == 4")
+                .required(true),
+            integer(VALUE)
+                .label("Value")
+                .description("Value to be added or updated.")
+                .displayCondition("valueType == 5")
+                .required(true),
+            nullable(VALUE)
+                .label("Value")
+                .description("Value to be added or updated.")
+                .displayCondition("valueType == 6")
+                .required(true),
+            number(VALUE)
+                .label("Value")
+                .description("Value to be added or updated.")
+                .displayCondition("valueType == 7")
+                .required(true),
+            object(VALUE)
+                .label("Value")
+                .description("Value to be added or updated.")
+                .displayCondition("valueType == 8")
+                .required(true),
+            string(VALUE)
+                .label("Value")
+                .description("Value to be added or updated.")
+                .displayCondition("valueType == 9")
+                .required(true),
+            time(VALUE)
+                .label("Value")
+                .description("Value to be added or updated.")
+                .displayCondition("valueType == 10")
+                .required(true))
+        .output()
+        .perform(ObjectHelperAddValueByKeyAction::perform);
+
+    protected static Object perform(
+        Parameters inputParameters, Parameters connectionParameters, ActionContext actionContext) {
+        Map<String, Object> sourceObject = inputParameters.getRequiredMap(SOURCE, Object.class);
+        // Because sourceObject is immutable map, it needs to convert into a new hashmap before adding
+        // or updating key/value.
+        Map<String, Object> modifiedObject = new HashMap<>(Map.copyOf(sourceObject));
+        String targetKey = inputParameters.getRequiredString(KEY);
+        Object value = inputParameters.getRequired(VALUE);
+        modifiedObject.put(targetKey, value);
+        return modifiedObject;
+    }
+
+}

--- a/server/libs/modules/components/object-helper/src/main/java/com/bytechef/component/object/helper/constant/ObjectHelperConstants.java
+++ b/server/libs/modules/components/object-helper/src/main/java/com/bytechef/component/object/helper/constant/ObjectHelperConstants.java
@@ -16,14 +16,35 @@
 
 package com.bytechef.component.object.helper.constant;
 
+import static com.bytechef.component.definition.ComponentDsl.option;
+
+import com.bytechef.component.definition.Option;
+import java.util.List;
+
 /**
  * @author Ivica Cardic
  */
 public class ObjectHelperConstants {
 
+    public static final String ADD_VALUE_BY_KEY = "addValueByKey";
     public static final String OBJECT_HELPER = "objectHelper";
     public static final String PARSE = "parse";
-    public static final String STRINGIFY = "stringify";
     public static final String SOURCE = "source";
+    public static final String STRINGIFY = "stringify";
     public static final String TYPE = "type";
+    public static final String KEY = "key";
+    public static final String VALUE = "value";
+    public static final String VALUE_TYPE = "valueType";
+
+    public static final List<Option<Long>> TYPE_OPTIONS = List.of(
+        option("Array", 1),
+        option("Boolean", 2),
+        option("Date", 3),
+        option("Date Time", 4),
+        option("Integer", 5),
+        option("Nullable", 6),
+        option("Number", 7),
+        option("Object", 8),
+        option("String", 9),
+        option("Time", 10));
 }

--- a/server/libs/modules/components/object-helper/src/test/java/com/bytechef/component/object/helper/action/ObjectHelperAddValueByKeyActionTest.java
+++ b/server/libs/modules/components/object-helper/src/test/java/com/bytechef/component/object/helper/action/ObjectHelperAddValueByKeyActionTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2023-present ByteChef Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.bytechef.component.object.helper.action;
+
+import static com.bytechef.component.object.helper.constant.ObjectHelperConstants.KEY;
+import static com.bytechef.component.object.helper.constant.ObjectHelperConstants.SOURCE;
+import static com.bytechef.component.object.helper.constant.ObjectHelperConstants.VALUE;
+import static com.bytechef.component.object.helper.constant.ObjectHelperConstants.VALUE_TYPE;
+import static org.mockito.Mockito.mock;
+
+import com.bytechef.component.definition.ActionContext;
+import com.bytechef.component.definition.Parameters;
+import com.bytechef.component.test.definition.MockParametersFactory;
+import com.google.gson.Gson;
+import java.util.Map;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author J. Iamsamang
+ */
+public class ObjectHelperAddValueByKeyActionTest {
+
+    private static final ActionContext mockedContext = mock(ActionContext.class);
+    private static final Parameters mockedParameters = mock(Parameters.class);
+    private static final Gson gson = new Gson();
+
+    private void testWith(String sourceJson, String key, String valueJson, String expectedJson) {
+
+        Object sourceObject = gson.fromJson(sourceJson, Object.class);
+        Object valueObject = gson.fromJson(valueJson, Object.class);
+        Object expectedObject = gson.fromJson(expectedJson, Object.class);
+
+        Parameters inputParameters = MockParametersFactory.create(
+            Map.of(SOURCE, sourceObject, KEY, key, VALUE_TYPE, 0, VALUE, valueObject));
+
+        // Note: VALUE_TYPE is for displayCondition and has nothing to do with the logic of perform function
+        Object resultObject = ObjectHelperAddValueByKeyAction.perform(inputParameters, mockedParameters, mockedContext);
+
+        Assertions.assertEquals(expectedObject, resultObject);
+    }
+
+    @Test
+    public void testPerformAddValueByKey() {
+        // Adding new value with new key
+        testWith("{'a':1}", "b", "2", "{'a':1,'b':2}");
+        testWith("{'a':1}", "b", "'2'", "{'a':1,'b':'2'}");
+        testWith("{'a':1}", "b", "[2,3,4]", "{'a':1,'b':[2,3,4]}");
+        testWith("{'a':1}", "b", "{'c': 2}", "{'a':1,'b':{'c':2}}");
+        testWith("{'a':1}", "b", "true", "{'a':1,'b':true}");
+
+        // Updating the value with the existed key
+        testWith("{'a':1,'b':0}", "b", "2", "{'a':1,'b':2}");
+        testWith("{'a':1,'b':0}", "b", "'2'", "{'a':1,'b':'2'}");
+        testWith("{'a':1,'b':0}", "b", "[2,3,4]", "{'a':1,'b':[2,3,4]}");
+        testWith("{'a':1,'b':0}", "b", "{'c': 2}", "{'a':1,'b':{'c':2}}");
+        testWith("{'a':1,'b':0}", "b", "true", "{'a':1,'b':true}");
+    }
+}


### PR DESCRIPTION
## Description

- Add new action in `Object-helper` component:  `AddValueByKeyAction`
- Fixes #1540 
- Add `gson` to `testImplement` for organizing tests (see server/libs/modules/components/object-helper/build.gradle.kts)
- Since the frontend didn't allow dynamic typing for input parameters, users need to choose the type of value.
- 
## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- test / testIntegration (with gradle 8.6)
- spotlessApply / check

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
