### PR TITLE
3423 client - pass additional props to ConnectionParameters component

### DIFF
--- a/client/src/shared/components/connection/ConnectionDialog.tsx
+++ b/client/src/shared/components/connection/ConnectionDialog.tsx
@@ -690,8 +690,13 @@ const ConnectionDialog = ({
                         <div className="px-6 pt-4">
                             <ConnectionParameters
                                 authorizationParameters={connection.authorizationParameters}
+                                authorizationType={connection.authorizationType}
+                                baseUri={connection.baseUri}
                                 connectionDefinition={connectionDefinition}
                                 connectionParameters={connection.connectionParameters}
+                                customAction={componentDefinition?.actions?.some(
+                                    (action) => action.name === 'customAction'
+                                )}
                             />
                         </div>
                     )}


### PR DESCRIPTION
This is a partial fix for #3423. The Base URI is still not displayed. Further changes are needed to fully resolve the problem.