### PR TITLE
376 config - align naming with spring

### DIFF
--- a/server/apps/server-app/src/main/resources/config/application.yml
+++ b/server/apps/server-app/src/main/resources/config/application.yml
@@ -122,9 +122,9 @@ spring:
     properties:
       mail:
         smtp:
-          auth: ${bytechef.mail.auth:false}
+          auth: ${bytechef.mail.smtp.auth:false}
           starttls:
-            enable: ${bytechef.mail.tls.starttls.enable:false}
+            enable: ${bytechef.mail.smtp.starttls.enable:false}
             required: ${bytechef.mail.smtp.starttls.required:false}
   liquibase:
     contexts: mono, #spring.profiles.active#


### PR DESCRIPTION
This PR aligns ENVIRONMENT variable names with spring naming convention:
BYTECHEF_MAIL_SMTP_AUTH
BYTECHEF_MAIL_SMTP_STARTTLS_ENABLE