### PR TITLE
Revert "1652 - Handle null `clusterRoot` in `ComponentDefinitionMappe…

### DIFF
--- a/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/src/main/java/com/bytechef/platform/configuration/web/rest/mapper/ComponentDefinitionMapper.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-rest/platform-configuration-rest-api/src/main/java/com/bytechef/platform/configuration/web/rest/mapper/ComponentDefinitionMapper.java
@@ -47,12 +47,6 @@ public class ComponentDefinitionMapper {
             ComponentDefinition componentDefinition,
             @MappingTarget ComponentDefinitionModel componentDefinitionModel) {
 
-            if (componentDefinitionModel.getClusterRoot() == null || !componentDefinitionModel.getClusterRoot()) {
-                componentDefinitionModel.actionClusterElementTypes(null);
-                componentDefinitionModel.setClusterElements(null);
-                componentDefinitionModel.clusterElementTypes(null);
-            }
-
             componentDefinitionModel.setIcon("/icons/%s.svg".formatted(componentDefinition.getName()));
         }
     }


### PR DESCRIPTION
…r` by resetting cluster-related fields"

This reverts commit 4fdcbfe4b657a613904e55492ede6d30134b00e3.
