### PR TITLE
3265 - Fix 'Upload Sample Output Data' window

### DIFF
--- a/client/src/pages/platform/workflow-editor/components/node-details-tabs/output-tab/OutputTabSampleDataDialog.tsx
+++ b/client/src/pages/platform/workflow-editor/components/node-details-tabs/output-tab/OutputTabSampleDataDialog.tsx
@@ -93,7 +93,7 @@ const OutputTabSampleDataDialog = ({onClose, onUpload, open, placeholder}: Outpu
                         </Suspense>
 
                         <div
-                            className="absolute left-[70px] top-[-2px] h-full text-sm text-muted-foreground"
+                            className="pointer-events-none absolute left-[70px] top-[-2px] h-full text-sm text-muted-foreground"
                             id="monaco-placeholder"
                         >
                             {EDITOR_PLACEHOLDER}

--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-json-schema-builder/PropertyJsonSchemaBuilderSampleDataDialog.tsx
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-json-schema-builder/PropertyJsonSchemaBuilderSampleDataDialog.tsx
@@ -119,7 +119,7 @@ const PropertyJsonSchemaBuilderSampleDataDialog = ({onChange}: {onChange?: (newS
                         </Suspense>
 
                         <div
-                            className="absolute left-[70px] top-[-2px] h-full text-sm text-muted-foreground"
+                            className="pointer-events-none absolute left-[70px] top-[-2px] h-full text-sm text-muted-foreground"
                             id="monaco-placeholder"
                         >
                             {EDITOR_PLACEHOLDER}


### PR DESCRIPTION
### Problem: 

- The editor seems to have inconsistent click behavior - it works when there's example code but becomes unresponsive when you try to type after clearing the content.

### Solution:
- Fix the click issue in the JSON editor by making the placeholder overlay non-interactive
--> The issue is that the placeholder div is positioned absolutely over the Monaco editor and is blocking mouse clicks. When there's content in the editor, the placeholder is hidden (display: none), but when the editor is empty, the placeholder is shown (display: block) and it's intercepting all mouse clicks.
The solution is to make the placeholder div non-interactive by adding pointer-events: none to its CSS.
--> add tailwind class: pointer-events-none
- Test the editor behavior to ensure clicks work properly in multiple scenarios
[screen-capture (5).webm](https://github.com/user-attachments/assets/9a5e044d-9113-43ae-8967-0257cf2a11cb)

Fixes #3265
