### PR TITLE
3562 - Replace badges in App Events flow

### DIFF
--- a/client/src/ee/pages/embedded/app-events/components/AppEventsFilterTitle.tsx
+++ b/client/src/ee/pages/embedded/app-events/components/AppEventsFilterTitle.tsx
@@ -1,4 +1,4 @@
-import {Badge} from '@/components/ui/badge';
+import Badge from '@/components/Badge/Badge';
 import {Workflow} from '@/ee/shared/middleware/embedded/configuration';
 
 const AppEventsFilterTitle = ({
@@ -14,9 +14,7 @@ const AppEventsFilterTitle = ({
         <div className="space-x-1">
             <span className="text-sm uppercase text-muted-foreground">Filter by workflow:</span>
 
-            <Badge variant="secondary">
-                <span className="text-sm">{label ?? 'All Workflows'}</span>
-            </Badge>
+            <Badge label={label ?? 'All Workflows'} styleType="secondary-filled" weight="semibold" />
         </div>
     );
 };


### PR DESCRIPTION
> fixes: #3562 

- side-note: this page has bug when you try to enter `new app event` --> long window appears, and no matter how far you zoom out, you cant reach top or bottom, or enter any data
<img width="1915" height="906" alt="image" src="https://github.com/user-attachments/assets/06ad719e-4139-4cd5-a584-81b76ccda5cc" />
<img width="1917" height="907" alt="image" src="https://github.com/user-attachments/assets/44a43542-d634-4700-ad35-1bc675cc076b" />
<img width="1919" height="911" alt="image" src="https://github.com/user-attachments/assets/a885d57b-608c-4317-8b1c-5c8e2f676a39" />



## Description:
update the App Events flow to use the custom Badge component instead of the shadcn Badge.
- manually navigated to: http://127.0.0.1:5173/embedded/app-events 

## Files:

- [x] client/src/ee/pages/embedded/app-events/components/AppEventsFilterTitle.tsx
<img width="760" height="233" alt="image" src="https://github.com/user-attachments/assets/201c057d-0286-413d-91a2-143656893835" />

