### PR TITLE
1132 - Notifications frontend implementation

### DIFF
--- a/client/src/ee/mutations/notifications.mutations.ts
+++ b/client/src/ee/mutations/notifications.mutations.ts
@@ -1,0 +1,51 @@
+import {Notification, NotificationApi} from '@/shared/middleware/platform/configuration';
+import {useMutation} from '@tanstack/react-query';
+
+interface CreateNotificationMutationProps {
+    onError?: (error: Error, variables: Notification) => void;
+    onSuccess?: (result: Notification, variables: Notification) => void;
+}
+
+export const useCreateNotificationMutation = (mutationProps?: CreateNotificationMutationProps) =>
+    useMutation<Notification, Error, Notification>({
+        mutationFn: (notification: Notification) => {
+            return new NotificationApi().createNotification({
+                notification,
+            });
+        },
+        onError: mutationProps?.onError,
+        onSuccess: mutationProps?.onSuccess,
+    });
+
+interface DeleteNotificationMutationProps {
+    onError?: (error: Error, variables: number) => void;
+    onSuccess?: (result: void, variables: number) => void;
+}
+
+export const useDeleteNotificationMutation = (mutationProps?: DeleteNotificationMutationProps) =>
+    useMutation<void, Error, number>({
+        mutationFn: (notificationId: number) => {
+            return new NotificationApi().deleteNotification({
+                notificationId,
+            });
+        },
+        onError: mutationProps?.onError,
+        onSuccess: mutationProps?.onSuccess,
+    });
+
+interface UpdateNotificationMutationProps {
+    onError?: (error: Error, variables: Notification) => void;
+    onSuccess?: (result: Notification, variables: Notification) => void;
+}
+
+export const useUpdateNotificationMutation = (mutationProps?: UpdateNotificationMutationProps) =>
+    useMutation<Notification, Error, Notification>({
+        mutationFn: (notification: Notification) => {
+            return new NotificationApi().updateNotification({
+                notification,
+                notificationId: notification.id!,
+            });
+        },
+        onError: mutationProps?.onError,
+        onSuccess: mutationProps?.onSuccess,
+    });

--- a/client/src/ee/queries/notificationEvents.queries.ts
+++ b/client/src/ee/queries/notificationEvents.queries.ts
@@ -1,0 +1,10 @@
+import {NotificationEvent, NotificationEventApi} from '@/shared/middleware/platform/configuration';
+import {useQuery} from '@tanstack/react-query';
+
+export const NotificationEventKeys = ['notificationEvents'];
+
+export const useGetNotificationEventsQuery = () =>
+    useQuery<NotificationEvent[], Error>({
+        queryFn: () => new NotificationEventApi().getNotificationEvents(),
+        queryKey: NotificationEventKeys,
+    });

--- a/client/src/ee/queries/notifications.queries.ts
+++ b/client/src/ee/queries/notifications.queries.ts
@@ -1,0 +1,10 @@
+import {Notification, NotificationApi} from '@/shared/middleware/platform/configuration';
+import {useQuery} from '@tanstack/react-query';
+
+export const NotificationKeys = ['notifications'];
+
+export const useGetNotificationsQuery = () =>
+    useQuery<Notification[], Error>({
+        queryFn: () => new NotificationApi().getNotifications(),
+        queryKey: NotificationKeys,
+    });

--- a/client/src/pages/platform/settings/notifications/Notifications.tsx
+++ b/client/src/pages/platform/settings/notifications/Notifications.tsx
@@ -1,0 +1,51 @@
+import EmptyList from '@/components/EmptyList';
+import PageLoader from '@/components/PageLoader';
+import {Button} from '@/components/ui/button';
+import {useGetNotificationsQuery} from '@/ee/queries/notifications.queries';
+import NotificationDialog from '@/pages/platform/settings/notifications/components/NotificationDialog';
+import NotificationsList from '@/pages/platform/settings/notifications/components/NotificationsList';
+import Header from '@/shared/layout/Header';
+import LayoutContainer from '@/shared/layout/LayoutContainer';
+import {Link2Icon} from 'lucide-react';
+
+const Notifications = () => {
+    const {
+        data: notifications,
+        error: notificationsError,
+        isLoading: notificationsIsLoading,
+    } = useGetNotificationsQuery();
+
+    return (
+        <LayoutContainer
+            header={
+                notifications &&
+                notifications.length > 0 && (
+                    <Header
+                        centerTitle={true}
+                        position="main"
+                        right={<NotificationDialog triggerNode={<Button>New Notification</Button>} />}
+                        title="Notifications"
+                    />
+                )
+            }
+            leftSidebarOpen={false}
+        >
+            <PageLoader errors={[notificationsError]} loading={notificationsIsLoading}>
+                {notifications && notifications.length > 0 ? (
+                    <div className="w-full divide-y divide-border/50 px-4 2xl:mx-auto 2xl:w-4/5">
+                        <NotificationsList notifications={notifications} />
+                    </div>
+                ) : (
+                    <EmptyList
+                        button={<NotificationDialog triggerNode={<Button>New Notification</Button>} />}
+                        icon={<Link2Icon className="size-12 text-gray-400" />}
+                        message="You do not have any Notification created yet."
+                        title="No Notifications"
+                    />
+                )}
+            </PageLoader>
+        </LayoutContainer>
+    );
+};
+
+export default Notifications;

--- a/client/src/pages/platform/settings/notifications/components/NotificationDialog.tsx
+++ b/client/src/pages/platform/settings/notifications/components/NotificationDialog.tsx
@@ -1,0 +1,249 @@
+import {MultiSelect} from '@/components/MultiSelect';
+import {Button} from '@/components/ui/button';
+import {
+    Dialog,
+    DialogClose,
+    DialogCloseButton,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    DialogTrigger,
+} from '@/components/ui/dialog';
+import {Form, FormControl, FormField, FormItem, FormLabel, FormMessage} from '@/components/ui/form';
+import {Input} from '@/components/ui/input';
+import {Select, SelectContent, SelectItem, SelectTrigger, SelectValue} from '@/components/ui/select';
+import {Textarea} from '@/components/ui/textarea';
+import {useCreateNotificationMutation, useUpdateNotificationMutation} from '@/ee/mutations/notifications.mutations';
+import {useGetNotificationEventsQuery} from '@/ee/queries/notificationEvents.queries';
+import {NotificationKeys} from '@/ee/queries/notifications.queries';
+import {Notification, NotificationTypeEnum} from '@/shared/middleware/platform/configuration';
+import {zodResolver} from '@hookform/resolvers/zod';
+import {useQueryClient} from '@tanstack/react-query';
+import React, {ReactNode, useState} from 'react';
+import {useForm} from 'react-hook-form';
+import {z} from 'zod';
+
+const formSchema = z.object({
+    name: z.string().min(1, 'Name is required').max(256, 'Name cannot be longer than 256 characters'),
+    notificationEventIds: z.array(z.number()),
+    settings: z.string(),
+    type: z.enum(['EMAIL', 'WEBHOOK'], {
+        required_error: 'Please select a notification type.',
+    }),
+});
+
+interface NotificationDialogProps {
+    notification?: Notification;
+    onClose?: () => void;
+    triggerNode?: ReactNode;
+}
+
+const NotificationDialog = ({notification, onClose, triggerNode}: NotificationDialogProps) => {
+    const [isOpen, setIsOpen] = useState(!triggerNode);
+
+    const form = useForm<z.infer<typeof formSchema>>({
+        defaultValues: {
+            name: notification?.name || '',
+            notificationEventIds: notification?.notificationEvents?.map((event) => event.id) || [],
+            settings: JSON.stringify(notification?.settings) || '',
+            type: notification?.type || NotificationTypeEnum.Email,
+        },
+        resolver: zodResolver(formSchema),
+    });
+
+    const {control, getValues, handleSubmit, reset} = form;
+
+    const {data: notificationEvents, isLoading: isNotificationEventsLoading} = useGetNotificationEventsQuery();
+
+    const queryClient = useQueryClient();
+
+    const onSuccess = () => {
+        queryClient.invalidateQueries({
+            queryKey: NotificationKeys,
+        });
+
+        closeDialog();
+    };
+
+    const createNotificationMutation = useCreateNotificationMutation({onSuccess});
+
+    const updateNotificationMutation = useUpdateNotificationMutation({onSuccess});
+
+    function closeDialog() {
+        setIsOpen(false);
+
+        if (onClose) {
+            onClose();
+        }
+
+        reset();
+    }
+
+    function saveNotification() {
+        const formData = getValues();
+
+        formData.settings = formData.settings
+            .split(/\r?\n/)
+            .filter((setting) => setting)
+            .map((setting) => ({[setting.split('=')[0]]: setting.split('=')[1]}))
+            .reduce((previousValue, value) => {
+                return {...previousValue, ...value};
+            }, {});
+
+        if (notification?.id) {
+            updateNotificationMutation.mutate({
+                ...notification,
+                ...formData,
+            });
+        } else {
+            createNotificationMutation.mutate({
+                ...notification,
+                ...formData,
+            });
+        }
+    }
+
+    return (
+        <Dialog
+            onOpenChange={(isOpen) => {
+                if (isOpen) {
+                    setIsOpen(isOpen);
+                } else {
+                    closeDialog();
+                }
+            }}
+            open={isOpen}
+        >
+            {triggerNode && <DialogTrigger asChild>{triggerNode}</DialogTrigger>}
+
+            <DialogContent>
+                <Form {...form}>
+                    <form
+                        className="flex flex-col gap-4"
+                        onSubmit={handleSubmit(saveNotification, (error) => console.log(error))}
+                    >
+                        <DialogHeader className="flex flex-row items-center justify-between space-y-0">
+                            <div className="flex flex-col space-y-1">
+                                <DialogTitle>{`${notification?.id ? 'Edit' : 'Create'}`} Notification</DialogTitle>
+
+                                <DialogDescription>Define notification parameters.</DialogDescription>
+                            </div>
+
+                            <DialogCloseButton />
+                        </DialogHeader>
+
+                        <FormField
+                            control={control}
+                            name="name"
+                            render={({field}) => (
+                                <FormItem>
+                                    <FormLabel>Name</FormLabel>
+
+                                    <FormControl>
+                                        <Input {...field} />
+                                    </FormControl>
+
+                                    <FormMessage />
+                                </FormItem>
+                            )}
+                        />
+
+                        <FormField
+                            control={control}
+                            name="type"
+                            render={({field}) => (
+                                <FormItem>
+                                    <FormLabel>Type</FormLabel>
+
+                                    <FormControl>
+                                        <Select onValueChange={field.onChange} value={field.value}>
+                                            <SelectTrigger className="w-full">
+                                                <SelectValue />
+                                            </SelectTrigger>
+
+                                            <SelectContent>
+                                                <SelectItem
+                                                    key={NotificationTypeEnum.Email.toString()}
+                                                    value={NotificationTypeEnum.Email.toString()}
+                                                >
+                                                    {NotificationTypeEnum.Email.toString()}
+                                                </SelectItem>
+
+                                                <SelectItem
+                                                    key={NotificationTypeEnum.Webhook.toString()}
+                                                    value={NotificationTypeEnum.Webhook.toString()}
+                                                >
+                                                    {NotificationTypeEnum.Webhook.toString()}
+                                                </SelectItem>
+                                            </SelectContent>
+                                        </Select>
+                                    </FormControl>
+
+                                    <FormMessage />
+                                </FormItem>
+                            )}
+                        />
+
+                        {notificationEvents && (
+                            <FormField
+                                control={control}
+                                name="notificationEventIds"
+                                render={({field}) => (
+                                    <FormItem>
+                                        <FormLabel>Events</FormLabel>
+
+                                        <FormControl>
+                                            <MultiSelect
+                                                defaultValue=""
+                                                onValueChange={field.onChange}
+                                                options={notificationEvents?.map((notificationEvent) => ({
+                                                    label: notificationEvent.type,
+                                                    value: notificationEvent.id,
+                                                }))}
+                                                optionsLoading={isNotificationEventsLoading}
+                                                placeholder={'Select events'}
+                                                value={field.value}
+                                            />
+                                        </FormControl>
+
+                                        <FormMessage />
+                                    </FormItem>
+                                )}
+                            />
+                        )}
+
+                        <FormField
+                            control={control}
+                            name="settings"
+                            render={({field}) => (
+                                <FormItem>
+                                    <FormLabel>Settings</FormLabel>
+
+                                    <FormControl>
+                                        <Textarea rows={6} {...field} />
+                                    </FormControl>
+
+                                    <FormMessage />
+                                </FormItem>
+                            )}
+                        />
+
+                        <DialogFooter>
+                            <DialogClose asChild>
+                                <Button type="button" variant="outline">
+                                    Cancel
+                                </Button>
+                            </DialogClose>
+
+                            <Button type="submit">Save</Button>
+                        </DialogFooter>
+                    </form>
+                </Form>
+            </DialogContent>
+        </Dialog>
+    );
+};
+
+export default NotificationDialog;

--- a/client/src/pages/platform/settings/notifications/components/NotificationsList.tsx
+++ b/client/src/pages/platform/settings/notifications/components/NotificationsList.tsx
@@ -1,0 +1,14 @@
+import NotificationsListItem from '@/pages/platform/settings/notifications/components/NotificationsListItem';
+import {Notification} from '@/shared/middleware/platform/configuration';
+
+const NotificationsList = ({notifications}: {notifications: Notification[]}) => {
+    return (
+        <ul className="w-full divide-y divide-gray-100 px-2 2xl:mx-auto 2xl:w-4/5" role="list">
+            {notifications.map((notification) => {
+                return <NotificationsListItem key={notification.id} notification={notification} />;
+            })}
+        </ul>
+    );
+};
+
+export default NotificationsList;

--- a/client/src/pages/platform/settings/notifications/components/NotificationsListItem.tsx
+++ b/client/src/pages/platform/settings/notifications/components/NotificationsListItem.tsx
@@ -1,0 +1,119 @@
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import {Button} from '@/components/ui/button';
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import {Tooltip, TooltipContent, TooltipTrigger} from '@/components/ui/tooltip';
+import {useDeleteNotificationMutation} from '@/ee/mutations/notifications.mutations';
+import {NotificationKeys} from '@/ee/queries/notifications.queries';
+import NotificationDialog from '@/pages/platform/settings/notifications/components/NotificationDialog';
+import {Notification} from '@/shared/middleware/platform/configuration';
+import {useQueryClient} from '@tanstack/react-query';
+import {EllipsisVerticalIcon} from 'lucide-react';
+import {useState} from 'react';
+
+const NotificationsListItem = ({notification}: {notification: Notification}) => {
+    const [showEditDialog, setShowEditDialog] = useState(false);
+    const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+
+    const queryClient = useQueryClient();
+
+    const deleteNotificationMutation = useDeleteNotificationMutation({
+        onSuccess: () => {
+            queryClient.invalidateQueries({
+                queryKey: NotificationKeys,
+            });
+        },
+    });
+
+    const handleAlertDeleteDialogClick = () => {
+        if (notification.id) {
+            deleteNotificationMutation.mutate(notification.id);
+
+            setShowDeleteDialog(false);
+        }
+    };
+
+    return (
+        <li className="relative flex items-center justify-between px-2 py-5 hover:bg-gray-50" key={notification.id}>
+            <div className="flex-1">
+                <span className="text-base">{notification.name}</span>
+            </div>
+
+            <div className="flex-1">
+                <span className="text-base">
+                    {notification.notificationEvents?.map((notificationEvent) => notificationEvent.type).join(', ')}
+                </span>
+            </div>
+
+            <div className="flex justify-end gap-x-6">
+                {notification.lastModifiedDate && notification.lastModifiedBy && (
+                    <Tooltip>
+                        <TooltipTrigger className="flex items-center text-sm text-gray-500">
+                            <span className="text-xs">
+                                {`Last modified at ${notification.lastModifiedDate?.toLocaleDateString()} ${notification.lastModifiedDate?.toLocaleTimeString()} by ${notification.lastModifiedBy}`}
+                            </span>
+                        </TooltipTrigger>
+
+                        <TooltipContent>Last Modified</TooltipContent>
+                    </Tooltip>
+                )}
+
+                <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                        <Button size="icon" variant="ghost">
+                            <EllipsisVerticalIcon className="size-4 hover:cursor-pointer" />
+                        </Button>
+                    </DropdownMenuTrigger>
+
+                    <DropdownMenuContent align="end">
+                        <DropdownMenuItem onClick={() => setShowEditDialog(true)}>Edit</DropdownMenuItem>
+
+                        <DropdownMenuSeparator />
+
+                        <DropdownMenuItem className="text-destructive" onClick={() => setShowDeleteDialog(true)}>
+                            Delete
+                        </DropdownMenuItem>
+                    </DropdownMenuContent>
+                </DropdownMenu>
+            </div>
+
+            <AlertDialog open={showDeleteDialog}>
+                <AlertDialogContent>
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>Are you sure you want to delete a notification?</AlertDialogTitle>
+
+                        <AlertDialogDescription>This action cannot be undone.</AlertDialogDescription>
+                    </AlertDialogHeader>
+
+                    <AlertDialogFooter>
+                        <AlertDialogCancel onClick={() => setShowDeleteDialog(false)}>Cancel</AlertDialogCancel>
+
+                        <AlertDialogAction className="bg-destructive" onClick={handleAlertDeleteDialogClick}>
+                            Delete
+                        </AlertDialogAction>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
+
+            {showEditDialog && (
+                <NotificationDialog notification={notification} onClose={() => setShowEditDialog(false)} />
+            )}
+        </li>
+    );
+};
+
+export default NotificationsListItem;

--- a/client/src/routes.tsx
+++ b/client/src/routes.tsx
@@ -32,6 +32,7 @@ import Home from '@/pages/home/Home';
 import AiProviders from '@/pages/platform/settings/ai-providers/AiProviders';
 import ApiKeys from '@/pages/platform/settings/api-keys/ApiKeys';
 import GitConfiguration from '@/pages/platform/settings/git-configuration/GitConfiguration';
+import Notifications from '@/pages/platform/settings/notifications/Notifications';
 import Workspaces from '@/pages/settings/automation/workspaces/Workspaces';
 import SigningKeys from '@/pages/settings/embedded/signing-keys/SigningKeys';
 import {AccessControl} from '@/shared/auth/AccessControl';
@@ -149,6 +150,14 @@ const platformSettingsRoutes = {
             ),
             path: 'api-keys',
         },
+        {
+            element: (
+                <PrivateRoute hasAnyAuthorities={[AUTHORITIES.ADMIN]}>
+                    <Notifications />
+                </PrivateRoute>
+            ),
+            path: 'notifications',
+        },
     ],
     navItems: [
         {
@@ -169,6 +178,10 @@ const platformSettingsRoutes = {
         {
             href: 'api-keys',
             title: 'API Keys',
+        },
+        {
+            href: 'notifications',
+            title: 'Notifications',
         },
     ],
 };


### PR DESCRIPTION
Work in progress:
1. NotificationDialog.Multiselect field doesn't support array default value, the problem could be in the Multiselect component itself
2. NotificationDialog.Settings field is not properly defined. Currently, it is TextArea free input. Desired behavior would be to render a different set of input fields based on the Notification type selected (EMAIL and WEBHOOK notifications have different settings). Notification Settings should be a JSON object with {[key: string] : string} schema

Notification object example:
``` 
{
        "id": 10,
        "createdBy": "admin",
        "createdDate": "2025-05-21T23:55:33.976128+02:00",
        "lastModifiedBy": "admin",
        "lastModifiedDate": "2025-05-22T14:51:38.180116+02:00",
        "name": "My Notification",
        "type": "EMAIL",
        "settings": {"email":"email@email.com"},
        "notificationEventIds": [1],
        "__version": 4
}
```