### PR TITLE
1522 - When creating a workflow, pressing Enter should try to submit the form

### DIFF
--- a/client/src/shared/components/workflow/WorkflowDialog.tsx
+++ b/client/src/shared/components/workflow/WorkflowDialog.tsx
@@ -18,8 +18,16 @@ import {IntegrationWorkflowKeys} from '@/ee/shared/queries/embedded/integrationW
 import {Workflow} from '@/shared/middleware/platform/configuration';
 import {ProjectWorkflowKeys} from '@/shared/queries/automation/projectWorkflows.queries';
 import {UseMutationResult, UseQueryResult, useQueryClient} from '@tanstack/react-query';
-import {ReactNode, useEffect, useState} from 'react';
+import {KeyboardEvent, ReactNode, useEffect, useRef, useState} from 'react';
 import {useForm} from 'react-hook-form';
+
+const handleEnterKeyPress = (handler: () => void) => {
+    return (e: KeyboardEvent) => {
+        if (e.key === 'Enter') {
+            handler();
+        }
+    };
+};
 
 interface WorkflowDialogProps {
     /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -133,6 +141,8 @@ const WorkflowDialog = ({
         closeDialog();
     }
 
+    const submitSavedWorkflow = handleSubmit(saveWorkflow);
+
     useEffect(() => {
         reset({
             description: workflow?.description || '',
@@ -153,7 +163,13 @@ const WorkflowDialog = ({
         >
             {triggerNode && <DialogTrigger asChild>{triggerNode}</DialogTrigger>}
 
-            <DialogContent onInteractOutside={(event) => event.preventDefault()}>
+            <DialogContent
+                onInteractOutside={(event) => event.preventDefault()}
+                onOpenAutoFocus={(e) => {
+                    e.preventDefault();
+                    labelRef.current?.focus();
+                }}
+            >
                 <DialogHeader className="flex flex-row items-center justify-between space-y-0">
                     <div className="flex flex-col space-y-1">
                         <DialogTitle>{`${!workflow?.id ? 'Create' : 'Edit'}`} Workflow</DialogTitle>
@@ -213,7 +229,7 @@ const WorkflowDialog = ({
                             </Button>
                         </DialogClose>
 
-                        <Button disabled={isPending} onClick={handleSubmit(saveWorkflow)} type="submit">
+                        <Button disabled={isPending} onClick={submitSavedWorkflow} type="submit">
                             Save
                         </Button>
                     </DialogFooter>

--- a/client/src/shared/components/workflow/WorkflowDialog.tsx
+++ b/client/src/shared/components/workflow/WorkflowDialog.tsx
@@ -56,7 +56,7 @@ const WorkflowDialog = ({
             label: workflow?.label || '',
         } as Workflow,
     });
-    const labelRef = useRef<HTMLInputElement>(null);
+    const labelInputRef = useRef<HTMLInputElement>(null);
 
     const {control, getValues, handleSubmit, reset} = form;
 
@@ -157,7 +157,7 @@ const WorkflowDialog = ({
                 onInteractOutside={(event) => event.preventDefault()}
                 onOpenAutoFocus={(e) => {
                     e.preventDefault();
-                    labelRef.current?.focus();
+                    labelInputRef.current?.focus();
                 }}
             >
                 <DialogHeader className="flex flex-row items-center justify-between space-y-0">
@@ -190,7 +190,7 @@ const WorkflowDialog = ({
                                                 handleSubmit(saveWorkflow)();
                                             }
                                         }}
-                                        ref={labelRef}
+                                        ref={labelInputRef}
                                     />
                                 </FormControl>
 

--- a/client/src/shared/components/workflow/WorkflowDialog.tsx
+++ b/client/src/shared/components/workflow/WorkflowDialog.tsx
@@ -56,6 +56,7 @@ const WorkflowDialog = ({
             label: workflow?.label || '',
         } as Workflow,
     });
+    const labelRef = useRef<HTMLInputElement>(null);
 
     const {control, getValues, handleSubmit, reset} = form;
 
@@ -176,7 +177,11 @@ const WorkflowDialog = ({
                                 <FormLabel>Label</FormLabel>
 
                                 <FormControl>
-                                    <Input {...field} />
+                                    <Input
+                                        {...field}
+                                        onKeyDown={handleEnterKeyPress(submitSavedWorkflow)}
+                                        ref={labelRef}
+                                    />
                                 </FormControl>
 
                                 <FormMessage />

--- a/client/src/shared/components/workflow/WorkflowDialog.tsx
+++ b/client/src/shared/components/workflow/WorkflowDialog.tsx
@@ -18,7 +18,7 @@ import {IntegrationWorkflowKeys} from '@/ee/shared/queries/embedded/integrationW
 import {Workflow} from '@/shared/middleware/platform/configuration';
 import {ProjectWorkflowKeys} from '@/shared/queries/automation/projectWorkflows.queries';
 import {UseMutationResult, UseQueryResult, useQueryClient} from '@tanstack/react-query';
-import {ReactNode, useEffect, useRef, useState} from 'react';
+import {KeyboardEvent, ReactNode, useEffect, useRef, useState} from 'react';
 import {useForm} from 'react-hook-form';
 
 interface WorkflowDialogProps {
@@ -133,6 +133,12 @@ const WorkflowDialog = ({
         closeDialog();
     }
 
+    const handleOnKeyDown = (event: KeyboardEvent) => {
+        if (event.key === 'Enter' && !event.shiftKey) {
+            saveWorkflow();
+        }
+    };
+
     useEffect(() => {
         reset({
             description: workflow?.description || '',
@@ -183,15 +189,7 @@ const WorkflowDialog = ({
                                 <FormLabel>Label</FormLabel>
 
                                 <FormControl>
-                                    <Input
-                                        {...field}
-                                        onKeyDown={(event) => {
-                                            if (event.key === 'Enter') {
-                                                handleSubmit(saveWorkflow)();
-                                            }
-                                        }}
-                                        ref={labelInputRef}
-                                    />
+                                    <Input {...field} onKeyDown={handleOnKeyDown} ref={labelInputRef} />
                                 </FormControl>
 
                                 <FormMessage />
@@ -211,11 +209,7 @@ const WorkflowDialog = ({
                                     <Textarea
                                         placeholder="Cute description of your project deployment"
                                         {...field}
-                                        onKeyDown={(event) => {
-                                            if (event.key === 'Enter' && event.shiftKey === false) {
-                                                handleSubmit(saveWorkflow)();
-                                            }
-                                        }}
+                                        onKeyDown={handleOnKeyDown}
                                     />
                                 </FormControl>
 

--- a/client/src/shared/components/workflow/WorkflowDialog.tsx
+++ b/client/src/shared/components/workflow/WorkflowDialog.tsx
@@ -18,16 +18,8 @@ import {IntegrationWorkflowKeys} from '@/ee/shared/queries/embedded/integrationW
 import {Workflow} from '@/shared/middleware/platform/configuration';
 import {ProjectWorkflowKeys} from '@/shared/queries/automation/projectWorkflows.queries';
 import {UseMutationResult, UseQueryResult, useQueryClient} from '@tanstack/react-query';
-import {KeyboardEvent, ReactNode, useEffect, useRef, useState} from 'react';
+import {ReactNode, useEffect, useRef, useState} from 'react';
 import {useForm} from 'react-hook-form';
-
-const handleEnterKeyDown = (handler: () => void) => {
-    return (e: KeyboardEvent) => {
-        if (e.key === 'Enter' && !e.shiftKey) {
-            handler();
-        }
-    };
-};
 
 interface WorkflowDialogProps {
     /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -141,8 +133,6 @@ const WorkflowDialog = ({
         closeDialog();
     }
 
-    const submitWorkflowToSaving = handleSubmit(saveWorkflow);
-
     useEffect(() => {
         reset({
             description: workflow?.description || '',
@@ -195,7 +185,11 @@ const WorkflowDialog = ({
                                 <FormControl>
                                     <Input
                                         {...field}
-                                        onKeyDown={handleEnterKeyDown(submitWorkflowToSaving)}
+                                        onKeyDown={(event) => {
+                                            if (event.key === 'Enter') {
+                                                handleSubmit(saveWorkflow)();
+                                            }
+                                        }}
                                         ref={labelRef}
                                     />
                                 </FormControl>
@@ -217,7 +211,11 @@ const WorkflowDialog = ({
                                     <Textarea
                                         placeholder="Cute description of your project deployment"
                                         {...field}
-                                        onKeyDown={handleEnterKeyDown(submitWorkflowToSaving)}
+                                        onKeyDown={(event) => {
+                                            if (event.key === 'Enter' && event.shiftKey === false) {
+                                                handleSubmit(saveWorkflow)();
+                                            }
+                                        }}
                                     />
                                 </FormControl>
 
@@ -233,7 +231,7 @@ const WorkflowDialog = ({
                             </Button>
                         </DialogClose>
 
-                        <Button disabled={isPending} onClick={submitWorkflowToSaving} type="submit">
+                        <Button disabled={isPending} onClick={handleSubmit(saveWorkflow)} type="submit">
                             Save
                         </Button>
                     </DialogFooter>

--- a/client/src/shared/components/workflow/WorkflowDialog.tsx
+++ b/client/src/shared/components/workflow/WorkflowDialog.tsx
@@ -23,7 +23,7 @@ import {useForm} from 'react-hook-form';
 
 const handleEnterKeyPress = (handler: () => void) => {
     return (e: KeyboardEvent) => {
-        if (e.key === 'Enter') {
+        if (e.key === 'Enter' && !e.shiftKey) {
             handler();
         }
     };
@@ -214,7 +214,11 @@ const WorkflowDialog = ({
                                 <FormLabel>Description</FormLabel>
 
                                 <FormControl>
-                                    <Textarea placeholder="Cute description of your project deployment" {...field} />
+                                    <Textarea
+                                        placeholder="Cute description of your project deployment"
+                                        {...field}
+                                        onKeyDown={handleEnterKeyPress(submitSavedWorkflow)}
+                                    />
                                 </FormControl>
 
                                 <FormMessage />

--- a/client/src/shared/components/workflow/WorkflowDialog.tsx
+++ b/client/src/shared/components/workflow/WorkflowDialog.tsx
@@ -161,8 +161,8 @@ const WorkflowDialog = ({
 
             <DialogContent
                 onInteractOutside={(event) => event.preventDefault()}
-                onOpenAutoFocus={(e) => {
-                    e.preventDefault();
+                onOpenAutoFocus={(event) => {
+                    event.preventDefault();
                     labelInputRef.current?.focus();
                 }}
             >

--- a/client/src/shared/components/workflow/WorkflowDialog.tsx
+++ b/client/src/shared/components/workflow/WorkflowDialog.tsx
@@ -21,7 +21,7 @@ import {UseMutationResult, UseQueryResult, useQueryClient} from '@tanstack/react
 import {KeyboardEvent, ReactNode, useEffect, useRef, useState} from 'react';
 import {useForm} from 'react-hook-form';
 
-const handleEnterKeyPress = (handler: () => void) => {
+const handleEnterKeyDown = (handler: () => void) => {
     return (e: KeyboardEvent) => {
         if (e.key === 'Enter' && !e.shiftKey) {
             handler();
@@ -141,7 +141,7 @@ const WorkflowDialog = ({
         closeDialog();
     }
 
-    const submitSavedWorkflow = handleSubmit(saveWorkflow);
+    const submitWorkflowToSaving = handleSubmit(saveWorkflow);
 
     useEffect(() => {
         reset({
@@ -195,7 +195,7 @@ const WorkflowDialog = ({
                                 <FormControl>
                                     <Input
                                         {...field}
-                                        onKeyDown={handleEnterKeyPress(submitSavedWorkflow)}
+                                        onKeyDown={handleEnterKeyDown(submitWorkflowToSaving)}
                                         ref={labelRef}
                                     />
                                 </FormControl>
@@ -217,7 +217,7 @@ const WorkflowDialog = ({
                                     <Textarea
                                         placeholder="Cute description of your project deployment"
                                         {...field}
-                                        onKeyDown={handleEnterKeyPress(submitSavedWorkflow)}
+                                        onKeyDown={handleEnterKeyDown(submitWorkflowToSaving)}
                                     />
                                 </FormControl>
 
@@ -233,7 +233,7 @@ const WorkflowDialog = ({
                             </Button>
                         </DialogClose>
 
-                        <Button disabled={isPending} onClick={submitSavedWorkflow} type="submit">
+                        <Button disabled={isPending} onClick={submitWorkflowToSaving} type="submit">
                             Save
                         </Button>
                     </DialogFooter>


### PR DESCRIPTION
## Description

Improves the UX of creating workflow dialog by confirming creation by just clicking Enter. This works when the focus is either on the Label input or the Description text area of the dialog. For easier implementation and better UX, now when the dialog is open, focus automatically goes to the Label input so the user can go straight to naming their workflow. One slight issue I came across is how new lines should be implemented in the description text area. This PR implementation allows users to go to a new line in the textarea by clicking Shift + Enter, and creates a workflow if only Enter is pressed when focus is on the description textarea.

Closes #1522 

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Manually tested on all focusable elements of the Workflow Creation Dialog

## Checklist:

- [✅] My code follows the style guidelines of this project
- [✅ ] I have performed a self-review of my own code
- [✅] I have commented my code, particularly in hard-to-understand areas (Code is fairly simple, so self-describing variables were enough in my opinion)
- [✅ ] I have made corresponding changes to the documentation (No documentation changes needed.)
- [✅] My changes generate no new warnings
- [✅] I have added tests that prove my fix is effective or that my feature works (All npm scripts stated in documentation were run and passed without errors.)
- [✅ ] New and existing unit tests pass locally with my changes (Component I worked on didn't have any tests for it, so I didn't change anything; I could add unit tests for it if that is needed for this change.)
