### PR TITLE
3498 - Replace badges in Templates flow

### DIFF
--- a/client/src/pages/automation/templates/components/TemplateCard.tsx
+++ b/client/src/pages/automation/templates/components/TemplateCard.tsx
@@ -1,5 +1,5 @@
+import Badge from '@/components/Badge/Badge';
 import LazyLoadSVG from '@/components/LazyLoadSVG/LazyLoadSVG';
-import {Badge} from '@/components/ui/badge';
 import {Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle} from '@/components/ui/card';
 import {Tooltip, TooltipContent, TooltipTrigger} from '@/components/ui/tooltip';
 import {Link} from 'react-router-dom';
@@ -30,9 +30,13 @@ export function TemplateCard({authorName, categories, description, icons, templa
                 <CardHeader>
                     <div className="flex items-center justify-end">
                         {categories.map((category, index) => (
-                            <Badge className="text-xs" key={index} variant="outline">
-                                {category}
-                            </Badge>
+                            <Badge
+                                className="text-xs"
+                                key={index}
+                                label={category}
+                                styleType="outline-outline"
+                                weight="semibold"
+                            />
                         ))}
                     </div>
 


### PR DESCRIPTION
fixes: #3498 

to see how badge would look like in templates card, I manually navigated to: http://127.0.0.1:5173/automation/projects/templates

- manually added template card with badge
- removed before commit

## Description:
Replace badges in Templates UI screens.

## Files:
- [x] client/src/pages/automation/templates/components/TemplateCard.tsx
- Badge shown in (simulated project templates) image: category 1

<img width="1353" height="675" alt="image" src="https://github.com/user-attachments/assets/7e661710-7f62-4cb4-86a6-40fcc3876334" />
