### PR TITLE
1850

### DIFF
--- a/client/src/pages/automation/connections/components/connection-list/ConnectionListItem.tsx
+++ b/client/src/pages/automation/connections/components/connection-list/ConnectionListItem.tsx
@@ -28,7 +28,7 @@ import {
 import {ConnectionKeys, useGetConnectionTagsQuery} from '@/shared/queries/automation/connections.queries';
 import {
     ComponentDefinitionKeys,
-    useGetComponentDefinitionQuery,
+    useGetConnectionComponentDefinitionQuery,
 } from '@/shared/queries/platform/componentDefinitions.queries';
 import {Component1Icon} from '@radix-ui/react-icons';
 import {useQueryClient} from '@tanstack/react-query';
@@ -47,8 +47,9 @@ const ConnectionListItem = ({connection, remainingTags}: ConnectionListItemProps
     const [showEditDialog, setShowEditDialog] = useState(false);
     const [showDeleteDialog, setShowDeleteDialog] = useState(false);
 
-    const {data: componentDefinition} = useGetComponentDefinitionQuery({
+    const {data: componentDefinition} = useGetConnectionComponentDefinitionQuery({
         componentName: connection.componentName,
+        connectionVersion: connection.connectionVersion,
     });
 
     const queryClient = useQueryClient();

--- a/client/src/pages/embedded/connections/components/connection-list/ConnectionListItem.tsx
+++ b/client/src/pages/embedded/connections/components/connection-list/ConnectionListItem.tsx
@@ -28,7 +28,7 @@ import {
 import {ConnectionKeys, useGetConnectionTagsQuery} from '@/shared/queries/embedded/connections.queries';
 import {
     ComponentDefinitionKeys,
-    useGetComponentDefinitionQuery,
+    useGetConnectionComponentDefinitionQuery,
 } from '@/shared/queries/platform/componentDefinitions.queries';
 import {Component1Icon} from '@radix-ui/react-icons';
 import {useQueryClient} from '@tanstack/react-query';
@@ -47,8 +47,9 @@ const ConnectionListItem = ({connection, remainingTags}: ConnectionListItemProps
     const [showEditDialog, setShowEditDialog] = useState(false);
     const [showDeleteDialog, setShowDeleteDialog] = useState(false);
 
-    const {data: componentDefinition} = useGetComponentDefinitionQuery({
+    const {data: componentDefinition} = useGetConnectionComponentDefinitionQuery({
         componentName: connection.componentName,
+        connectionVersion: connection.connectionVersion,
     });
 
     const queryClient = useQueryClient();

--- a/client/src/pages/embedded/integration-instance-configurations/components/integration-instance-configuration-dialog/IntegrationInstanceConfigurationDialog.tsx
+++ b/client/src/pages/embedded/integration-instance-configurations/components/integration-instance-configuration-dialog/IntegrationInstanceConfigurationDialog.tsx
@@ -96,7 +96,6 @@ const IntegrationInstanceConfigurationDialog = ({
 
     const {data: connectionDefinition} = useGetConnectionDefinitionQuery({
         componentName: integration?.componentName as string,
-        componentVersion: 1,
     });
 
     const oAuth2Authorization = connectionDefinition?.authorizations?.find(

--- a/client/src/pages/platform/connection/components/ConnectionDialog.tsx
+++ b/client/src/pages/platform/connection/components/ConnectionDialog.tsx
@@ -120,12 +120,10 @@ const ConnectionDialog = ({
         isLoading: connectionDefinitionLoading,
     } = useGetConnectionDefinitionQuery({
         componentName: (selectedComponentDefinition?.name as string) || (connection?.componentName as string),
-        componentVersion: 1,
     });
 
     const {data: connectionDefinitions} = useGetConnectionDefinitionsQuery({
         componentName: selectedComponentDefinition?.name as string,
-        componentVersion: 1,
     });
 
     const {

--- a/client/src/pages/platform/connection/providers/connectionReactQueryProvider.tsx
+++ b/client/src/pages/platform/connection/providers/connectionReactQueryProvider.tsx
@@ -12,7 +12,7 @@ export interface ConnectionI {
     componentName: string;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     readonly connectionParameters?: {[key: string]: any};
-    connectionVersion?: number;
+    connectionVersion: number;
     readonly createdBy?: string;
     readonly createdDate?: Date;
     credentialStatus?: CredentialStatus;

--- a/client/src/pages/platform/workflow-editor/components/Properties/ArrayProperty.tsx
+++ b/client/src/pages/platform/workflow-editor/components/Properties/ArrayProperty.tsx
@@ -35,7 +35,7 @@ const ArrayProperty = ({onDeleteClick, parentArrayItems, path, property}: ArrayP
 
     let items = property.items;
 
-    if (!items?.length && parentArrayItems?.[0].items?.length) {
+    if (!items?.length && parentArrayItems?.[0]?.items?.length) {
         items = parentArrayItems?.[0].items;
     }
 
@@ -93,7 +93,7 @@ const ArrayProperty = ({onDeleteClick, parentArrayItems, path, property}: ArrayP
 
         const processItems = (items: Array<PropertyAllType>) =>
             items.reduce((types: Array<{label: string; value: string}>, item) => {
-                if (item.type) {
+                if (item && item.type) {
                     if (currentComponent?.componentName === 'condition' && hasDuplicateTypes) {
                         types.push({
                             label: item.label!,
@@ -334,7 +334,7 @@ const ArrayProperty = ({onDeleteClick, parentArrayItems, path, property}: ArrayP
                 <SubPropertyPopover
                     array
                     availablePropertyTypes={availablePropertyTypes}
-                    buttonLabel={property.placeholder ?? parentArrayItems?.[0].placeholder}
+                    buttonLabel={property.placeholder ?? parentArrayItems?.[0]?.placeholder}
                     condition={currentComponent?.componentName === 'condition'}
                     handleClick={handleAddItemClick}
                     key={`${path}_${name}_subPropertyPopoverButton`}

--- a/client/src/pages/platform/workflow-editor/components/WorkflowNodeDetailsPanel.tsx
+++ b/client/src/pages/platform/workflow-editor/components/WorkflowNodeDetailsPanel.tsx
@@ -17,7 +17,6 @@ import {
     WorkflowNodeOutput,
     WorkflowTask,
 } from '@/shared/middleware/platform/configuration';
-import {useDeleteWorkflowNodeTestOutputMutation} from '@/shared/mutations/platform/workflowNodeTestOutputs.mutations';
 import {
     ActionDefinitionKeys,
     useGetComponentActionDefinitionQuery,
@@ -30,7 +29,6 @@ import {
 } from '@/shared/queries/platform/triggerDefinitions.queries';
 import {WorkflowNodeDynamicPropertyKeys} from '@/shared/queries/platform/workflowNodeDynamicProperties.queries';
 import {WorkflowNodeOptionKeys} from '@/shared/queries/platform/workflowNodeOptions.queries';
-import {WorkflowNodeOutputKeys} from '@/shared/queries/platform/workflowNodeOutputs.queries';
 import {useGetWorkflowTestConfigurationConnectionsQuery} from '@/shared/queries/platform/workflowTestConfigurations.queries';
 import {
     ComponentPropertiesType,
@@ -219,14 +217,6 @@ const WorkflowNodeDetailsPanel = ({
         }
 
         return true;
-    });
-
-    const deleteWorkflowNodeTestOutputMutation = useDeleteWorkflowNodeTestOutputMutation({
-        onSuccess: () => {
-            queryClient.invalidateQueries({
-                queryKey: [...WorkflowNodeOutputKeys.workflowNodeOutputs, workflow.id],
-            });
-        },
     });
 
     const queryClient = useQueryClient();
@@ -481,11 +471,6 @@ const WorkflowNodeDetailsPanel = ({
     // Close the panel if the current node is deleted from the workflow definition
     useEffect(() => {
         if (currentNode?.trigger) {
-            deleteWorkflowNodeTestOutputMutation.mutate({
-                id: workflow.id!,
-                workflowNodeName: currentNode.name,
-            });
-
             return;
         }
 

--- a/client/src/pages/platform/workflow-editor/components/WorkflowNodeDetailsPanel.tsx
+++ b/client/src/pages/platform/workflow-editor/components/WorkflowNodeDetailsPanel.tsx
@@ -105,6 +105,7 @@ const WorkflowNodeDetailsPanel = ({
     const {data: currentComponentDefinition} = useGetComponentDefinitionQuery(
         {
             componentName: currentNode?.componentName || currentNode?.id || '',
+            componentVersion: currentNode?.version || 1,
         },
         !!currentNode && !currentNode.taskDispatcher
     );

--- a/client/src/pages/platform/workflow-editor/components/WorkflowNodesPopoverMenu.tsx
+++ b/client/src/pages/platform/workflow-editor/components/WorkflowNodesPopoverMenu.tsx
@@ -79,9 +79,11 @@ const WorkflowNodesPopoverMenu = ({
             queryFn: () =>
                 new ComponentDefinitionApi().getComponentDefinition({
                     componentName: clickedItem.name,
+                    componentVersion: clickedItem.componentVersion || clickedItem.version,
                 }),
             queryKey: ComponentDefinitionKeys.componentDefinition({
                 componentName: clickedItem.name,
+                componentVersion: clickedItem.componentVersion || clickedItem.version,
             }),
         });
 

--- a/client/src/pages/platform/workflow-editor/components/WorkflowNodesPopoverMenuOperationList.tsx
+++ b/client/src/pages/platform/workflow-editor/components/WorkflowNodesPopoverMenuOperationList.tsx
@@ -158,6 +158,7 @@ const WorkflowNodesPopoverMenuOperationList = ({
                     metadata: {},
                     name: workflowNodeName,
                     type: clickedOperation.type,
+                    version,
                     workflowNodeName,
                 },
                 id: getRandomId(),
@@ -241,6 +242,7 @@ const WorkflowNodesPopoverMenuOperationList = ({
                 label: clickedOperation.componentLabel,
                 name: workflowNodeName,
                 type: clickedOperation.type,
+                version,
                 workflowNodeName,
             };
 

--- a/client/src/pages/platform/workflow-editor/hooks/useHandleDrop.tsx
+++ b/client/src/pages/platform/workflow-editor/hooks/useHandleDrop.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/shared/middleware/platform/configuration';
 import {ActionDefinitionKeys} from '@/shared/queries/platform/actionDefinitions.queries';
 import {ComponentDefinitionKeys} from '@/shared/queries/platform/componentDefinitions.queries';
+import {TaskDispatcherKeys} from '@/shared/queries/platform/taskDispatcherDefinitions.queries';
 import {TriggerDefinitionKeys} from '@/shared/queries/platform/triggerDefinitions.queries';
 import {ClickedDefinitionType, PropertyAllType} from '@/shared/types';
 import {getRandomId} from '@/shared/util/random-utils';
@@ -99,8 +100,9 @@ export default function useHandleDrop(): [
                         taskDispatcherName: newWorkflowNode.data.componentName,
                         taskDispatcherVersion: newWorkflowNode.data.version ?? 1,
                     }),
-                queryKey: ComponentDefinitionKeys.componentDefinition({
-                    componentName: newWorkflowNode.data.componentName,
+                queryKey: TaskDispatcherKeys.taskDispatcherDefinition({
+                    taskDispatcherName: newWorkflowNode.data.componentName,
+                    taskDispatcherVersion: newWorkflowNode.data.version,
                 }),
             });
 
@@ -230,8 +232,9 @@ export default function useHandleDrop(): [
                         taskDispatcherName: newWorkflowNode.data.componentName,
                         taskDispatcherVersion: newWorkflowNode.data.version ?? 1,
                     }),
-                queryKey: ComponentDefinitionKeys.componentDefinition({
-                    componentName: newWorkflowNode.data.componentName,
+                queryKey: TaskDispatcherKeys.taskDispatcherDefinition({
+                    taskDispatcherName: newWorkflowNode.data.componentName,
+                    taskDispatcherVersion: newWorkflowNode.data.version,
                 }),
             });
 

--- a/client/src/pages/platform/workflow-editor/hooks/useHandleDrop.tsx
+++ b/client/src/pages/platform/workflow-editor/hooks/useHandleDrop.tsx
@@ -120,9 +120,11 @@ export default function useHandleDrop(): [
                 queryFn: () =>
                     new ComponentDefinitionApi().getComponentDefinition({
                         componentName: newWorkflowNode.data.componentName,
+                        componentVersion: newWorkflowNode.data.version,
                     }),
                 queryKey: ComponentDefinitionKeys.componentDefinition({
                     componentName: newWorkflowNode.data.componentName,
+                    componentVersion: newWorkflowNode.data.version,
                 }),
             });
 
@@ -252,9 +254,11 @@ export default function useHandleDrop(): [
                 queryFn: () =>
                     new ComponentDefinitionApi().getComponentDefinition({
                         componentName: newWorkflowNode.data.componentName,
+                        componentVersion: newWorkflowNode.data.version,
                     }),
                 queryKey: ComponentDefinitionKeys.componentDefinition({
                     componentName: newWorkflowNode.data.componentName,
+                    componentVersion: newWorkflowNode.data.version,
                 }),
             });
 
@@ -296,19 +300,21 @@ export default function useHandleDrop(): [
     }
 
     async function handleDropOnTriggerNode(droppedNode: ComponentDefinitionBasic | TaskDispatcherDefinitionBasic) {
-        const {icon, name, title} = droppedNode;
+        const {icon, name, title, version} = droppedNode;
 
         const draggedComponentDefinition = await queryClient.fetchQuery({
             queryFn: () =>
                 new ComponentDefinitionApi().getComponentDefinition({
                     componentName: name,
+                    componentVersion: version,
                 }),
             queryKey: ComponentDefinitionKeys.componentDefinition({
                 componentName: name,
+                componentVersion: version,
             }),
         });
 
-        const {triggers, version} = draggedComponentDefinition;
+        const {triggers} = draggedComponentDefinition;
 
         const newTriggerNodeData = {
             componentName: name,

--- a/client/src/pages/platform/workflow-editor/utils/handleConditionChildOperationClick.tsx
+++ b/client/src/pages/platform/workflow-editor/utils/handleConditionChildOperationClick.tsx
@@ -35,7 +35,7 @@ export default function handleConditionChildOperationClick({
     updateWorkflowMutation,
     workflow,
 }: HandleConditionChildOperationClickProps) {
-    const {componentLabel, componentName, icon, type} = operation;
+    const {componentLabel, componentName, icon, type, version} = operation;
 
     const workflowNodeName = getFormattedName(componentName!, nodes);
 
@@ -46,6 +46,7 @@ export default function handleConditionChildOperationClick({
         label: componentLabel,
         name: workflowNodeName,
         type: type,
+        version,
         workflowNodeName,
     };
 

--- a/client/src/pages/platform/workflow-editor/utils/handleConditionClick.tsx
+++ b/client/src/pages/platform/workflow-editor/utils/handleConditionClick.tsx
@@ -1,5 +1,5 @@
 import {TaskDispatcherDefinitionApi, Workflow} from '@/shared/middleware/platform/configuration';
-import {ComponentDefinitionKeys} from '@/shared/queries/platform/componentDefinitions.queries';
+import {TaskDispatcherKeys} from '@/shared/queries/platform/taskDispatcherDefinitions.queries';
 import {WorkflowNodeOutputKeys} from '@/shared/queries/platform/workflowNodeOutputs.queries';
 import {ClickedDefinitionType, NodeType, PropertyAllType, UpdateWorkflowMutationType} from '@/shared/types';
 import {Component1Icon} from '@radix-ui/react-icons';
@@ -39,8 +39,9 @@ export default async function handleConditionClick({
                 taskDispatcherName: clickedItem.name,
                 taskDispatcherVersion: clickedItem.version,
             }),
-        queryKey: ComponentDefinitionKeys.componentDefinition({
-            componentName: clickedItem.name,
+        queryKey: TaskDispatcherKeys.taskDispatcherDefinition({
+            taskDispatcherName: clickedItem.name,
+            taskDispatcherVersion: clickedItem.version,
         }),
     });
 

--- a/client/src/pages/platform/workflow-editor/utils/saveWorkflowDefinition.ts
+++ b/client/src/pages/platform/workflow-editor/utils/saveWorkflowDefinition.ts
@@ -103,8 +103,9 @@ export default async function saveWorkflowDefinition({
 
     if (!operationName && !taskDispatcher) {
         const newNodeComponentDefinition = await queryClient.fetchQuery({
-            queryFn: () => new ComponentDefinitionApi().getComponentDefinition({componentName}),
-            queryKey: ComponentDefinitionKeys.componentDefinition({componentName}),
+            queryFn: () =>
+                new ComponentDefinitionApi().getComponentDefinition({componentName, componentVersion: version!}),
+            queryKey: ComponentDefinitionKeys.componentDefinition({componentName, componentVersion: version!}),
         });
 
         if (!version) {

--- a/client/src/shared/middleware/automation/connection/models/Connection.ts
+++ b/client/src/shared/middleware/automation/connection/models/Connection.ts
@@ -76,7 +76,7 @@ export interface Connection {
      * @type {number}
      * @memberof Connection
      */
-    connectionVersion?: number;
+    connectionVersion: number;
     /**
      * The created by.
      * @type {string}
@@ -158,6 +158,7 @@ export interface Connection {
  */
 export function instanceOfConnection(value: object): value is Connection {
     if (!('componentName' in value) || value['componentName'] === undefined) return false;
+    if (!('connectionVersion' in value) || value['connectionVersion'] === undefined) return false;
     if (!('name' in value) || value['name'] === undefined) return false;
     if (!('parameters' in value) || value['parameters'] === undefined) return false;
     return true;
@@ -178,7 +179,7 @@ export function ConnectionFromJSONTyped(json: any, ignoreDiscriminator: boolean)
         'authorizationParameters': json['authorizationParameters'] == null ? undefined : json['authorizationParameters'],
         'componentName': json['componentName'],
         'connectionParameters': json['connectionParameters'] == null ? undefined : json['connectionParameters'],
-        'connectionVersion': json['connectionVersion'] == null ? undefined : json['connectionVersion'],
+        'connectionVersion': json['connectionVersion'],
         'createdBy': json['createdBy'] == null ? undefined : json['createdBy'],
         'createdDate': json['createdDate'] == null ? undefined : (new Date(json['createdDate'])),
         'credentialStatus': json['credentialStatus'] == null ? undefined : CredentialStatusFromJSON(json['credentialStatus']),

--- a/client/src/shared/middleware/automation/connection/models/ConnectionBase.ts
+++ b/client/src/shared/middleware/automation/connection/models/ConnectionBase.ts
@@ -76,7 +76,7 @@ export interface ConnectionBase {
      * @type {number}
      * @memberof ConnectionBase
      */
-    connectionVersion?: number;
+    connectionVersion: number;
     /**
      * The created by.
      * @type {string}
@@ -152,6 +152,7 @@ export interface ConnectionBase {
  */
 export function instanceOfConnectionBase(value: object): value is ConnectionBase {
     if (!('componentName' in value) || value['componentName'] === undefined) return false;
+    if (!('connectionVersion' in value) || value['connectionVersion'] === undefined) return false;
     if (!('name' in value) || value['name'] === undefined) return false;
     if (!('parameters' in value) || value['parameters'] === undefined) return false;
     return true;
@@ -172,7 +173,7 @@ export function ConnectionBaseFromJSONTyped(json: any, ignoreDiscriminator: bool
         'authorizationParameters': json['authorizationParameters'] == null ? undefined : json['authorizationParameters'],
         'componentName': json['componentName'],
         'connectionParameters': json['connectionParameters'] == null ? undefined : json['connectionParameters'],
-        'connectionVersion': json['connectionVersion'] == null ? undefined : json['connectionVersion'],
+        'connectionVersion': json['connectionVersion'],
         'createdBy': json['createdBy'] == null ? undefined : json['createdBy'],
         'createdDate': json['createdDate'] == null ? undefined : (new Date(json['createdDate'])),
         'credentialStatus': json['credentialStatus'] == null ? undefined : CredentialStatusFromJSON(json['credentialStatus']),

--- a/client/src/shared/middleware/embedded/connection/models/Connection.ts
+++ b/client/src/shared/middleware/embedded/connection/models/Connection.ts
@@ -76,7 +76,7 @@ export interface Connection {
      * @type {number}
      * @memberof Connection
      */
-    connectionVersion?: number;
+    connectionVersion: number;
     /**
      * The created by.
      * @type {string}
@@ -152,6 +152,7 @@ export interface Connection {
  */
 export function instanceOfConnection(value: object): value is Connection {
     if (!('componentName' in value) || value['componentName'] === undefined) return false;
+    if (!('connectionVersion' in value) || value['connectionVersion'] === undefined) return false;
     if (!('name' in value) || value['name'] === undefined) return false;
     if (!('parameters' in value) || value['parameters'] === undefined) return false;
     return true;
@@ -172,7 +173,7 @@ export function ConnectionFromJSONTyped(json: any, ignoreDiscriminator: boolean)
         'authorizationParameters': json['authorizationParameters'] == null ? undefined : json['authorizationParameters'],
         'componentName': json['componentName'],
         'connectionParameters': json['connectionParameters'] == null ? undefined : json['connectionParameters'],
-        'connectionVersion': json['connectionVersion'] == null ? undefined : json['connectionVersion'],
+        'connectionVersion': json['connectionVersion'],
         'createdBy': json['createdBy'] == null ? undefined : json['createdBy'],
         'createdDate': json['createdDate'] == null ? undefined : (new Date(json['createdDate'])),
         'credentialStatus': json['credentialStatus'] == null ? undefined : CredentialStatusFromJSON(json['credentialStatus']),

--- a/client/src/shared/middleware/embedded/connection/models/ConnectionBase.ts
+++ b/client/src/shared/middleware/embedded/connection/models/ConnectionBase.ts
@@ -76,7 +76,7 @@ export interface ConnectionBase {
      * @type {number}
      * @memberof ConnectionBase
      */
-    connectionVersion?: number;
+    connectionVersion: number;
     /**
      * The created by.
      * @type {string}
@@ -152,6 +152,7 @@ export interface ConnectionBase {
  */
 export function instanceOfConnectionBase(value: object): value is ConnectionBase {
     if (!('componentName' in value) || value['componentName'] === undefined) return false;
+    if (!('connectionVersion' in value) || value['connectionVersion'] === undefined) return false;
     if (!('name' in value) || value['name'] === undefined) return false;
     if (!('parameters' in value) || value['parameters'] === undefined) return false;
     return true;
@@ -172,7 +173,7 @@ export function ConnectionBaseFromJSONTyped(json: any, ignoreDiscriminator: bool
         'authorizationParameters': json['authorizationParameters'] == null ? undefined : json['authorizationParameters'],
         'componentName': json['componentName'],
         'connectionParameters': json['connectionParameters'] == null ? undefined : json['connectionParameters'],
-        'connectionVersion': json['connectionVersion'] == null ? undefined : json['connectionVersion'],
+        'connectionVersion': json['connectionVersion'],
         'createdBy': json['createdBy'] == null ? undefined : json['createdBy'],
         'createdDate': json['createdDate'] == null ? undefined : (new Date(json['createdDate'])),
         'credentialStatus': json['credentialStatus'] == null ? undefined : CredentialStatusFromJSON(json['credentialStatus']),

--- a/client/src/shared/middleware/platform/configuration/apis/ComponentDefinitionApi.ts
+++ b/client/src/shared/middleware/platform/configuration/apis/ComponentDefinitionApi.ts
@@ -30,7 +30,7 @@ import {
 
 export interface GetComponentDefinitionRequest {
     componentName: string;
-    componentVersion?: number;
+    componentVersion: number;
 }
 
 export interface GetComponentDefinitionVersionsRequest {
@@ -43,6 +43,11 @@ export interface GetComponentDefinitionsRequest {
     connectionDefinitions?: boolean;
     triggerDefinitions?: boolean;
     include?: Array<string>;
+}
+
+export interface GetConnectionComponentDefinitionRequest {
+    componentName: string;
+    connectionVersion: number;
 }
 
 export interface GetDataStreamComponentDefinitionsRequest {
@@ -70,16 +75,19 @@ export class ComponentDefinitionApi extends runtime.BaseAPI {
             );
         }
 
-        const queryParameters: any = {};
-
-        if (requestParameters['componentVersion'] != null) {
-            queryParameters['componentVersion'] = requestParameters['componentVersion'];
+        if (requestParameters['componentVersion'] == null) {
+            throw new runtime.RequiredError(
+                'componentVersion',
+                'Required parameter "componentVersion" was null or undefined when calling getComponentDefinition().'
+            );
         }
+
+        const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
 
         const response = await this.request({
-            path: `/component-definitions/{componentName}`.replace(`{${"componentName"}}`, encodeURIComponent(String(requestParameters['componentName']))),
+            path: `/component-definitions/{componentName}/versions/{componentVersion}`.replace(`{${"componentName"}}`, encodeURIComponent(String(requestParameters['componentName']))).replace(`{${"componentVersion"}}`, encodeURIComponent(String(requestParameters['componentVersion']))),
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
@@ -184,6 +192,48 @@ export class ComponentDefinitionApi extends runtime.BaseAPI {
      */
     async getComponentDefinitions(requestParameters: GetComponentDefinitionsRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<Array<ComponentDefinitionBasic>> {
         const response = await this.getComponentDefinitionsRaw(requestParameters, initOverrides);
+        return await response.value();
+    }
+
+    /**
+     * Get a connection component definition.
+     * Get a connection component definition
+     */
+    async getConnectionComponentDefinitionRaw(requestParameters: GetConnectionComponentDefinitionRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<ComponentDefinition>> {
+        if (requestParameters['componentName'] == null) {
+            throw new runtime.RequiredError(
+                'componentName',
+                'Required parameter "componentName" was null or undefined when calling getConnectionComponentDefinition().'
+            );
+        }
+
+        if (requestParameters['connectionVersion'] == null) {
+            throw new runtime.RequiredError(
+                'connectionVersion',
+                'Required parameter "connectionVersion" was null or undefined when calling getConnectionComponentDefinition().'
+            );
+        }
+
+        const queryParameters: any = {};
+
+        const headerParameters: runtime.HTTPHeaders = {};
+
+        const response = await this.request({
+            path: `/component-definitions/{componentName}/connection-versions/{connectionVersion}`.replace(`{${"componentName"}}`, encodeURIComponent(String(requestParameters['componentName']))).replace(`{${"connectionVersion"}}`, encodeURIComponent(String(requestParameters['connectionVersion']))),
+            method: 'GET',
+            headers: headerParameters,
+            query: queryParameters,
+        }, initOverrides);
+
+        return new runtime.JSONApiResponse(response, (jsonValue) => ComponentDefinitionFromJSON(jsonValue));
+    }
+
+    /**
+     * Get a connection component definition.
+     * Get a connection component definition
+     */
+    async getConnectionComponentDefinition(requestParameters: GetConnectionComponentDefinitionRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<ComponentDefinition> {
+        const response = await this.getConnectionComponentDefinitionRaw(requestParameters, initOverrides);
         return await response.value();
     }
 

--- a/client/src/shared/middleware/platform/configuration/apis/ConnectionDefinitionApi.ts
+++ b/client/src/shared/middleware/platform/configuration/apis/ConnectionDefinitionApi.ts
@@ -61,7 +61,7 @@ export class ConnectionDefinitionApi extends runtime.BaseAPI {
         const headerParameters: runtime.HTTPHeaders = {};
 
         const response = await this.request({
-            path: `/component-definitions/{componentName}/versions/connection-definition`.replace(`{${"componentName"}}`, encodeURIComponent(String(requestParameters['componentName']))),
+            path: `/component-definitions/{componentName}/connection-definition`.replace(`{${"componentName"}}`, encodeURIComponent(String(requestParameters['componentName']))),
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,
@@ -100,7 +100,7 @@ export class ConnectionDefinitionApi extends runtime.BaseAPI {
         const headerParameters: runtime.HTTPHeaders = {};
 
         const response = await this.request({
-            path: `/component-definitions/{componentName}/versions/connection-definitions`.replace(`{${"componentName"}}`, encodeURIComponent(String(requestParameters['componentName']))),
+            path: `/component-definitions/{componentName}/connection-definitions`.replace(`{${"componentName"}}`, encodeURIComponent(String(requestParameters['componentName']))),
             method: 'GET',
             headers: headerParameters,
             query: queryParameters,

--- a/client/src/shared/middleware/platform/configuration/models/TaskDispatcherDefinitionBasic.ts
+++ b/client/src/shared/middleware/platform/configuration/models/TaskDispatcherDefinitionBasic.ts
@@ -57,6 +57,12 @@ export interface TaskDispatcherDefinitionBasic {
      * @memberof TaskDispatcherDefinitionBasic
      */
     title?: string;
+    /**
+     * The version of a task dispatcher.
+     * @type {number}
+     * @memberof TaskDispatcherDefinitionBasic
+     */
+    version: number;
 }
 
 /**
@@ -64,6 +70,7 @@ export interface TaskDispatcherDefinitionBasic {
  */
 export function instanceOfTaskDispatcherDefinitionBasic(value: object): value is TaskDispatcherDefinitionBasic {
     if (!('name' in value) || value['name'] === undefined) return false;
+    if (!('version' in value) || value['version'] === undefined) return false;
     return true;
 }
 
@@ -82,6 +89,7 @@ export function TaskDispatcherDefinitionBasicFromJSONTyped(json: any, ignoreDisc
         'name': json['name'],
         'resources': json['resources'] == null ? undefined : ResourcesFromJSON(json['resources']),
         'title': json['title'] == null ? undefined : json['title'],
+        'version': json['version'],
     };
 }
 
@@ -101,6 +109,7 @@ export function TaskDispatcherDefinitionBasicToJSONTyped(value?: TaskDispatcherD
         'name': value['name'],
         'resources': ResourcesToJSON(value['resources']),
         'title': value['title'],
+        'version': value['version'],
     };
 }
 

--- a/client/src/shared/queries/platform/componentDefinitions.queries.ts
+++ b/client/src/shared/queries/platform/componentDefinitions.queries.ts
@@ -7,6 +7,7 @@ import {
     ComponentDefinitionBasic,
     GetComponentDefinitionRequest,
     GetComponentDefinitionsModeTypeEnum,
+    GetConnectionComponentDefinitionRequest,
     GetDataStreamComponentDefinitionsRequest,
 } from '@/shared/middleware/platform/configuration';
 import {useQuery} from '@tanstack/react-query';
@@ -25,6 +26,11 @@ export const ComponentDefinitionKeys = {
         request.componentVersion,
     ],
     componentDefinitions: ['componentDefinitions'] as const,
+    connectionComponentDefinition: (request: GetConnectionComponentDefinitionRequest) => [
+        ...ComponentDefinitionKeys.componentDefinitions,
+        request.componentName,
+        request.connectionVersion,
+    ],
     filteredComponentDefinitions: (request?: GetComponentDefinitionsRequestI) => [
         ...ComponentDefinitionKeys.componentDefinitions,
         request,
@@ -39,6 +45,16 @@ export const useGetComponentDefinitionQuery = (request: GetComponentDefinitionRe
     useQuery<ComponentDefinition, Error>({
         queryKey: ComponentDefinitionKeys.componentDefinition(request),
         queryFn: () => new ComponentDefinitionApi().getComponentDefinition(request),
+        enabled: enabled === undefined ? true : enabled,
+    });
+
+export const useGetConnectionComponentDefinitionQuery = (
+    request: GetConnectionComponentDefinitionRequest,
+    enabled?: boolean
+) =>
+    useQuery<ComponentDefinition, Error>({
+        queryKey: ComponentDefinitionKeys.connectionComponentDefinition(request),
+        queryFn: () => new ComponentDefinitionApi().getConnectionComponentDefinition(request),
         enabled: enabled === undefined ? true : enabled,
     });
 

--- a/client/src/shared/queries/platform/taskDispatcherDefinitions.queries.ts
+++ b/client/src/shared/queries/platform/taskDispatcherDefinitions.queries.ts
@@ -8,6 +8,7 @@ import {useQuery} from '@tanstack/react-query';
 
 export const TaskDispatcherKeys = {
     taskDispatcherDefinition: (request: GetTaskDispatcherDefinitionRequest) => [
+        ...TaskDispatcherKeys.taskDispatcherDefinitions,
         request.taskDispatcherName,
         request.taskDispatcherVersion,
     ],

--- a/server/apps/server-app/src/main/resources/banner.txt
+++ b/server/apps/server-app/src/main/resources/banner.txt
@@ -1,3 +1,4 @@
+
 ${AnsiColor.BLUE}888888b.  ${AnsiColor.DEFAULT}          888            ${AnsiColor.BRIGHT_CYAN}  .d8888b.  ${AnsiColor.DEFAULT}888                .d888
 ${AnsiColor.BLUE}888  "88b ${AnsiColor.DEFAULT}          888            ${AnsiColor.BRIGHT_CYAN} d88P  Y88b ${AnsiColor.DEFAULT}888               d88P"
 ${AnsiColor.BLUE}888  .88P ${AnsiColor.DEFAULT}          888            ${AnsiColor.BRIGHT_CYAN} 888    888 ${AnsiColor.DEFAULT}888               888
@@ -9,4 +10,5 @@ ${AnsiColor.BLUE}8888888P" ${AnsiColor.DEFAULT}  "Y88888  "Y888  "Y8888 ${AnsiCo
 ${AnsiColor.BLUE}          ${AnsiColor.DEFAULT}      888
 ${AnsiColor.BLUE}          ${AnsiColor.DEFAULT} Y8b d88P
 ${AnsiColor.BLUE}          ${AnsiColor.DEFAULT}  "Y88P"
+
 ${AnsiColor.GREEN}Powered by Spring Boot v${spring-boot.version}

--- a/server/ee/libs/platform/platform-component/platform-component-remote-client/src/main/java/com/bytechef/ee/platform/component/remote/client/service/RemoteComponentDefinitionServiceClient.java
+++ b/server/ee/libs/platform/platform-component/platform-component-remote-client/src/main/java/com/bytechef/ee/platform/component/remote/client/service/RemoteComponentDefinitionServiceClient.java
@@ -104,6 +104,11 @@ public class RemoteComponentDefinitionServiceClient extends AbstractWorkerClient
     }
 
     @Override
+    public ComponentDefinition getConnectionComponentDefinition(@NonNull String name, int connectionVersion) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public List<ComponentDefinition> getDataStreamComponentDefinitions(@NonNull ComponentType componentType) {
         // TODO
 

--- a/server/libs/automation/automation-connection/automation-connection-rest/generated/src/main/java/com/bytechef/automation/connection/web/rest/ConnectionApi.java
+++ b/server/libs/automation/automation-connection/automation-connection-rest/generated/src/main/java/com/bytechef/automation/connection/web/rest/ConnectionApi.java
@@ -32,7 +32,7 @@ import java.util.Map;
 import java.util.Optional;
 import jakarta.annotation.Generated;
 
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-27T19:49:55.762804+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:29:25.156676+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 @Validated
 @Tag(name = "connection", description = "The Automation Connection Internal API")
 public interface ConnectionApi {

--- a/server/libs/automation/automation-connection/automation-connection-rest/generated/src/main/java/com/bytechef/automation/connection/web/rest/ConnectionTagApi.java
+++ b/server/libs/automation/automation-connection/automation-connection-rest/generated/src/main/java/com/bytechef/automation/connection/web/rest/ConnectionTagApi.java
@@ -32,7 +32,7 @@ import java.util.Map;
 import java.util.Optional;
 import jakarta.annotation.Generated;
 
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-27T19:49:55.762804+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:29:25.156676+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 @Validated
 @Tag(name = "connection-tag", description = "The Automation Connection Tag Internal API")
 public interface ConnectionTagApi {

--- a/server/libs/automation/automation-connection/automation-connection-rest/generated/src/main/java/com/bytechef/automation/connection/web/rest/model/ConnectionBaseModel.java
+++ b/server/libs/automation/automation-connection/automation-connection-rest/generated/src/main/java/com/bytechef/automation/connection/web/rest/model/ConnectionBaseModel.java
@@ -32,7 +32,7 @@ import jakarta.annotation.Generated;
 
 @Schema(name = "connection_base", description = "Contains all required information to open a connection to a service defined by componentName parameter.")
 @JsonTypeName("connection_base")
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-27T19:49:55.762804+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:29:25.156676+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public class ConnectionBaseModel {
 
   private Boolean active;
@@ -82,8 +82,9 @@ public class ConnectionBaseModel {
   /**
    * Constructor with only required parameters
    */
-  public ConnectionBaseModel(String componentName, String name, Map<String, Object> parameters) {
+  public ConnectionBaseModel(String componentName, Integer connectionVersion, String name, Map<String, Object> parameters) {
     this.componentName = componentName;
+    this.connectionVersion = connectionVersion;
     this.name = name;
     this.parameters = parameters;
   }
@@ -213,8 +214,8 @@ public class ConnectionBaseModel {
    * The version of a component that uses this connection.
    * @return connectionVersion
    */
-  
-  @Schema(name = "connectionVersion", description = "The version of a component that uses this connection.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  @NotNull 
+  @Schema(name = "connectionVersion", description = "The version of a component that uses this connection.", requiredMode = Schema.RequiredMode.REQUIRED)
   @JsonProperty("connectionVersion")
   public Integer getConnectionVersion() {
     return connectionVersion;

--- a/server/libs/automation/automation-connection/automation-connection-rest/generated/src/main/java/com/bytechef/automation/connection/web/rest/model/ConnectionEnvironmentModel.java
+++ b/server/libs/automation/automation-connection/automation-connection-rest/generated/src/main/java/com/bytechef/automation/connection/web/rest/model/ConnectionEnvironmentModel.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
  * The environment of a connection.
  */
 
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-27T19:49:55.762804+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:29:25.156676+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public enum ConnectionEnvironmentModel {
   
   DEVELOPMENT("DEVELOPMENT"),

--- a/server/libs/automation/automation-connection/automation-connection-rest/generated/src/main/java/com/bytechef/automation/connection/web/rest/model/ConnectionModel.java
+++ b/server/libs/automation/automation-connection/automation-connection-rest/generated/src/main/java/com/bytechef/automation/connection/web/rest/model/ConnectionModel.java
@@ -32,7 +32,7 @@ import jakarta.annotation.Generated;
 
 @Schema(name = "Connection", description = "Contains all required information to open a connection to a service defined by componentName parameter.")
 @JsonTypeName("Connection")
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-27T19:49:55.762804+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:29:25.156676+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public class ConnectionModel {
 
   private Boolean active;
@@ -84,8 +84,9 @@ public class ConnectionModel {
   /**
    * Constructor with only required parameters
    */
-  public ConnectionModel(String componentName, String name, Map<String, Object> parameters) {
+  public ConnectionModel(String componentName, Integer connectionVersion, String name, Map<String, Object> parameters) {
     this.componentName = componentName;
+    this.connectionVersion = connectionVersion;
     this.name = name;
     this.parameters = parameters;
   }
@@ -215,8 +216,8 @@ public class ConnectionModel {
    * The version of a component that uses this connection.
    * @return connectionVersion
    */
-  
-  @Schema(name = "connectionVersion", description = "The version of a component that uses this connection.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  @NotNull 
+  @Schema(name = "connectionVersion", description = "The version of a component that uses this connection.", requiredMode = Schema.RequiredMode.REQUIRED)
   @JsonProperty("connectionVersion")
   public Integer getConnectionVersion() {
     return connectionVersion;

--- a/server/libs/automation/automation-connection/automation-connection-rest/generated/src/main/java/com/bytechef/automation/connection/web/rest/model/CredentialStatusModel.java
+++ b/server/libs/automation/automation-connection/automation-connection-rest/generated/src/main/java/com/bytechef/automation/connection/web/rest/model/CredentialStatusModel.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
  * Gets or Sets credential_status
  */
 
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-27T19:49:55.762804+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:29:25.156676+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public enum CredentialStatusModel {
   
   VALID("VALID"),

--- a/server/libs/embedded/embedded-connection/embedded-connection-rest/generated/src/main/java/com/bytechef/embedded/connection/web/rest/ConnectionApi.java
+++ b/server/libs/embedded/embedded-connection/embedded-connection-rest/generated/src/main/java/com/bytechef/embedded/connection/web/rest/ConnectionApi.java
@@ -32,7 +32,7 @@ import java.util.Map;
 import java.util.Optional;
 import jakarta.annotation.Generated;
 
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-27T19:49:56.171918+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:29:43.709208+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 @Validated
 @Tag(name = "connection", description = "The Embedded Connection Internal API")
 public interface ConnectionApi {

--- a/server/libs/embedded/embedded-connection/embedded-connection-rest/generated/src/main/java/com/bytechef/embedded/connection/web/rest/ConnectionTagApi.java
+++ b/server/libs/embedded/embedded-connection/embedded-connection-rest/generated/src/main/java/com/bytechef/embedded/connection/web/rest/ConnectionTagApi.java
@@ -32,7 +32,7 @@ import java.util.Map;
 import java.util.Optional;
 import jakarta.annotation.Generated;
 
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-27T19:49:56.171918+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:29:43.709208+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 @Validated
 @Tag(name = "connection-tag", description = "The Embedded Connection Tag Internal API")
 public interface ConnectionTagApi {

--- a/server/libs/embedded/embedded-connection/embedded-connection-rest/generated/src/main/java/com/bytechef/embedded/connection/web/rest/model/ConnectionBaseModel.java
+++ b/server/libs/embedded/embedded-connection/embedded-connection-rest/generated/src/main/java/com/bytechef/embedded/connection/web/rest/model/ConnectionBaseModel.java
@@ -32,7 +32,7 @@ import jakarta.annotation.Generated;
 
 @Schema(name = "connection_base", description = "Contains all required information to open a connection to a service defined by componentName parameter.")
 @JsonTypeName("connection_base")
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-27T19:49:56.171918+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:29:43.709208+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public class ConnectionBaseModel {
 
   private Boolean active;
@@ -82,8 +82,9 @@ public class ConnectionBaseModel {
   /**
    * Constructor with only required parameters
    */
-  public ConnectionBaseModel(String componentName, String name, Map<String, Object> parameters) {
+  public ConnectionBaseModel(String componentName, Integer connectionVersion, String name, Map<String, Object> parameters) {
     this.componentName = componentName;
+    this.connectionVersion = connectionVersion;
     this.name = name;
     this.parameters = parameters;
   }
@@ -213,8 +214,8 @@ public class ConnectionBaseModel {
    * The version of a component that uses this connection.
    * @return connectionVersion
    */
-  
-  @Schema(name = "connectionVersion", description = "The version of a component that uses this connection.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  @NotNull 
+  @Schema(name = "connectionVersion", description = "The version of a component that uses this connection.", requiredMode = Schema.RequiredMode.REQUIRED)
   @JsonProperty("connectionVersion")
   public Integer getConnectionVersion() {
     return connectionVersion;

--- a/server/libs/embedded/embedded-connection/embedded-connection-rest/generated/src/main/java/com/bytechef/embedded/connection/web/rest/model/ConnectionEnvironmentModel.java
+++ b/server/libs/embedded/embedded-connection/embedded-connection-rest/generated/src/main/java/com/bytechef/embedded/connection/web/rest/model/ConnectionEnvironmentModel.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
  * The environment of a connection.
  */
 
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-27T19:49:56.171918+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:29:43.709208+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public enum ConnectionEnvironmentModel {
   
   DEVELOPMENT("DEVELOPMENT"),

--- a/server/libs/embedded/embedded-connection/embedded-connection-rest/generated/src/main/java/com/bytechef/embedded/connection/web/rest/model/ConnectionModel.java
+++ b/server/libs/embedded/embedded-connection/embedded-connection-rest/generated/src/main/java/com/bytechef/embedded/connection/web/rest/model/ConnectionModel.java
@@ -32,7 +32,7 @@ import jakarta.annotation.Generated;
 
 @Schema(name = "Connection", description = "Contains all required information to open a connection to a service defined by componentName parameter.")
 @JsonTypeName("Connection")
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-27T19:49:56.171918+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:29:43.709208+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public class ConnectionModel {
 
   private Boolean active;
@@ -82,8 +82,9 @@ public class ConnectionModel {
   /**
    * Constructor with only required parameters
    */
-  public ConnectionModel(String componentName, String name, Map<String, Object> parameters) {
+  public ConnectionModel(String componentName, Integer connectionVersion, String name, Map<String, Object> parameters) {
     this.componentName = componentName;
+    this.connectionVersion = connectionVersion;
     this.name = name;
     this.parameters = parameters;
   }
@@ -213,8 +214,8 @@ public class ConnectionModel {
    * The version of a component that uses this connection.
    * @return connectionVersion
    */
-  
-  @Schema(name = "connectionVersion", description = "The version of a component that uses this connection.", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  @NotNull 
+  @Schema(name = "connectionVersion", description = "The version of a component that uses this connection.", requiredMode = Schema.RequiredMode.REQUIRED)
   @JsonProperty("connectionVersion")
   public Integer getConnectionVersion() {
     return connectionVersion;

--- a/server/libs/embedded/embedded-connection/embedded-connection-rest/generated/src/main/java/com/bytechef/embedded/connection/web/rest/model/CredentialStatusModel.java
+++ b/server/libs/embedded/embedded-connection/embedded-connection-rest/generated/src/main/java/com/bytechef/embedded/connection/web/rest/model/CredentialStatusModel.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
  * Gets or Sets credential_status
  */
 
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-27T19:49:56.171918+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:29:43.709208+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public enum CredentialStatusModel {
   
   VALID("VALID"),

--- a/server/libs/platform/platform-component/platform-component-api/src/main/java/com/bytechef/platform/component/service/ComponentDefinitionService.java
+++ b/server/libs/platform/platform-component/platform-component-api/src/main/java/com/bytechef/platform/component/service/ComponentDefinitionService.java
@@ -45,6 +45,8 @@ public interface ComponentDefinitionService {
 
     List<ComponentDefinition> getComponentDefinitionVersions(@NonNull String name);
 
+    ComponentDefinition getConnectionComponentDefinition(@NonNull String name, int connectionVersion);
+
     List<ComponentDefinition> getDataStreamComponentDefinitions(@NonNull ComponentType componentType);
 
     DataStreamItemReader getDataStreamItemReader(@NonNull String componentName, int componentVersion);

--- a/server/libs/platform/platform-component/platform-component-service/src/main/java/com/bytechef/platform/component/service/ComponentDefinitionServiceImpl.java
+++ b/server/libs/platform/platform-component/platform-component-service/src/main/java/com/bytechef/platform/component/service/ComponentDefinitionServiceImpl.java
@@ -18,6 +18,7 @@ package com.bytechef.platform.component.service;
 
 import com.bytechef.commons.util.CollectionUtils;
 import com.bytechef.commons.util.OptionalUtils;
+import com.bytechef.component.definition.ConnectionDefinition;
 import com.bytechef.component.definition.DataStreamDefinition;
 import com.bytechef.component.definition.DataStreamItemReader;
 import com.bytechef.component.definition.DataStreamItemWriter;
@@ -37,6 +38,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Predicate;
 import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Service;
@@ -95,6 +97,32 @@ public class ComponentDefinitionServiceImpl implements ComponentDefinitionServic
             .stream()
             .map(ComponentDefinition::new)
             .toList();
+    }
+
+    @Override
+    public ComponentDefinition getConnectionComponentDefinition(@NonNull String name, int connectionVersion) {
+        return componentDefinitionRegistry.getComponentDefinitions()
+            .stream()
+            .filter(componentDefinition -> {
+                if (name.equals(componentDefinition.getName())) {
+                    Optional<ConnectionDefinition> connectionDefinitionOptional = componentDefinition.getConnection();
+
+                    if (connectionDefinitionOptional.isEmpty()) {
+                        return false;
+                    }
+
+                    ConnectionDefinition connectionDefinition = connectionDefinitionOptional.get();
+
+                    return connectionDefinition.getVersion() == connectionVersion;
+                }
+
+                return false;
+            })
+            .findFirst()
+            .map(ComponentDefinition::new)
+            .orElseThrow(() -> new IllegalArgumentException(
+                "Connection component definition with name: %s, connectionVersion: %d not found".formatted(
+                    name, connectionVersion)));
     }
 
     @Override

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/ActionDefinitionApi.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/ActionDefinitionApi.java
@@ -33,7 +33,7 @@ import java.util.Map;
 import java.util.Optional;
 import jakarta.annotation.Generated;
 
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 @Validated
 @Tag(name = "action-definition", description = "The Platform Action Definition Internal API")
 public interface ActionDefinitionApi {

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/ComponentDefinitionApi.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/ComponentDefinitionApi.java
@@ -34,7 +34,7 @@ import java.util.Map;
 import java.util.Optional;
 import jakarta.annotation.Generated;
 
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 @Validated
 @Tag(name = "component-definition", description = "The Platform Component Definition Internal API")
 public interface ComponentDefinitionApi {
@@ -44,11 +44,11 @@ public interface ComponentDefinitionApi {
     }
 
     /**
-     * GET /component-definitions/{componentName} : Get a component definition
+     * GET /component-definitions/{componentName}/versions/{componentVersion} : Get a component definition
      * Get a component definition.
      *
      * @param componentName The name of a component to get. (required)
-     * @param componentVersion The version of a component to get. If not set, teh latest version is returned. (optional)
+     * @param componentVersion The version of a component to get. (required)
      * @return Successful operation. (status code 200)
      */
     @Operation(
@@ -64,18 +64,18 @@ public interface ComponentDefinitionApi {
     )
     @RequestMapping(
         method = RequestMethod.GET,
-        value = "/component-definitions/{componentName}",
+        value = "/component-definitions/{componentName}/versions/{componentVersion}",
         produces = { "application/json" }
     )
     
     default ResponseEntity<ComponentDefinitionModel> getComponentDefinition(
         @Parameter(name = "componentName", description = "The name of a component to get.", required = true, in = ParameterIn.PATH) @PathVariable("componentName") String componentName,
-        @Parameter(name = "componentVersion", description = "The version of a component to get. If not set, teh latest version is returned.", in = ParameterIn.QUERY) @Valid @RequestParam(value = "componentVersion", required = false) Integer componentVersion
+        @Parameter(name = "componentVersion", description = "The version of a component to get.", required = true, in = ParameterIn.PATH) @PathVariable("componentVersion") Integer componentVersion
     ) {
         getRequest().ifPresent(request -> {
             for (MediaType mediaType: MediaType.parseMediaTypes(request.getHeader("Accept"))) {
                 if (mediaType.isCompatibleWith(MediaType.valueOf("application/json"))) {
-                    String exampleString = "{ \"icon\" : \"icon\", \"description\" : \"description\", \"resources\" : { \"documentationUrl\" : \"documentationUrl\" }, \"title\" : \"title\", \"triggers\" : [ { \"help\" : { \"body\" : \"body\", \"learnMoreUrl\" : \"learnMoreUrl\" }, \"name\" : \"name\", \"description\" : \"description\", \"title\" : \"title\", \"type\" : \"STATIC_WEBHOOK\" }, { \"help\" : { \"body\" : \"body\", \"learnMoreUrl\" : \"learnMoreUrl\" }, \"name\" : \"name\", \"description\" : \"description\", \"title\" : \"title\", \"type\" : \"STATIC_WEBHOOK\" } ], \"version\" : 6, \"tags\" : [ \"tags\", \"tags\" ], \"dataStreamSupported\" : true, \"connectionRequired\" : true, \"name\" : \"name\", \"connection\" : { \"componentTitle\" : \"componentTitle\", \"componentDescription\" : \"componentDescription\", \"componentName\" : \"componentName\", \"version\" : 0 }, \"categories\" : [ { \"label\" : \"label\", \"key\" : \"key\" }, { \"label\" : \"label\", \"key\" : \"key\" } ], \"actions\" : [ { \"help\" : { \"body\" : \"body\", \"learnMoreUrl\" : \"learnMoreUrl\" }, \"name\" : \"name\", \"description\" : \"description\", \"title\" : \"title\" }, { \"help\" : { \"body\" : \"body\", \"learnMoreUrl\" : \"learnMoreUrl\" }, \"name\" : \"name\", \"description\" : \"description\", \"title\" : \"title\" } ], \"unifiedApiCategory\" : \"ACCOUNTING\" }";
+                    String exampleString = "{ \"icon\" : \"icon\", \"description\" : \"description\", \"resources\" : { \"documentationUrl\" : \"documentationUrl\" }, \"title\" : \"title\", \"triggers\" : [ { \"help\" : { \"body\" : \"body\", \"learnMoreUrl\" : \"learnMoreUrl\" }, \"name\" : \"name\", \"description\" : \"description\", \"title\" : \"title\", \"type\" : \"STATIC_WEBHOOK\" }, { \"help\" : { \"body\" : \"body\", \"learnMoreUrl\" : \"learnMoreUrl\" }, \"name\" : \"name\", \"description\" : \"description\", \"title\" : \"title\", \"type\" : \"STATIC_WEBHOOK\" } ], \"version\" : 0, \"tags\" : [ \"tags\", \"tags\" ], \"dataStreamSupported\" : true, \"connectionRequired\" : true, \"name\" : \"name\", \"connection\" : { \"componentTitle\" : \"componentTitle\", \"componentDescription\" : \"componentDescription\", \"componentName\" : \"componentName\", \"version\" : 0 }, \"categories\" : [ { \"label\" : \"label\", \"key\" : \"key\" }, { \"label\" : \"label\", \"key\" : \"key\" } ], \"actions\" : [ { \"help\" : { \"body\" : \"body\", \"learnMoreUrl\" : \"learnMoreUrl\" }, \"name\" : \"name\", \"description\" : \"description\", \"title\" : \"title\" }, { \"help\" : { \"body\" : \"body\", \"learnMoreUrl\" : \"learnMoreUrl\" }, \"name\" : \"name\", \"description\" : \"description\", \"title\" : \"title\" } ], \"unifiedApiCategory\" : \"ACCOUNTING\" }";
                     ApiUtil.setExampleResponse(request, "application/json", exampleString);
                     break;
                 }
@@ -166,6 +166,49 @@ public interface ComponentDefinitionApi {
             for (MediaType mediaType: MediaType.parseMediaTypes(request.getHeader("Accept"))) {
                 if (mediaType.isCompatibleWith(MediaType.valueOf("application/json"))) {
                     String exampleString = "[ { \"icon\" : \"icon\", \"name\" : \"name\", \"actionsCount\" : 0, \"description\" : \"description\", \"title\" : \"title\", \"version\" : 1, \"triggersCount\" : 6 }, { \"icon\" : \"icon\", \"name\" : \"name\", \"actionsCount\" : 0, \"description\" : \"description\", \"title\" : \"title\", \"version\" : 1, \"triggersCount\" : 6 } ]";
+                    ApiUtil.setExampleResponse(request, "application/json", exampleString);
+                    break;
+                }
+            }
+        });
+        return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
+
+    }
+
+
+    /**
+     * GET /component-definitions/{componentName}/connection-versions/{connectionVersion} : Get a connection component definition
+     * Get a connection component definition.
+     *
+     * @param componentName The name of a component to get. (required)
+     * @param connectionVersion The version of a component connection to get. (required)
+     * @return Successful operation. (status code 200)
+     */
+    @Operation(
+        operationId = "getConnectionComponentDefinition",
+        summary = "Get a connection component definition",
+        description = "Get a connection component definition.",
+        tags = { "component-definition" },
+        responses = {
+            @ApiResponse(responseCode = "200", description = "Successful operation.", content = {
+                @Content(mediaType = "application/json", schema = @Schema(implementation = ComponentDefinitionModel.class))
+            })
+        }
+    )
+    @RequestMapping(
+        method = RequestMethod.GET,
+        value = "/component-definitions/{componentName}/connection-versions/{connectionVersion}",
+        produces = { "application/json" }
+    )
+    
+    default ResponseEntity<ComponentDefinitionModel> getConnectionComponentDefinition(
+        @Parameter(name = "componentName", description = "The name of a component to get.", required = true, in = ParameterIn.PATH) @PathVariable("componentName") String componentName,
+        @Parameter(name = "connectionVersion", description = "The version of a component connection to get.", required = true, in = ParameterIn.PATH) @PathVariable("connectionVersion") Integer connectionVersion
+    ) {
+        getRequest().ifPresent(request -> {
+            for (MediaType mediaType: MediaType.parseMediaTypes(request.getHeader("Accept"))) {
+                if (mediaType.isCompatibleWith(MediaType.valueOf("application/json"))) {
+                    String exampleString = "{ \"icon\" : \"icon\", \"description\" : \"description\", \"resources\" : { \"documentationUrl\" : \"documentationUrl\" }, \"title\" : \"title\", \"triggers\" : [ { \"help\" : { \"body\" : \"body\", \"learnMoreUrl\" : \"learnMoreUrl\" }, \"name\" : \"name\", \"description\" : \"description\", \"title\" : \"title\", \"type\" : \"STATIC_WEBHOOK\" }, { \"help\" : { \"body\" : \"body\", \"learnMoreUrl\" : \"learnMoreUrl\" }, \"name\" : \"name\", \"description\" : \"description\", \"title\" : \"title\", \"type\" : \"STATIC_WEBHOOK\" } ], \"version\" : 0, \"tags\" : [ \"tags\", \"tags\" ], \"dataStreamSupported\" : true, \"connectionRequired\" : true, \"name\" : \"name\", \"connection\" : { \"componentTitle\" : \"componentTitle\", \"componentDescription\" : \"componentDescription\", \"componentName\" : \"componentName\", \"version\" : 0 }, \"categories\" : [ { \"label\" : \"label\", \"key\" : \"key\" }, { \"label\" : \"label\", \"key\" : \"key\" } ], \"actions\" : [ { \"help\" : { \"body\" : \"body\", \"learnMoreUrl\" : \"learnMoreUrl\" }, \"name\" : \"name\", \"description\" : \"description\", \"title\" : \"title\" }, { \"help\" : { \"body\" : \"body\", \"learnMoreUrl\" : \"learnMoreUrl\" }, \"name\" : \"name\", \"description\" : \"description\", \"title\" : \"title\" } ], \"unifiedApiCategory\" : \"ACCOUNTING\" }";
                     ApiUtil.setExampleResponse(request, "application/json", exampleString);
                     break;
                 }

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/ConnectionDefinitionApi.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/ConnectionDefinitionApi.java
@@ -33,7 +33,7 @@ import java.util.Map;
 import java.util.Optional;
 import jakarta.annotation.Generated;
 
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 @Validated
 @Tag(name = "connection-definition", description = "The Platform Connection Definition Internal API")
 public interface ConnectionDefinitionApi {
@@ -43,7 +43,7 @@ public interface ConnectionDefinitionApi {
     }
 
     /**
-     * GET /component-definitions/{componentName}/versions/connection-definition : Get connection definition for a component
+     * GET /component-definitions/{componentName}/connection-definition : Get connection definition for a component
      * Get connection definition for a component.
      *
      * @param componentName The name of a component. (required)
@@ -63,7 +63,7 @@ public interface ConnectionDefinitionApi {
     )
     @RequestMapping(
         method = RequestMethod.GET,
-        value = "/component-definitions/{componentName}/versions/connection-definition",
+        value = "/component-definitions/{componentName}/connection-definition",
         produces = { "application/json" }
     )
     
@@ -86,7 +86,7 @@ public interface ConnectionDefinitionApi {
 
 
     /**
-     * GET /component-definitions/{componentName}/versions/connection-definitions : Get all compatible connection definitions for a component
+     * GET /component-definitions/{componentName}/connection-definitions : Get all compatible connection definitions for a component
      * Get all compatible connection definitions for a component.
      *
      * @param componentName The name of a component. (required)
@@ -106,7 +106,7 @@ public interface ConnectionDefinitionApi {
     )
     @RequestMapping(
         method = RequestMethod.GET,
-        value = "/component-definitions/{componentName}/versions/connection-definitions",
+        value = "/component-definitions/{componentName}/connection-definitions",
         produces = { "application/json" }
     )
     

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/Oauth2Api.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/Oauth2Api.java
@@ -34,7 +34,7 @@ import java.util.Map;
 import java.util.Optional;
 import jakarta.annotation.Generated;
 
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 @Validated
 @Tag(name = "oauth2", description = "the oauth2 API")
 public interface Oauth2Api {

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/TaskDispatcherDefinitionApi.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/TaskDispatcherDefinitionApi.java
@@ -33,7 +33,7 @@ import java.util.Map;
 import java.util.Optional;
 import jakarta.annotation.Generated;
 
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 @Validated
 @Tag(name = "task-dispatcher-definition", description = "The Platform Task Dispatcher Definition Internal API")
 public interface TaskDispatcherDefinitionApi {
@@ -115,7 +115,7 @@ public interface TaskDispatcherDefinitionApi {
         getRequest().ifPresent(request -> {
             for (MediaType mediaType: MediaType.parseMediaTypes(request.getHeader("Accept"))) {
                 if (mediaType.isCompatibleWith(MediaType.valueOf("application/json"))) {
-                    String exampleString = "[ { \"icon\" : \"icon\", \"name\" : \"name\", \"description\" : \"description\", \"resources\" : { \"documentationUrl\" : \"documentationUrl\" }, \"title\" : \"title\" }, { \"icon\" : \"icon\", \"name\" : \"name\", \"description\" : \"description\", \"resources\" : { \"documentationUrl\" : \"documentationUrl\" }, \"title\" : \"title\" } ]";
+                    String exampleString = "[ { \"icon\" : \"icon\", \"name\" : \"name\", \"description\" : \"description\", \"resources\" : { \"documentationUrl\" : \"documentationUrl\" }, \"title\" : \"title\", \"version\" : 0 }, { \"icon\" : \"icon\", \"name\" : \"name\", \"description\" : \"description\", \"resources\" : { \"documentationUrl\" : \"documentationUrl\" }, \"title\" : \"title\", \"version\" : 0 } ]";
                     ApiUtil.setExampleResponse(request, "application/json", exampleString);
                     break;
                 }

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/TriggerDefinitionApi.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/TriggerDefinitionApi.java
@@ -33,7 +33,7 @@ import java.util.Map;
 import java.util.Optional;
 import jakarta.annotation.Generated;
 
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 @Validated
 @Tag(name = "trigger-definition", description = "The Platform Trigger Definition Internal API")
 public interface TriggerDefinitionApi {

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/WorkflowNodeDescriptionApi.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/WorkflowNodeDescriptionApi.java
@@ -32,7 +32,7 @@ import java.util.Map;
 import java.util.Optional;
 import jakarta.annotation.Generated;
 
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 @Validated
 @Tag(name = "workflow-node-description", description = "The Platform Workflow Node Description Internal API")
 public interface WorkflowNodeDescriptionApi {

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/WorkflowNodeDynamicPropertiesApi.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/WorkflowNodeDynamicPropertiesApi.java
@@ -32,7 +32,7 @@ import java.util.Map;
 import java.util.Optional;
 import jakarta.annotation.Generated;
 
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 @Validated
 @Tag(name = "workflow-node-dynamic-properties", description = "The Platform Workflow Node Dynamic Properties Internal API")
 public interface WorkflowNodeDynamicPropertiesApi {

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/WorkflowNodeOptionApi.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/WorkflowNodeOptionApi.java
@@ -32,7 +32,7 @@ import java.util.Map;
 import java.util.Optional;
 import jakarta.annotation.Generated;
 
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 @Validated
 @Tag(name = "workflow-node-option", description = "The Platform Workflow Node Option Internal API")
 public interface WorkflowNodeOptionApi {

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/WorkflowNodeOutputApi.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/WorkflowNodeOutputApi.java
@@ -32,7 +32,7 @@ import java.util.Map;
 import java.util.Optional;
 import jakarta.annotation.Generated;
 
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 @Validated
 @Tag(name = "workflow-node-output", description = "The Platform Workflow Node Output Internal API")
 public interface WorkflowNodeOutputApi {

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/WorkflowNodeParameterApi.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/WorkflowNodeParameterApi.java
@@ -36,7 +36,7 @@ import java.util.Map;
 import java.util.Optional;
 import jakarta.annotation.Generated;
 
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 @Validated
 @Tag(name = "workflow-node-parameter", description = "The Platform Workflow Node Parameter Internal API")
 public interface WorkflowNodeParameterApi {

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/WorkflowNodeScriptApi.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/WorkflowNodeScriptApi.java
@@ -32,7 +32,7 @@ import java.util.Map;
 import java.util.Optional;
 import jakarta.annotation.Generated;
 
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 @Validated
 @Tag(name = "workflow-node-script", description = "The Platform Workflow Node Script Internal API")
 public interface WorkflowNodeScriptApi {

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/WorkflowNodeTestOutputApi.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/WorkflowNodeTestOutputApi.java
@@ -32,7 +32,7 @@ import java.util.Map;
 import java.util.Optional;
 import jakarta.annotation.Generated;
 
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 @Validated
 @Tag(name = "workflow-node-test-output", description = "The Platform Workflow Node Test Output Internal API")
 public interface WorkflowNodeTestOutputApi {

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/WorkflowTestConfigurationApi.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/WorkflowTestConfigurationApi.java
@@ -35,7 +35,7 @@ import java.util.Map;
 import java.util.Optional;
 import jakarta.annotation.Generated;
 
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 @Validated
 @Tag(name = "workflow-test-configuration", description = "The Platform Workflow Test Configuration Internal API")
 public interface WorkflowTestConfigurationApi {

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/ActionDefinitionBasicModel.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/ActionDefinitionBasicModel.java
@@ -22,7 +22,7 @@ import jakarta.annotation.Generated;
 
 @Schema(name = "ActionDefinitionBasic", description = "An action is a portion of reusable code that accomplish a specific task. When building a workflow, each action is represented as a task inside the workflow. The task 'type' property is defined as [component name]/v[component version]/[action name]. Action properties are used to set properties of the task inside the workflow.")
 @JsonTypeName("ActionDefinitionBasic")
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public class ActionDefinitionBasicModel {
 
   private String description;

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/ActionDefinitionModel.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/ActionDefinitionModel.java
@@ -26,7 +26,7 @@ import jakarta.annotation.Generated;
 
 @Schema(name = "ActionDefinition", description = "An action is a portion of reusable code that accomplish a specific task. When building a workflow, each action is represented as a task inside the workflow. The task 'type' property is defined as [component name]/v[component version]/[action name]. Action properties are used to set properties of the task inside the workflow.")
 @JsonTypeName("ActionDefinition")
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public class ActionDefinitionModel {
 
   private String componentName;

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/ArrayPropertyModel.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/ArrayPropertyModel.java
@@ -34,7 +34,7 @@ import jakarta.annotation.Generated;
 
 @Schema(name = "ArrayProperty", description = "An array property type.")
 
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public class ArrayPropertyModel extends ValuePropertyModel {
 
   @Valid

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/AuthorizationModel.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/AuthorizationModel.java
@@ -27,7 +27,7 @@ import jakarta.annotation.Generated;
 
 @Schema(name = "Authorization", description = "Contains information required for a connection's authorization.")
 @JsonTypeName("Authorization")
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public class AuthorizationModel {
 
   private String description;

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/AuthorizationTypeModel.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/AuthorizationTypeModel.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
  * Authorization type.
  */
 
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public enum AuthorizationTypeModel {
   
   API_KEY("API_KEY"),

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/BooleanPropertyModel.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/BooleanPropertyModel.java
@@ -32,7 +32,7 @@ import jakarta.annotation.Generated;
 
 @Schema(name = "BooleanProperty", description = "A boolean property type.")
 
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public class BooleanPropertyModel extends ValuePropertyModel {
 
   private Boolean defaultValue;

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/ComponentCategoryModel.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/ComponentCategoryModel.java
@@ -21,7 +21,7 @@ import jakarta.annotation.Generated;
 
 @Schema(name = "ComponentCategory", description = "A category of component.")
 @JsonTypeName("ComponentCategory")
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public class ComponentCategoryModel {
 
   private String key;

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/ComponentDefinitionBasicModel.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/ComponentDefinitionBasicModel.java
@@ -21,7 +21,7 @@ import jakarta.annotation.Generated;
 
 @Schema(name = "ComponentDefinitionBasic", description = "A component contains a set of reusable code(actions) that accomplish specific tasks, triggers and connections if there is a need for a connection to an outside service.")
 @JsonTypeName("ComponentDefinitionBasic")
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public class ComponentDefinitionBasicModel {
 
   private Integer actionsCount;

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/ComponentDefinitionModel.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/ComponentDefinitionModel.java
@@ -31,7 +31,7 @@ import jakarta.annotation.Generated;
 
 @Schema(name = "ComponentDefinition", description = "A component contains a set of reusable code(actions) that accomplish specific tasks, triggers and connections if there is a need for a connection to an outside service.")
 @JsonTypeName("ComponentDefinition")
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public class ComponentDefinitionModel {
 
   @Valid

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/ConnectionDefinitionBasicModel.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/ConnectionDefinitionBasicModel.java
@@ -21,7 +21,7 @@ import jakarta.annotation.Generated;
 
 @Schema(name = "ConnectionDefinitionBasic", description = "Definition of a connection to an outside service.")
 @JsonTypeName("ConnectionDefinitionBasic")
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public class ConnectionDefinitionBasicModel {
 
   private String componentDescription;

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/ConnectionDefinitionModel.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/ConnectionDefinitionModel.java
@@ -26,7 +26,7 @@ import jakarta.annotation.Generated;
 
 @Schema(name = "ConnectionDefinition", description = "Definition of a connection to an outside service.")
 @JsonTypeName("ConnectionDefinition")
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public class ConnectionDefinitionModel {
 
   private Boolean authorizationRequired = true;

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/ControlTypeModel.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/ControlTypeModel.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
  * A type of the control to show in UI.
  */
 
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public enum ControlTypeModel {
   
   ARRAY_BUILDER("ARRAY_BUILDER"),

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/DataStreamComponentModel.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/DataStreamComponentModel.java
@@ -21,7 +21,7 @@ import jakarta.annotation.Generated;
 
 @Schema(name = "DataStreamComponent", description = "The source/destination data stream component.")
 @JsonTypeName("DataStreamComponent")
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public class DataStreamComponentModel {
 
   private String componentName;

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/DatePropertyModel.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/DatePropertyModel.java
@@ -35,7 +35,7 @@ import jakarta.annotation.Generated;
 
 @Schema(name = "DateProperty", description = "A date property type.")
 
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public class DatePropertyModel extends ValuePropertyModel {
 
   @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/DateTimePropertyModel.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/DateTimePropertyModel.java
@@ -35,7 +35,7 @@ import jakarta.annotation.Generated;
 
 @Schema(name = "DateTimeProperty", description = "A date-time property type.")
 
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public class DateTimePropertyModel extends ValuePropertyModel {
 
   @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/DeleteWorkflowNodeParameter200ResponseModel.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/DeleteWorkflowNodeParameter200ResponseModel.java
@@ -22,7 +22,7 @@ import jakarta.annotation.Generated;
  */
 
 @JsonTypeName("deleteWorkflowNodeParameter_200_response")
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public class DeleteWorkflowNodeParameter200ResponseModel {
 
   @Valid

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/DeleteWorkflowNodeParameterRequestModel.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/DeleteWorkflowNodeParameterRequestModel.java
@@ -20,7 +20,7 @@ import jakarta.annotation.Generated;
  */
 
 @JsonTypeName("deleteWorkflowNodeParameter_request")
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public class DeleteWorkflowNodeParameterRequestModel {
 
   private String path;

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/DynamicPropertiesPropertyModel.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/DynamicPropertiesPropertyModel.java
@@ -28,7 +28,7 @@ import jakarta.annotation.Generated;
 
 @Schema(name = "DynamicPropertiesProperty", description = "A dynamic properties property type.")
 
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public class DynamicPropertiesPropertyModel extends PropertyModel {
 
   private String header;

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/ExecutionErrorModel.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/ExecutionErrorModel.java
@@ -24,7 +24,7 @@ import jakarta.annotation.Generated;
 
 @Schema(name = "ExecutionError", description = "Contains information about an error that happened during execution.")
 @JsonTypeName("ExecutionError")
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public class ExecutionErrorModel {
 
   private String message;

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/FileEntryPropertyModel.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/FileEntryPropertyModel.java
@@ -32,7 +32,7 @@ import jakarta.annotation.Generated;
 
 @Schema(name = "FileEntryProperty", description = "An file entry property type.")
 
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public class FileEntryPropertyModel extends ValuePropertyModel {
 
   @Valid

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/GetOAuth2AuthorizationParametersRequestModel.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/GetOAuth2AuthorizationParametersRequestModel.java
@@ -23,7 +23,7 @@ import jakarta.annotation.Generated;
 
 @Schema(name = "getOAuth2AuthorizationParameters_request", description = "Contains all required information to open a connection to a service defined by componentName parameter.")
 @JsonTypeName("getOAuth2AuthorizationParameters_request")
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public class GetOAuth2AuthorizationParametersRequestModel {
 
   private String authorizationName;

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/GetWorkflowNodeDescription200ResponseModel.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/GetWorkflowNodeDescription200ResponseModel.java
@@ -20,7 +20,7 @@ import jakarta.annotation.Generated;
  */
 
 @JsonTypeName("getWorkflowNodeDescription_200_response")
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public class GetWorkflowNodeDescription200ResponseModel {
 
   private String description;

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/GetWorkflowNodeParameterDisplayConditions200ResponseModel.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/GetWorkflowNodeParameterDisplayConditions200ResponseModel.java
@@ -22,7 +22,7 @@ import jakarta.annotation.Generated;
  */
 
 @JsonTypeName("getWorkflowNodeParameterDisplayConditions_200_response")
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public class GetWorkflowNodeParameterDisplayConditions200ResponseModel {
 
   @Valid

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/HelpModel.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/HelpModel.java
@@ -21,7 +21,7 @@ import jakarta.annotation.Generated;
 
 @Schema(name = "Help", description = "The help text that is meant to guide your users as to how to configure this action or trigger.")
 @JsonTypeName("Help")
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public class HelpModel {
 
   private String body;

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/IntegerPropertyModel.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/IntegerPropertyModel.java
@@ -33,7 +33,7 @@ import jakarta.annotation.Generated;
 
 @Schema(name = "IntegerProperty", description = "An integer property type.")
 
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public class IntegerPropertyModel extends ValuePropertyModel {
 
   private Long defaultValue;

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/NullPropertyModel.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/NullPropertyModel.java
@@ -28,7 +28,7 @@ import jakarta.annotation.Generated;
 
 @Schema(name = "NullProperty", description = "A null property type.")
 
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public class NullPropertyModel extends ValuePropertyModel {
 
   public NullPropertyModel() {

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/NumberPropertyModel.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/NumberPropertyModel.java
@@ -33,7 +33,7 @@ import jakarta.annotation.Generated;
 
 @Schema(name = "NumberProperty", description = "A number property type.")
 
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public class NumberPropertyModel extends ValuePropertyModel {
 
   private Double defaultValue;

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/OAuth2AuthorizationParametersModel.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/OAuth2AuthorizationParametersModel.java
@@ -25,7 +25,7 @@ import jakarta.annotation.Generated;
  */
 
 @JsonTypeName("OAuth2AuthorizationParameters")
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public class OAuth2AuthorizationParametersModel {
 
   private String authorizationUrl;

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/OAuth2PropertiesModel.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/OAuth2PropertiesModel.java
@@ -23,7 +23,7 @@ import jakarta.annotation.Generated;
  */
 
 @JsonTypeName("OAuth2Properties")
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public class OAuth2PropertiesModel {
 
   private String redirectUri;

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/ObjectPropertyModel.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/ObjectPropertyModel.java
@@ -36,7 +36,7 @@ import jakarta.annotation.Generated;
 
 @Schema(name = "ObjectProperty", description = "An object property type.")
 
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public class ObjectPropertyModel extends ValuePropertyModel {
 
   @Valid

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/OptionModel.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/OptionModel.java
@@ -24,7 +24,7 @@ import jakarta.annotation.Generated;
 
 @Schema(name = "Option", description = "Defines valid property value.")
 @JsonTypeName("Option")
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public class OptionModel {
 
   private String description;

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/OptionsDataSourceModel.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/OptionsDataSourceModel.java
@@ -24,7 +24,7 @@ import jakarta.annotation.Generated;
 
 @Schema(name = "OptionsDataSource", description = "Defines function that should dynamically load options for the property.")
 @JsonTypeName("OptionsDataSource")
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public class OptionsDataSourceModel {
 
   @Valid

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/PropertiesDataSourceModel.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/PropertiesDataSourceModel.java
@@ -24,7 +24,7 @@ import jakarta.annotation.Generated;
 
 @Schema(name = "PropertiesDataSource", description = "Defines function that should load properties.")
 @JsonTypeName("PropertiesDataSource")
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public class PropertiesDataSourceModel {
 
   @Valid

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/PropertyModel.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/PropertyModel.java
@@ -47,7 +47,7 @@ import jakarta.annotation.Generated;
   @JsonSubTypes.Type(value = ValuePropertyModel.class, name = "ValueProperty")
 })
 
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public class PropertyModel {
 
   private Boolean advancedOption = false;

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/PropertyTypeModel.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/PropertyTypeModel.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
  * A type of property.
  */
 
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public enum PropertyTypeModel {
   
   ARRAY("ARRAY"),

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/ResourcesModel.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/ResourcesModel.java
@@ -21,7 +21,7 @@ import jakarta.annotation.Generated;
 
 @Schema(name = "Resources", description = "A set of available resources.")
 @JsonTypeName("Resources")
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public class ResourcesModel {
 
   private String documentationUrl;

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/SaveWorkflowTestConfigurationConnectionRequestModel.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/SaveWorkflowTestConfigurationConnectionRequestModel.java
@@ -20,7 +20,7 @@ import jakarta.annotation.Generated;
  */
 
 @JsonTypeName("saveWorkflowTestConfigurationConnection_request")
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public class SaveWorkflowTestConfigurationConnectionRequestModel {
 
   private Long connectionId;

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/SaveWorkflowTestConfigurationInputsRequestModel.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/SaveWorkflowTestConfigurationInputsRequestModel.java
@@ -22,7 +22,7 @@ import jakarta.annotation.Generated;
  */
 
 @JsonTypeName("saveWorkflowTestConfigurationInputs_request")
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public class SaveWorkflowTestConfigurationInputsRequestModel {
 
   @Valid

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/ScriptTestExecutionModel.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/ScriptTestExecutionModel.java
@@ -22,7 +22,7 @@ import jakarta.annotation.Generated;
 
 @Schema(name = "ScriptTestExecution", description = "Contains information about test execution of a script.")
 @JsonTypeName("ScriptTestExecution")
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public class ScriptTestExecutionModel {
 
   private ExecutionErrorModel error;

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/StringPropertyModel.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/StringPropertyModel.java
@@ -33,7 +33,7 @@ import jakarta.annotation.Generated;
 
 @Schema(name = "StringProperty", description = "A string property.")
 
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public class StringPropertyModel extends ValuePropertyModel {
 
   private String languageId;

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/TaskDispatcherDefinitionBasicModel.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/TaskDispatcherDefinitionBasicModel.java
@@ -22,7 +22,7 @@ import jakarta.annotation.Generated;
 
 @Schema(name = "TaskDispatcherDefinitionBasic", description = "A task dispatcher defines a strategy for dispatching tasks to be executed.")
 @JsonTypeName("TaskDispatcherDefinitionBasic")
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public class TaskDispatcherDefinitionBasicModel {
 
   private String description;
@@ -35,6 +35,8 @@ public class TaskDispatcherDefinitionBasicModel {
 
   private String title;
 
+  private Integer version;
+
   public TaskDispatcherDefinitionBasicModel() {
     super();
   }
@@ -42,8 +44,9 @@ public class TaskDispatcherDefinitionBasicModel {
   /**
    * Constructor with only required parameters
    */
-  public TaskDispatcherDefinitionBasicModel(String name) {
+  public TaskDispatcherDefinitionBasicModel(String name, Integer version) {
     this.name = name;
+    this.version = version;
   }
 
   public TaskDispatcherDefinitionBasicModel description(String description) {
@@ -146,6 +149,26 @@ public class TaskDispatcherDefinitionBasicModel {
     this.title = title;
   }
 
+  public TaskDispatcherDefinitionBasicModel version(Integer version) {
+    this.version = version;
+    return this;
+  }
+
+  /**
+   * The version of a task dispatcher.
+   * @return version
+   */
+  @NotNull 
+  @Schema(name = "version", description = "The version of a task dispatcher.", requiredMode = Schema.RequiredMode.REQUIRED)
+  @JsonProperty("version")
+  public Integer getVersion() {
+    return version;
+  }
+
+  public void setVersion(Integer version) {
+    this.version = version;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -159,12 +182,13 @@ public class TaskDispatcherDefinitionBasicModel {
         Objects.equals(this.icon, taskDispatcherDefinitionBasic.icon) &&
         Objects.equals(this.name, taskDispatcherDefinitionBasic.name) &&
         Objects.equals(this.resources, taskDispatcherDefinitionBasic.resources) &&
-        Objects.equals(this.title, taskDispatcherDefinitionBasic.title);
+        Objects.equals(this.title, taskDispatcherDefinitionBasic.title) &&
+        Objects.equals(this.version, taskDispatcherDefinitionBasic.version);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(description, icon, name, resources, title);
+    return Objects.hash(description, icon, name, resources, title, version);
   }
 
   @Override
@@ -176,6 +200,7 @@ public class TaskDispatcherDefinitionBasicModel {
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
     sb.append("    resources: ").append(toIndentedString(resources)).append("\n");
     sb.append("    title: ").append(toIndentedString(title)).append("\n");
+    sb.append("    version: ").append(toIndentedString(version)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/TaskDispatcherDefinitionModel.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/TaskDispatcherDefinitionModel.java
@@ -26,7 +26,7 @@ import jakarta.annotation.Generated;
 
 @Schema(name = "TaskDispatcherDefinition", description = "A task dispatcher defines a strategy for dispatching tasks to be executed.")
 @JsonTypeName("TaskDispatcherDefinition")
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public class TaskDispatcherDefinitionModel {
 
   private String description;

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/TaskDispatcherOperationRequestModel.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/TaskDispatcherOperationRequestModel.java
@@ -22,7 +22,7 @@ import jakarta.annotation.Generated;
  */
 
 @JsonTypeName("TaskDispatcherOperationRequest")
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public class TaskDispatcherOperationRequestModel {
 
   @Valid

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/TaskPropertyModel.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/TaskPropertyModel.java
@@ -27,7 +27,7 @@ import jakarta.annotation.Generated;
 
 @Schema(name = "TaskProperty", description = "A task property used in task dispatchers.")
 
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public class TaskPropertyModel extends PropertyModel {
 
   private String name;

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/TimePropertyModel.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/TimePropertyModel.java
@@ -33,7 +33,7 @@ import jakarta.annotation.Generated;
 
 @Schema(name = "TimeProperty", description = "A time property.")
 
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public class TimePropertyModel extends ValuePropertyModel {
 
   private String defaultValue;

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/TriggerDefinitionBasicModel.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/TriggerDefinitionBasicModel.java
@@ -24,7 +24,7 @@ import jakarta.annotation.Generated;
 
 @Schema(name = "TriggerDefinitionBasic", description = "A trigger definition defines ways to trigger workflows from the outside services.")
 @JsonTypeName("TriggerDefinitionBasic")
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public class TriggerDefinitionBasicModel {
 
   private String description;

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/TriggerDefinitionModel.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/TriggerDefinitionModel.java
@@ -28,7 +28,7 @@ import jakarta.annotation.Generated;
 
 @Schema(name = "TriggerDefinition", description = "A trigger definition defines ways to trigger workflows from the outside services.")
 @JsonTypeName("TriggerDefinition")
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public class TriggerDefinitionModel {
 
   private String componentName;

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/TriggerTypeModel.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/TriggerTypeModel.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
  * Gets or Sets TriggerType
  */
 
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public enum TriggerTypeModel {
   
   STATIC_WEBHOOK("STATIC_WEBHOOK"),

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/UnifiedApiCategoryModel.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/UnifiedApiCategoryModel.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
  * A category of unified API.
  */
 
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public enum UnifiedApiCategoryModel {
   
   ACCOUNTING("ACCOUNTING"),

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/UpdateWorkflowNodeParameter200ResponseModel.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/UpdateWorkflowNodeParameter200ResponseModel.java
@@ -22,7 +22,7 @@ import jakarta.annotation.Generated;
  */
 
 @JsonTypeName("updateWorkflowNodeParameter_200_response")
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public class UpdateWorkflowNodeParameter200ResponseModel {
 
   @Valid

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/UpdateWorkflowNodeParameterRequestModel.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/UpdateWorkflowNodeParameterRequestModel.java
@@ -20,7 +20,7 @@ import jakarta.annotation.Generated;
  */
 
 @JsonTypeName("updateWorkflowNodeParameter_request")
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public class UpdateWorkflowNodeParameterRequestModel {
 
   private Boolean includeInMetadata = false;

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/ValuePropertyModel.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/ValuePropertyModel.java
@@ -48,7 +48,7 @@ import jakarta.annotation.Generated;
   @JsonSubTypes.Type(value = TimePropertyModel.class, name = "TIME")
 })
 
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public class ValuePropertyModel extends PropertyModel {
 
   private ControlTypeModel controlType;

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/WorkflowBasicModel.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/WorkflowBasicModel.java
@@ -23,7 +23,7 @@ import jakarta.annotation.Generated;
 
 @Schema(name = "WorkflowBasic", description = "The blueprint that describe the execution of a job.")
 @JsonTypeName("WorkflowBasic")
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public class WorkflowBasicModel {
 
   private String createdBy;

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/WorkflowConnectionModel.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/WorkflowConnectionModel.java
@@ -20,7 +20,7 @@ import jakarta.annotation.Generated;
  */
 
 @JsonTypeName("WorkflowConnection")
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public class WorkflowConnectionModel {
 
   private String componentName;

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/WorkflowFormatModel.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/WorkflowFormatModel.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
  * Gets or Sets WorkflowFormat
  */
 
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public enum WorkflowFormatModel {
   
   JSON("JSON"),

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/WorkflowInputModel.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/WorkflowInputModel.java
@@ -20,7 +20,7 @@ import jakarta.annotation.Generated;
  */
 
 @JsonTypeName("WorkflowInput")
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public class WorkflowInputModel {
 
   private String label;

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/WorkflowModel.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/WorkflowModel.java
@@ -32,7 +32,7 @@ import jakarta.annotation.Generated;
 
 @Schema(name = "Workflow", description = "The blueprint that describe the execution of a job.")
 @JsonTypeName("Workflow")
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public class WorkflowModel implements com.bytechef.platform.configuration.web.rest.model.WorkflowModelAware {
 
   private String createdBy;

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/WorkflowNodeOutputModel.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/WorkflowNodeOutputModel.java
@@ -25,7 +25,7 @@ import jakarta.annotation.Generated;
 
 @Schema(name = "WorkflowNodeOutput", description = "The workflow node output")
 @JsonTypeName("WorkflowNodeOutput")
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public class WorkflowNodeOutputModel {
 
   private ActionDefinitionModel actionDefinition;

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/WorkflowNodeTestOutputModel.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/WorkflowNodeTestOutputModel.java
@@ -21,7 +21,7 @@ import jakarta.annotation.Generated;
 
 @Schema(name = "WorkflowNodeTestOutput", description = "Contains test output of a workflow node.")
 @JsonTypeName("WorkflowNodeTestOutput")
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public class WorkflowNodeTestOutputModel {
 
   private Long id;

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/WorkflowOutputModel.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/WorkflowOutputModel.java
@@ -20,7 +20,7 @@ import jakarta.annotation.Generated;
  */
 
 @JsonTypeName("WorkflowOutput")
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public class WorkflowOutputModel {
 
   private String name;

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/WorkflowTaskModel.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/WorkflowTaskModel.java
@@ -28,7 +28,7 @@ import jakarta.annotation.Generated;
 
 @Schema(name = "WorkflowTask", description = "Represents a definition of a workflow task.")
 @JsonTypeName("WorkflowTask")
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public class WorkflowTaskModel {
 
   @Valid

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/WorkflowTestConfigurationConnectionModel.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/WorkflowTestConfigurationConnectionModel.java
@@ -21,7 +21,7 @@ import jakarta.annotation.Generated;
 
 @Schema(name = "WorkflowTestConfigurationConnection", description = "The connection used in a particular action task or trigger.")
 @JsonTypeName("WorkflowTestConfigurationConnection")
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public class WorkflowTestConfigurationConnectionModel {
 
   private Long connectionId;

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/WorkflowTestConfigurationModel.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/WorkflowTestConfigurationModel.java
@@ -29,7 +29,7 @@ import jakarta.annotation.Generated;
 
 @Schema(name = "WorkflowTestConfiguration", description = "Contains configuration and connections required for the test execution of a particular workflow.")
 @JsonTypeName("WorkflowTestConfiguration")
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public class WorkflowTestConfigurationModel {
 
   private String createdBy;

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/WorkflowTriggerModel.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/generated/src/main/java/com/bytechef/platform/configuration/web/rest/model/WorkflowTriggerModel.java
@@ -27,7 +27,7 @@ import jakarta.annotation.Generated;
 
 @Schema(name = "WorkflowTrigger", description = "Represents a definition of a workflow trigger.")
 @JsonTypeName("WorkflowTrigger")
-@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-11-30T08:22:07.952410+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
+@Generated(value = "org.openapitools.codegen.languages.SpringCodegen", date = "2024-12-17T07:23:43.893312+01:00[Europe/Zagreb]", comments = "Generator version: 7.10.0")
 public class WorkflowTriggerModel {
 
   @Valid

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-impl/openapi.yaml
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-impl/openapi.yaml
@@ -87,13 +87,69 @@ paths:
                 type: "array"
                 items:
                   $ref: "#/components/schemas/ComponentDefinitionBasic"
-  /component-definitions/{componentName}:
+  /component-definitions/{componentName}/connection-definition:
     get:
-      description: "Get a component definition."
-      summary: "Get a component definition"
+      description: "Get connection definition for a component."
+      summary: "Get connection definition for a component"
+      tags:
+        - "connection-definition"
+      operationId: "getComponentConnectionDefinition"
+      parameters:
+        - name: "componentName"
+          description: "The name of a component."
+          required: true
+          in: "path"
+          schema:
+            type: "string"
+        - name: "componentVersion"
+          description: "The version of a component."
+          required: false
+          in: "query"
+          schema:
+            type: "integer"
+      responses:
+        "200":
+          description: "Successful operation."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ConnectionDefinition"
+  /component-definitions/{componentName}/connection-definitions:
+    get:
+      description: "Get all compatible connection definitions for a component."
+      summary: "Get all compatible connection definitions for a component"
+      tags:
+        - "connection-definition"
+      operationId: "getComponentConnectionDefinitions"
+      parameters:
+        - name: "componentName"
+          description: "The name of a component."
+          required: true
+          in: "path"
+          schema:
+            type: "string"
+        - name: "componentVersion"
+          description: "The version of a component."
+          required: false
+          in: "query"
+          schema:
+            type: "integer"
+      responses:
+        "200":
+          description: "Successful operation."
+          content:
+            application/json:
+              schema:
+                type: "array"
+                items:
+                  $ref: "#/components/schemas/ConnectionDefinitionBasic"
+  /component-definitions/{componentName}/connection-versions/{connectionVersion}:
+    get:
+      description: "Get a connection component definition."
+      summary: "Get a connection component definition"
       tags:
         - "component-definition"
-      operationId: "getComponentDefinition"
+      operationId: "getConnectionComponentDefinition"
       parameters:
         - name: "componentName"
           description: "The name of a component to get."
@@ -101,11 +157,10 @@ paths:
           in: "path"
           schema:
             type: "string"
-        - name: "componentVersion"
-          description: "The version of a component to get. If not set, teh latest version\
-          \ is returned."
-          required: false
-          in: "query"
+        - name: "connectionVersion"
+          description: "The version of a component connection to get."
+          required: true
+          in: "path"
           schema:
             type: "integer"
       responses:
@@ -138,6 +193,33 @@ paths:
                 type: "array"
                 items:
                   $ref: "#/components/schemas/ComponentDefinitionBasic"
+  /component-definitions/{componentName}/versions/{componentVersion}:
+    get:
+      description: "Get a component definition."
+      summary: "Get a component definition"
+      tags:
+        - "component-definition"
+      operationId: "getComponentDefinition"
+      parameters:
+        - name: "componentName"
+          description: "The name of a component to get."
+          required: true
+          in: "path"
+          schema:
+            type: "string"
+        - name: "componentVersion"
+          description: "The version of a component to get."
+          required: true
+          in: "path"
+          schema:
+            type: "integer"
+      responses:
+        "200":
+          description: "Successful operation."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ComponentDefinition"
   /component-definitions/{componentName}/versions/{componentVersion}/action-definitions:
     get:
       description: "Get a list of action definitions for a component."
@@ -200,62 +282,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ActionDefinition"
-  /component-definitions/{componentName}/versions/connection-definition:
-    get:
-      description: "Get connection definition for a component."
-      summary: "Get connection definition for a component"
-      tags:
-      - "connection-definition"
-      operationId: "getComponentConnectionDefinition"
-      parameters:
-      - name: "componentName"
-        description: "The name of a component."
-        required: true
-        in: "path"
-        schema:
-          type: "string"
-      - name: "componentVersion"
-        description: "The version of a component."
-        required: false
-        in: "query"
-        schema:
-          type: "integer"
-      responses:
-        "200":
-          description: "Successful operation."
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ConnectionDefinition"
-  /component-definitions/{componentName}/versions/connection-definitions:
-    get:
-      description: "Get all compatible connection definitions for a component."
-      summary: "Get all compatible connection definitions for a component"
-      tags:
-      - "connection-definition"
-      operationId: "getComponentConnectionDefinitions"
-      parameters:
-      - name: "componentName"
-        description: "The name of a component."
-        required: true
-        in: "path"
-        schema:
-          type: "string"
-      - name: "componentVersion"
-        description: "The version of a component."
-        required: false
-        in: "query"
-        schema:
-          type: "integer"
-      responses:
-        "200":
-          description: "Successful operation."
-          content:
-            application/json:
-              schema:
-                type: "array"
-                items:
-                  $ref: "#/components/schemas/ConnectionDefinitionBasic"
   /component-definitions/{componentName}/versions/{componentVersion}/trigger-definitions:
     get:
       description: "Get a list of trigger definitionss for a component."
@@ -1811,6 +1837,7 @@ components:
       type: "object"
       required:
       - "name"
+      - "version"
       properties:
         description:
           description: "The description."
@@ -1826,6 +1853,9 @@ components:
         title:
           description: "The title"
           type: "string"
+        version:
+          description: "The version of a task dispatcher."
+          type: "integer"
     TaskDispatcherOperationRequest:
       type: "object"
       required:

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-impl/src/main/java/com/bytechef/platform/configuration/web/rest/ComponentDefinitionApiController.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-impl/src/main/java/com/bytechef/platform/configuration/web/rest/ComponentDefinitionApiController.java
@@ -55,6 +55,16 @@ public class ComponentDefinitionApiController implements ComponentDefinitionApi 
     }
 
     @Override
+    public ResponseEntity<ComponentDefinitionModel> getConnectionComponentDefinition(
+        String componentName, Integer connectionVersion) {
+
+        return ResponseEntity.ok(
+            conversionService.convert(
+                componentDefinitionService.getConnectionComponentDefinition(componentName, connectionVersion),
+                ComponentDefinitionModel.class));
+    }
+
+    @Override
     public ResponseEntity<ComponentDefinitionModel> getComponentDefinition(
         String componentName, Integer componentVersion) {
 

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-impl/src/main/java/com/bytechef/platform/configuration/web/rest/json/WorkflowNodeOutputModelJsonSerializer.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-impl/src/main/java/com/bytechef/platform/configuration/web/rest/json/WorkflowNodeOutputModelJsonSerializer.java
@@ -29,6 +29,7 @@ import org.springframework.boot.jackson.JsonComponent;
  */
 @JsonComponent
 public class WorkflowNodeOutputModelJsonSerializer extends JsonSerializer<WorkflowNodeOutputModel> {
+
     @Override
     public void serialize(WorkflowNodeOutputModel value, JsonGenerator jsonGenerator, SerializerProvider serializers)
         throws IOException {

--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-impl/src/main/java/com/bytechef/platform/configuration/web/rest/json/WorkflowTriggerModelJsonSerializer.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-impl/src/main/java/com/bytechef/platform/configuration/web/rest/json/WorkflowTriggerModelJsonSerializer.java
@@ -30,6 +30,7 @@ import org.springframework.boot.jackson.JsonComponent;
  */
 @JsonComponent
 public class WorkflowTriggerModelJsonSerializer extends JsonSerializer<WorkflowTriggerModel> {
+
     @Override
     public void serialize(WorkflowTriggerModel value, JsonGenerator jsonGenerator, SerializerProvider serializers)
         throws IOException {

--- a/server/libs/platform/platform-configuration/platform-configuration-service/src/main/java/com/bytechef/platform/configuration/event/WorkflowAfterSaveEventListener.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-service/src/main/java/com/bytechef/platform/configuration/event/WorkflowAfterSaveEventListener.java
@@ -25,6 +25,9 @@ import org.springframework.data.relational.core.mapping.event.AbstractRelational
 import org.springframework.data.relational.core.mapping.event.AfterSaveEvent;
 import org.springframework.stereotype.Component;
 
+/**
+ * @author Ivica Cardic
+ */
 @Component
 public class WorkflowAfterSaveEventListener extends AbstractRelationalEventListener<Workflow> {
 

--- a/server/libs/platform/platform-configuration/platform-configuration-service/src/main/java/com/bytechef/platform/configuration/service/WorkflowNodeTestOutputServiceImpl.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-service/src/main/java/com/bytechef/platform/configuration/service/WorkflowNodeTestOutputServiceImpl.java
@@ -49,8 +49,7 @@ public class WorkflowNodeTestOutputServiceImpl implements WorkflowNodeTestOutput
 
     @Override
     public void deleteWorkflowNodeTestOutput(String workflowId, String workflowNodeName) {
-        workflowNodeTestOutputRepository
-            .findByWorkflowIdAndWorkflowNodeName(workflowId, workflowNodeName)
+        workflowNodeTestOutputRepository.findByWorkflowIdAndWorkflowNodeName(workflowId, workflowNodeName)
             .ifPresent(workflowNodeTestOutputRepository::delete);
     }
 

--- a/server/libs/platform/platform-connection/platform-connection-rest/openapi/components/schemas/objects/connection_base.yaml
+++ b/server/libs/platform/platform-connection/platform-connection-rest/openapi/components/schemas/objects/connection_base.yaml
@@ -4,7 +4,7 @@ type: "object"
 required:
   - "name"
   - "componentName"
-  - "componentVersion"
+  - "connectionVersion"
   - "parameters"
 properties:
   active:


### PR DESCRIPTION
- **1715 - client - Fix handling arrays as array items**
- **1814 - Update custom banner**
- **1850 - platform-configuration-rest - Set componentVersion as required, add endpoint for fetching component definitions via connection version**
- **1850 - Generate**
- **1850 - client - Generate**
- **1850 - SF**
- **1850 - client - Fix wrong ReqctQuery keys**
- **1850 - client - componentVersion is required**
- **1850 - client - Fetch component definition via connectionVersion**
- **1850 - client - Fetch latest connection definition**
- **1850 - client - Don’t delete workflow node test outputs whcn clicking on a trigger node**
- **1850 - Update ComponentDefinitionApiController**
- **1850 - Remove test ouput if a trigger name is different**
- **1850 - SF**
