### PR TITLE
Made  Project card clickable to open the list of workflows

### DIFF
--- a/client/src/pages/automation/projects/components/project-list/ProjectListItem.tsx
+++ b/client/src/pages/automation/projects/components/project-list/ProjectListItem.tsx
@@ -79,6 +79,7 @@ const ProjectListItem = ({project, projectGitConfiguration, remainingTags}: Proj
     const [showProjectShareDialog, setShowProjectShareDialog] = useState(false);
     const [showPublishProjectDialog, setShowPublishProjectDialog] = useState(false);
     const [showWorkflowDialog, setShowWorkflowDialog] = useState(false);
+    const collapsibleRef = useRef<HTMLButtonElement | null>(null);
 
     const hiddenFileInputRef = useRef<HTMLInputElement>(null);
 
@@ -200,16 +201,16 @@ const ProjectListItem = ({project, projectGitConfiguration, remainingTags}: Proj
     const handlePullProjectFromGitClick = () => {
         pullProjectFromGitMutation.mutate({id: project.id!});
     };
+    const handleProjectListItemClick = () => {
+        if (project.projectWorkflowIds && project.projectWorkflowIds.length > 0) {
+            collapsibleRef.current?.click();
+        }
+    };
 
     return (
         <>
             <div className="flex w-full items-center justify-between rounded-md px-2 hover:bg-destructive-foreground"
-            onClick={() => {
-     if (project.projectWorkflowIds && project.projectWorkflowIds.length > 0) {
-      const collapsibleTrigger = document.getElementById(`collapsible-trigger-${project.id}`);
-      collapsibleTrigger?.click();
-    }
-  }}
+            onClick={handleProjectListItemClick}
             >
                 <div className="flex flex-1 items-center py-5 group-data-[state='open']:border-none">
                     <div className="flex-1">
@@ -247,7 +248,7 @@ const ProjectListItem = ({project, projectGitConfiguration, remainingTags}: Proj
 
                         <div className="relative mt-2 sm:flex sm:items-center sm:justify-between">
                             <div className="flex items-center">
-                                <CollapsibleTrigger id={`collapsible-trigger-${project.id}`} className="group mr-4 flex items-center text-xs font-semibold text-muted-foreground">
+                                <CollapsibleTrigger id={`collapsible-trigger-${project.id}`} ref={collapsibleRef} className="group mr-4 flex items-center text-xs font-semibold text-muted-foreground">
                                     <div className="mr-1">
                                         {project.projectWorkflowIds?.length === 1
                                             ? `${project.projectWorkflowIds?.length} workflow`


### PR DESCRIPTION
 

## Description

This PR makes the entire Project card clickable so that users can open the list of workflows for that project. Previously, only the “Workflows” text was clickable, which was not intuitive.

Fixes #3209

---

## Type of Change

* [x] Bug fix / UX improvement (non-breaking change)
* [ ] New feature
* [ ] Breaking change
* [ ] Documentation update

---

## How to Test

1. Navigate to the Projects list.
2. Click anywhere on a Project card.
3. Verify that it opens the workflows list for that project.
4. Ensure all other dropdown menu actions and buttons still work as expected.

---

## Checklist

* [x] Code follows project style guidelines
* [x] Self-reviewed my changes
* [x] All existing functionality works as expected
* [x] No new warnings or errors introduced

--- 