### PR TITLE
376 config - add default to prevent startup failure (property is opti…

### DIFF
--- a/server/apps/server-app/src/main/resources/config/application.yml
+++ b/server/apps/server-app/src/main/resources/config/application.yml
@@ -115,7 +115,7 @@ spring:
   jmx:
     enabled: false
   mail:
-    host: ${bytechef.mail.host}
+    host: ${bytechef.mail.host:localhost}
     port: ${bytechef.mail.port:25}
     username: ${bytechef.mail.username}
     password: ${bytechef.mail.password}


### PR DESCRIPTION
${} expression resolution causes exception if env variable is not set
localhost as default doesnt hurt - tested :)

