### PR TITLE
3111 - Redirects don't happen after workflow deletion

### DIFF
--- a/client/src/pages/automation/project/components/project-header/components/settings-menu/hooks/useSettingsMenu.ts
+++ b/client/src/pages/automation/project/components/project-header/components/settings-menu/hooks/useSettingsMenu.ts
@@ -116,16 +116,18 @@ export const useSettingsMenu = ({project, workflow}: {project: Project; workflow
                 queryKey: ProjectWorkflowKeys.projectWorkflows(projectId),
             });
 
-            // exact here prevents double fetchs of project
             queryClient.invalidateQueries({
                 exact: true,
                 queryKey: ProjectKeys.project(projectId),
             });
 
             const baseUrl = '/automation/projects';
-            const firstRemainingWorkflowUrlSuffix = firstRemainingWorkflowId
-                ? `/${projectId}/project-workflows/${firstRemainingWorkflowId}?${searchParams}`
-                : '';
+            let firstRemainingWorkflowUrlSuffix = '';
+
+            if (firstRemainingWorkflowId) {
+                firstRemainingWorkflowUrlSuffix = `/${projectId}/project-workflows/${firstRemainingWorkflowId}?${searchParams}`;
+            }
+
             navigate(baseUrl + firstRemainingWorkflowUrlSuffix);
         },
     });


### PR DESCRIPTION
## Description

Fixes unnecessary refetch of workflow after deletion in the settings menu by removing the second useProject hook call. It also handles deleting the last workflow project edge case.

Fixes #3111
Fixes #2762 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manually test with React Query devtools

## Checklist:

- [ + ] My code follows the style guidelines of this project
- [ + ] I have performed a self-review of my own code
- [ + ] I have commented my code, particularly in hard-to-understand areas
- [ + ] I have made corresponding changes to the documentation
- [ + ] My changes generate no new warnings
- [ + ] I have added tests that prove my fix is effective or that my feature works (there were no prior tests, if needed, I could add tests
- [ + ] New and existing unit tests pass locally with my changes

I am sending the master because development has been deleted
