### PR TITLE
Revert "2981 - don't populate nodes from tasks if workflow hasn't been fetched yet"

### DIFF
--- a/client/src/pages/platform/workflow-editor/hooks/useLayout.tsx
+++ b/client/src/pages/platform/workflow-editor/hooks/useLayout.tsx
@@ -399,10 +399,6 @@ export default function useLayout({
     });
 
     useEffect(() => {
-        if (!workflow) {
-            return;
-        }
-
         let layoutNodes = allNodes;
         let edges: Edge[] = taskEdges;
 
@@ -433,7 +429,6 @@ export default function useLayout({
             }));
 
             const lastEdge = edges[edges.length - 1];
-
             if (lastEdge && lastEdge.target === FINAL_PLACEHOLDER_NODE_ID) {
                 edges.pop();
             }
@@ -462,7 +457,7 @@ export default function useLayout({
         });
 
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [canvasWidth, tasks, triggers, workflow]);
+    }, [canvasWidth, tasks, triggers]);
 
     useEffect(() => {
         if (canvasWidth > 0) {


### PR DESCRIPTION


This reverts commit d49fc936ceec77cf6747c9f3744e2cff28fecd0a.