### PR TITLE
1896 tls email fixes

### DIFF
--- a/server/apps/server-app/src/main/resources/config/application.yml
+++ b/server/apps/server-app/src/main/resources/config/application.yml
@@ -136,13 +136,18 @@ spring:
       mail:
         debug: ${bytechef.mail.debug:false}
         smtp:
-          auth: ${bytechef.mail.smtp.auth:false}
+          auth: ${bytechef.mail.auth:false}
           starttls:
-            enable: ${bytechef.mail.smtp.starttls.enable:false}
-            required: ${bytechef.mail.smtp.starttls.required:false}
+            enable: ${bytechef.mail.starttls.enable:false}
+            required: ${bytechef.mail.starttls.required:false}
+        smtps:
+          auth: true
+          starttls:
+            enable: ${bytechef.mail.starttls.enable:false}
+            required: ${bytechef.mail.starttls.required:false}
         transport:
-          protocol: ${bytechef.mail.transport.protocol:smtp}
-    protocol: ${bytechef.mail.transport.protocol:smtp}
+          protocol: ${bytechef.mail.protocol:smtp}
+    protocol: ${bytechef.mail.protocol:smtp}
     ssl:
       enabled: ${bytechef.mail.ssl.enabled:false}
   liquibase:

--- a/server/libs/config/app-config/src/main/java/com/bytechef/config/ApplicationProperties.java
+++ b/server/libs/config/app-config/src/main/java/com/bytechef/config/ApplicationProperties.java
@@ -1567,6 +1567,10 @@ public class ApplicationProperties {
             public boolean isEnabled() {
                 return enabled;
             }
+
+            public void setEnabled(boolean enabled) {
+                this.enabled = enabled;
+            }
         }
 
         public static class Transport {


### PR DESCRIPTION
added smtps configuration
During test I noticed that *.smtp.auth applies only if smtp is selected.

Also.. ApplicationProperties.Mail.SSL ends up with exception because of missing setter. Issue cant be caught if property is not set.