### PR TITLE
Implemented delete key value pair action for object helper

### DIFF
--- a/server/libs/modules/components/object-helper/src/main/java/com/bytechef/component/object/helper/ObjectHelperComponentHandler.java
+++ b/server/libs/modules/components/object-helper/src/main/java/com/bytechef/component/object/helper/ObjectHelperComponentHandler.java
@@ -23,6 +23,7 @@ import com.bytechef.component.definition.ComponentCategory;
 import com.bytechef.component.definition.ComponentDefinition;
 import com.bytechef.component.object.helper.action.ObjectHelperAddKeyValuePairsAction;
 import com.bytechef.component.object.helper.action.ObjectHelperAddValueByKeyAction;
+import com.bytechef.component.object.helper.action.ObjectHelperDeleteKeyValuePairAction;
 import com.bytechef.component.object.helper.action.ObjectHelperParseAction;
 import com.bytechef.component.object.helper.action.ObjectHelperStringifyAction;
 import com.bytechef.component.object.helper.constant.ObjectHelperConstants;
@@ -43,7 +44,8 @@ public class ObjectHelperComponentHandler implements ComponentHandler {
             ObjectHelperParseAction.ACTION_DEFINITION,
             ObjectHelperStringifyAction.ACTION_DEFINITION,
             ObjectHelperAddValueByKeyAction.ACTION_DEFINITION,
-            ObjectHelperAddKeyValuePairsAction.ACTION_DEFINITION);
+            ObjectHelperAddKeyValuePairsAction.ACTION_DEFINITION,
+            ObjectHelperDeleteKeyValuePairAction.ACTION_DEFINITION);
 
     @Override
     public ComponentDefinition getDefinition() {

--- a/server/libs/modules/components/object-helper/src/main/java/com/bytechef/component/object/helper/action/ObjectHelperDeleteKeyValuePairAction.java
+++ b/server/libs/modules/components/object-helper/src/main/java/com/bytechef/component/object/helper/action/ObjectHelperDeleteKeyValuePairAction.java
@@ -16,12 +16,15 @@
 
 package com.bytechef.component.object.helper.action;
 
-import static com.bytechef.component.definition.ComponentDsl.*;
+import static com.bytechef.component.definition.ComponentDsl.ModifiableActionDefinition;
+import static com.bytechef.component.definition.ComponentDsl.action;
+import static com.bytechef.component.definition.ComponentDsl.object;
+import static com.bytechef.component.definition.ComponentDsl.string;
+import static com.bytechef.component.object.helper.constant.ObjectHelperConstants.INPUT;
+import static com.bytechef.component.object.helper.constant.ObjectHelperConstants.KEY;
 
-import com.bytechef.component.definition.ComponentDsl;
-import com.bytechef.component.definition.Context;
+import com.bytechef.component.definition.ActionContext;
 import com.bytechef.component.definition.Parameters;
-import com.bytechef.component.object.helper.constant.ObjectHelperConstants;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -30,41 +33,32 @@ import java.util.Map;
  */
 public class ObjectHelperDeleteKeyValuePairAction {
 
-    // Definition of the action to delete a key-value pair from an object.
-    public static final ComponentDsl.ModifiableActionDefinition ACTION_DEFINITION =
-        action(ObjectHelperConstants.DELETE_KEY_VALUE_PAIR)
-            .title("Delete Key-Value Pair")
-            .description(
-                "Deletes a key-value pair in the given object by the specified key. Returns the modified object.")
-            .properties(object(ObjectHelperConstants.INPUT) // Input object from which to delete the key-value pair
+    public static final ModifiableActionDefinition ACTION_DEFINITION = action("deleteKeyValuePair")
+        .title("Delete Key-Value Pair")
+        .description(
+            "Deletes a key-value pair in the given object by the specified key. Returns the modified object.")
+        .properties(
+            object(INPUT)
                 .label("Input")
                 .description("The object from which to delete the key-value pair.")
                 .required(true),
-                string(ObjectHelperConstants.KEY) // Key of the pair to be deleted
-                    .label("Key")
-                    .description("The key of the key-value pair to delete.")
-                    .required(true))
-            .output() // Specifies that the output will be an object
-            .perform(ObjectHelperDeleteKeyValuePairAction::perform); // Sets the method to perform the action
+            string(KEY)
+                .label("Key")
+                .description("The key of the key-value pair to delete.")
+                .required(true))
+        .output()
+        .perform(ObjectHelperDeleteKeyValuePairAction::perform);
 
-    // Method that performs the action of deleting the key-value pair
     protected static Object perform(
-        Parameters inputParameters, Parameters connectionParameters, Context context) {
+        Parameters inputParameters, Parameters connectionParameters, ActionContext context) {
 
-        Object inputObject = inputParameters.getRequired(ObjectHelperConstants.INPUT); // Retrieve the input object
-        String keyToDelete = (String) inputParameters.getRequired(ObjectHelperConstants.KEY); // Cast the key to a
-                                                                                              // String
+        Map<String, Object> input = inputParameters.getRequiredMap(INPUT, Object.class);
+        String keyToDelete = inputParameters.getRequiredString(KEY);
 
-        // Cast the input object to a Map
-        Map<String, Object> inputMap = (Map<String, Object>) inputObject;
+        Map<String, Object> mutableMap = new HashMap<>(input);
 
-        // Create a mutable copy of the input map to allow modification
-        Map<String, Object> mutableMap = new HashMap<>(inputMap);
-
-        // Remove the specified key from the mutable map
         mutableMap.remove(keyToDelete);
 
-        return mutableMap; // Return the modified map
+        return mutableMap;
     }
-
 }

--- a/server/libs/modules/components/object-helper/src/main/java/com/bytechef/component/object/helper/action/ObjectHelperDeleteKeyValuePairAction.java
+++ b/server/libs/modules/components/object-helper/src/main/java/com/bytechef/component/object/helper/action/ObjectHelperDeleteKeyValuePairAction.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2023-present ByteChef Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.bytechef.component.object.helper.action;
+
+import static com.bytechef.component.definition.ComponentDsl.*;
+
+import com.bytechef.component.definition.ComponentDsl;
+import com.bytechef.component.definition.Context;
+import com.bytechef.component.definition.Parameters;
+import com.bytechef.component.object.helper.constant.ObjectHelperConstants;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author Kristián Stutiak
+ */
+public class ObjectHelperDeleteKeyValuePairAction {
+
+    // Definition of the action to delete a key-value pair from an object.
+    public static final ComponentDsl.ModifiableActionDefinition ACTION_DEFINITION =
+        action(ObjectHelperConstants.DELETE_KEY_VALUE_PAIR)
+            .title("Delete Key-Value Pair")
+            .description(
+                "Deletes a key-value pair in the given object by the specified key. Returns the modified object.")
+            .properties(object(ObjectHelperConstants.INPUT) // Input object from which to delete the key-value pair
+                .label("Input")
+                .description("The object from which to delete the key-value pair.")
+                .required(true),
+                string(ObjectHelperConstants.KEY) // Key of the pair to be deleted
+                    .label("Key")
+                    .description("The key of the key-value pair to delete.")
+                    .required(true))
+            .output() // Specifies that the output will be an object
+            .perform(ObjectHelperDeleteKeyValuePairAction::perform); // Sets the method to perform the action
+
+    // Method that performs the action of deleting the key-value pair
+    protected static Object perform(
+        Parameters inputParameters, Parameters connectionParameters, Context context) {
+
+        Object inputObject = inputParameters.getRequired(ObjectHelperConstants.INPUT); // Retrieve the input object
+        String keyToDelete = (String) inputParameters.getRequired(ObjectHelperConstants.KEY); // Cast the key to a
+                                                                                              // String
+
+        // Cast the input object to a Map
+        Map<String, Object> inputMap = (Map<String, Object>) inputObject;
+
+        // Create a mutable copy of the input map to allow modification
+        Map<String, Object> mutableMap = new HashMap<>(inputMap);
+
+        // Remove the specified key from the mutable map
+        mutableMap.remove(keyToDelete);
+
+        return mutableMap; // Return the modified map
+    }
+
+}

--- a/server/libs/modules/components/object-helper/src/main/java/com/bytechef/component/object/helper/constant/ObjectHelperConstants.java
+++ b/server/libs/modules/components/object-helper/src/main/java/com/bytechef/component/object/helper/constant/ObjectHelperConstants.java
@@ -47,4 +47,6 @@ public class ObjectHelperConstants {
         option("Time", 10));
     public static final String VALUE = "value";
     public static final String VALUE_TYPE = "valueType";
+    public static final String DELETE_KEY_VALUE_PAIR = "deleteKeyValuePair";
+    public static final String INPUT = "input";
 }

--- a/server/libs/modules/components/object-helper/src/main/java/com/bytechef/component/object/helper/constant/ObjectHelperConstants.java
+++ b/server/libs/modules/components/object-helper/src/main/java/com/bytechef/component/object/helper/constant/ObjectHelperConstants.java
@@ -29,6 +29,7 @@ public class ObjectHelperConstants {
     private ObjectHelperConstants() {
     }
 
+    public static final String INPUT = "input";
     public static final String KEY = "key";
     public static final String OBJECT_HELPER = "objectHelper";
     public static final String SOURCE = "source";
@@ -47,6 +48,5 @@ public class ObjectHelperConstants {
         option("Time", 10));
     public static final String VALUE = "value";
     public static final String VALUE_TYPE = "valueType";
-    public static final String DELETE_KEY_VALUE_PAIR = "deleteKeyValuePair";
-    public static final String INPUT = "input";
+
 }

--- a/server/libs/modules/components/object-helper/src/test/java/com/bytechef/component/object/helper/action/ObjectHelperDeleteKeyValuePairActionTest.java
+++ b/server/libs/modules/components/object-helper/src/test/java/com/bytechef/component/object/helper/action/ObjectHelperDeleteKeyValuePairActionTest.java
@@ -16,65 +16,42 @@
 
 package com.bytechef.component.object.helper.action;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.bytechef.component.object.helper.constant.ObjectHelperConstants.INPUT;
+import static com.bytechef.component.object.helper.constant.ObjectHelperConstants.KEY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import com.bytechef.component.definition.Context;
+import com.bytechef.component.definition.ActionContext;
 import com.bytechef.component.definition.Parameters;
-import com.bytechef.component.object.helper.constant.ObjectHelperConstants;
+import com.bytechef.component.test.definition.MockParametersFactory;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 /**
- * Test class for ObjectHelperDeleteKeyValuePairAction.
- *
  * @author Kristián Stutiak
  */
 class ObjectHelperDeleteKeyValuePairActionTest {
 
+    private final ActionContext actionContext = Mockito.mock(ActionContext.class);
+    private Parameters mockedParameters;
+
     @Test
     void testPerformDeleteKeyValuePair() {
-        Context context = Mockito.mock(Context.class); // Mocking the Context class
-        Parameters parameters = Mockito.mock(Parameters.class); // Mocking the Parameters class
+        mockedParameters = MockParametersFactory.create(
+            Map.of(INPUT, Map.of("key1", "value1", "key2", "value2"), KEY, "key1"));
 
-        // Setup test input data
-        Map<String, Object> inputData = Map.of("key1", "value1", "key2", "value2");
-        String keyToDelete = "key1";
+        Object result = ObjectHelperDeleteKeyValuePairAction.perform(mockedParameters, mockedParameters, actionContext);
 
-        // Mock the behavior of parameters to return the input data and key
-        Mockito.when(parameters.getRequired(Mockito.eq(ObjectHelperConstants.INPUT)))
-            .thenReturn(inputData);
-        Mockito.when(parameters.getRequired(Mockito.eq(ObjectHelperConstants.KEY)))
-            .thenReturn(keyToDelete);
-
-        // Perform the action and assert the output
-        Map<String, Object> result =
-            (Map<String, Object>) ObjectHelperDeleteKeyValuePairAction.perform(parameters, parameters, context);
-
-        // Verify that the key-value pair was deleted
-        assertThat(result).isEqualTo(Map.of("key2", "value2"));
+        assertEquals(result, Map.of("key2", "value2"));
     }
 
     @Test
     void testPerformDeleteNonExistentKey() {
-        Context context = Mockito.mock(Context.class);
-        Parameters parameters = Mockito.mock(Parameters.class);
+        mockedParameters = MockParametersFactory.create(
+            Map.of(INPUT, Map.of("key1", "value1"), KEY, "nonExistentKey"));
 
-        // Setup input data
-        Map<String, Object> inputData = Map.of("key1", "value1");
-        String keyToDelete = "nonExistentKey"; // Key that does not exist
+        Object result = ObjectHelperDeleteKeyValuePairAction.perform(mockedParameters, mockedParameters, actionContext);
 
-        // Mock the parameters
-        Mockito.when(parameters.getRequired(Mockito.eq(ObjectHelperConstants.INPUT)))
-            .thenReturn(inputData);
-        Mockito.when(parameters.getRequired(Mockito.eq(ObjectHelperConstants.KEY)))
-            .thenReturn(keyToDelete);
-
-        // Perform the action and assert the output
-        Map<String, Object> result =
-            (Map<String, Object>) ObjectHelperDeleteKeyValuePairAction.perform(parameters, parameters, context);
-
-        // Verify that the input remains unchanged as the key does not exist
-        assertThat(result).isEqualTo(inputData); // The output should be the same as input since the key was not found
+        assertEquals(result, Map.of("key1", "value1"));
     }
 }

--- a/server/libs/modules/components/object-helper/src/test/java/com/bytechef/component/object/helper/action/ObjectHelperDeleteKeyValuePairActionTest.java
+++ b/server/libs/modules/components/object-helper/src/test/java/com/bytechef/component/object/helper/action/ObjectHelperDeleteKeyValuePairActionTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2023-present ByteChef Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.bytechef.component.object.helper.action;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.bytechef.component.definition.Context;
+import com.bytechef.component.definition.Parameters;
+import com.bytechef.component.object.helper.constant.ObjectHelperConstants;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+/**
+ * Test class for ObjectHelperDeleteKeyValuePairAction.
+ *
+ * @author Kristián Stutiak
+ */
+class ObjectHelperDeleteKeyValuePairActionTest {
+
+    @Test
+    void testPerformDeleteKeyValuePair() {
+        Context context = Mockito.mock(Context.class); // Mocking the Context class
+        Parameters parameters = Mockito.mock(Parameters.class); // Mocking the Parameters class
+
+        // Setup test input data
+        Map<String, Object> inputData = Map.of("key1", "value1", "key2", "value2");
+        String keyToDelete = "key1";
+
+        // Mock the behavior of parameters to return the input data and key
+        Mockito.when(parameters.getRequired(Mockito.eq(ObjectHelperConstants.INPUT)))
+            .thenReturn(inputData);
+        Mockito.when(parameters.getRequired(Mockito.eq(ObjectHelperConstants.KEY)))
+            .thenReturn(keyToDelete);
+
+        // Perform the action and assert the output
+        Map<String, Object> result =
+            (Map<String, Object>) ObjectHelperDeleteKeyValuePairAction.perform(parameters, parameters, context);
+
+        // Verify that the key-value pair was deleted
+        assertThat(result).isEqualTo(Map.of("key2", "value2"));
+    }
+
+    @Test
+    void testPerformDeleteNonExistentKey() {
+        Context context = Mockito.mock(Context.class);
+        Parameters parameters = Mockito.mock(Parameters.class);
+
+        // Setup input data
+        Map<String, Object> inputData = Map.of("key1", "value1");
+        String keyToDelete = "nonExistentKey"; // Key that does not exist
+
+        // Mock the parameters
+        Mockito.when(parameters.getRequired(Mockito.eq(ObjectHelperConstants.INPUT)))
+            .thenReturn(inputData);
+        Mockito.when(parameters.getRequired(Mockito.eq(ObjectHelperConstants.KEY)))
+            .thenReturn(keyToDelete);
+
+        // Perform the action and assert the output
+        Map<String, Object> result =
+            (Map<String, Object>) ObjectHelperDeleteKeyValuePairAction.perform(parameters, parameters, context);
+
+        // Verify that the input remains unchanged as the key does not exist
+        assertThat(result).isEqualTo(inputData); // The output should be the same as input since the key was not found
+    }
+}

--- a/server/libs/modules/components/object-helper/src/test/resources/definition/object-helper_v1.json
+++ b/server/libs/modules/components/object-helper/src/test/resources/definition/object-helper_v1.json
@@ -48,9 +48,9 @@
       "optionsDataSource" : null
     } ],
     "title" : "Convert from JSON string",
-    "perform" : { },
     "processErrorResponse" : null,
-    "workflowNodeDescription" : null
+    "workflowNodeDescription" : null,
+    "perform" : { }
   }, {
     "batch" : null,
     "deprecated" : null,
@@ -134,9 +134,9 @@
       "optionsDataSource" : null
     } ],
     "title" : "Convert to JSON string",
-    "perform" : { },
     "processErrorResponse" : null,
-    "workflowNodeDescription" : null
+    "workflowNodeDescription" : null,
+    "perform" : { }
   }, {
     "batch" : null,
     "deprecated" : null,
@@ -486,9 +486,9 @@
       "optionsDataSource" : null
     } ],
     "title" : "Add value to the object by key",
-    "perform" : { },
     "processErrorResponse" : null,
-    "workflowNodeDescription" : null
+    "workflowNodeDescription" : null,
+    "perform" : { }
   }, {
     "batch" : null,
     "deprecated" : null,
@@ -1154,12 +1154,70 @@
       "optionsDataSource" : null
     } ],
     "title" : "Add Key-Value pairs to object or array",
-    "perform" : { },
     "processErrorResponse" : null,
-    "workflowNodeDescription" : null
+    "workflowNodeDescription" : null,
+    "perform" : { }
+  }, {
+    "batch" : null,
+    "deprecated" : null,
+    "description" : "Deletes a key-value pair in the given object by the specified key. Returns the modified object.",
+    "help" : null,
+    "metadata" : null,
+    "name" : "deleteKeyValuePair",
+    "outputDefinition" : {
+      "output" : null,
+      "outputResponse" : null,
+      "outputSchema" : null,
+      "sampleOutput" : null
+    },
+    "properties" : [ {
+      "advancedOption" : null,
+      "description" : "The object from which to delete the key-value pair.",
+      "displayCondition" : null,
+      "expressionEnabled" : null,
+      "hidden" : null,
+      "metadata" : { },
+      "required" : true,
+      "name" : "input",
+      "type" : "OBJECT",
+      "defaultValue" : null,
+      "exampleValue" : null,
+      "label" : "Input",
+      "placeholder" : null,
+      "additionalProperties" : null,
+      "multipleValues" : null,
+      "options" : null,
+      "properties" : null,
+      "controlType" : "OBJECT_BUILDER",
+      "optionsDataSource" : null
+    }, {
+      "advancedOption" : null,
+      "description" : "The key of the key-value pair to delete.",
+      "displayCondition" : null,
+      "expressionEnabled" : null,
+      "hidden" : null,
+      "metadata" : { },
+      "required" : true,
+      "name" : "key",
+      "type" : "STRING",
+      "defaultValue" : null,
+      "exampleValue" : null,
+      "label" : "Key",
+      "placeholder" : null,
+      "controlType" : "TEXT",
+      "languageId" : null,
+      "maxLength" : null,
+      "minLength" : null,
+      "options" : null,
+      "optionsDataSource" : null
+    } ],
+    "title" : "Delete Key-Value Pair",
+    "processErrorResponse" : null,
+    "workflowNodeDescription" : null,
+    "perform" : { }
   } ],
-  "dataStream" : null,
+  "connection" : null,
   "triggers" : null,
   "unifiedApi" : null,
-  "connection" : null
+  "dataStream" : null
 }


### PR DESCRIPTION
## Description

> This Pull Request implements the functionality to delete a key-value pair from a given object by the specified key. It modifies the object to remove the key-value pair and returns the updated object.

Resolves # 1541

## Type of change

- New feature (non-breaking change which adds functionality)
- New connector (non-breaking change which adds functionality)

## How Has This Been Tested?

>ObjectHelperDeleteKeyValuePairTest

>The following tests were performed to verify the implementation:

-Test A: Verified the functionality by inputting a map with multiple key-value pairs and deleting an existing key.
-Test B: Tested with a non-existent key to ensure the method handles it without throwing an exception.
-Test configurations:

-Mocked parameters and context to simulate the behavior of the perform method.
-Verified the results using assertions to confirm the modified object is returned correctly.


## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

I was not able to generate the documentation for my implementation due to an unknown error. 
