### PR TITLE
3893 - extend an INTEGER property check to make sure it's not a string before further checks

### DIFF
--- a/client/src/pages/platform/workflow-editor/components/properties/components/PropertyComboBox.tsx
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/PropertyComboBox.tsx
@@ -11,7 +11,7 @@ import {
 } from '@/shared/queries/platform/workflowNodeOptions.queries';
 import {useEnvironmentStore} from '@/shared/stores/useEnvironmentStore';
 import {CheckIcon, ChevronsUpDownIcon, CircleQuestionMarkIcon} from 'lucide-react';
-import {FocusEventHandler, ReactNode, useEffect, useMemo, useState} from 'react';
+import {FocusEventHandler, ReactNode, useCallback, useEffect, useMemo, useState} from 'react';
 import InlineSVG from 'react-inlinesvg';
 import {twMerge} from 'tailwind-merge';
 import {useShallow} from 'zustand/shallow';
@@ -293,6 +293,19 @@ const PropertyComboBox = ({
         dependencyMissing && 'text-destructive'
     );
 
+    const handleValueChange = useCallback(
+        (value: string) => {
+            setOpen(false);
+
+            setValue(value);
+
+            if (onValueChange) {
+                onValueChange(value);
+            }
+        },
+        [onValueChange]
+    );
+
     useEffect(() => {
         if (initialValue !== undefined) {
             setValue(initialValue.toString());
@@ -431,15 +444,7 @@ const PropertyComboBox = ({
                                     <CommandItem
                                         className="cursor-pointer font-normal hover:bg-muted"
                                         key={option.value.toString()}
-                                        onSelect={() => {
-                                            setOpen(false);
-
-                                            setValue(option.value.toString());
-
-                                            if (onValueChange) {
-                                                onValueChange(option.value.toString());
-                                            }
-                                        }}
+                                        onSelect={() => handleValueChange(option.value.toString())}
                                         value={option.value.toString()}
                                     >
                                         {option.icon && (

--- a/client/src/pages/platform/workflow-editor/components/properties/hooks/useProperty.ts
+++ b/client/src/pages/platform/workflow-editor/components/properties/hooks/useProperty.ts
@@ -535,7 +535,7 @@ export const useProperty = ({
 
             let actualValue: boolean | null | number | string = type === 'BOOLEAN' ? value === 'true' : value;
 
-            if (type === 'INTEGER' && !mentionInputValue.startsWith('${')) {
+            if (type === 'INTEGER' && typeof mentionInputValue === 'string' && !mentionInputValue.startsWith('${')) {
                 actualValue = parseInt(value);
             } else if (type === 'NUMBER' && !mentionInputValue.startsWith('${')) {
                 actualValue = parseFloat(value);
@@ -548,7 +548,11 @@ export const useProperty = ({
                     let actualValue: boolean | null | number | string =
                         type === 'BOOLEAN' ? defaultValueString === 'true' : defaultValueString;
 
-                    if (type === 'INTEGER' && !mentionInputValue.startsWith('${')) {
+                    if (
+                        type === 'INTEGER' &&
+                        typeof mentionInputValue === 'string' &&
+                        !mentionInputValue.startsWith('${')
+                    ) {
                         actualValue = parseInt(defaultValueString);
                     } else if (type === 'NUMBER' && !mentionInputValue.startsWith('${')) {
                         actualValue = parseFloat(defaultValueString);


### PR DESCRIPTION
Fixes #3893 