### PR TITLE
4000 KnowledgeBase - client - Add document list components

### DIFF
--- a/client/src/pages/automation/knowledge-base/components/KnowledgeBaseDocumentChunkEditDialog.tsx
+++ b/client/src/pages/automation/knowledge-base/components/KnowledgeBaseDocumentChunkEditDialog.tsx
@@ -1,0 +1,74 @@
+import Button from '@/components/Button/Button';
+import {
+    Dialog,
+    DialogCloseButton,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import {Label} from '@/components/ui/label';
+import {Textarea} from '@/components/ui/textarea';
+
+interface EditingChunkI {
+    id: string;
+    content: string;
+}
+
+interface Props {
+    editingChunk: EditingChunkI | null;
+    isPending: boolean;
+    onClose: () => void;
+    onContentChange: (content: string) => void;
+    onSave: () => void;
+}
+
+const KnowledgeBaseDocumentChunkEditDialog = ({editingChunk, isPending, onClose, onContentChange, onSave}: Props) => {
+    if (!editingChunk) {
+        return null;
+    }
+
+    return (
+        <Dialog onOpenChange={(open) => !open && onClose()} open={true}>
+            <DialogContent className="sm:max-w-[600px]">
+                <DialogHeader className="flex flex-row items-center justify-between space-y-0">
+                    <div className="flex flex-col space-y-1">
+                        <DialogTitle>Edit Chunk</DialogTitle>
+
+                        <DialogDescription>
+                            Modify the text content of this chunk. Changes will be re-embedded in the vector store.
+                        </DialogDescription>
+                    </div>
+
+                    <DialogCloseButton />
+                </DialogHeader>
+
+                <div className="space-y-4 py-4">
+                    <div className="space-y-2">
+                        <Label htmlFor="content">Content</Label>
+
+                        <Textarea
+                            id="content"
+                            onChange={(event) => onContentChange(event.target.value)}
+                            rows={10}
+                            value={editingChunk.content}
+                        />
+                    </div>
+                </div>
+
+                <DialogFooter>
+                    <Button onClick={onClose} variant="outline">
+                        Cancel
+                    </Button>
+
+                    <Button disabled={isPending} onClick={onSave}>
+                        {isPending ? 'Saving...' : 'Save Changes'}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+};
+
+export default KnowledgeBaseDocumentChunkEditDialog;

--- a/client/src/pages/automation/knowledge-base/components/knowledge-base-document-list/KnowledgeBaseDocumentChunkDeleteDialog.tsx
+++ b/client/src/pages/automation/knowledge-base/components/knowledge-base-document-list/KnowledgeBaseDocumentChunkDeleteDialog.tsx
@@ -1,0 +1,56 @@
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+
+interface KnowledgeBaseDocumentChunkDeleteDialogProps {
+    chunkCount: number;
+    isPending: boolean;
+    onClose: () => void;
+    onConfirm: () => void;
+    open: boolean;
+}
+
+const KnowledgeBaseDocumentChunkDeleteDialog = ({
+    chunkCount,
+    isPending,
+    onClose,
+    onConfirm,
+    open,
+}: KnowledgeBaseDocumentChunkDeleteDialogProps) => {
+    return (
+        <AlertDialog open={open}>
+            <AlertDialogContent>
+                <AlertDialogHeader>
+                    <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
+
+                    <AlertDialogDescription>
+                        {`This action cannot be undone. This will permanently delete ${chunkCount === 1 ? 'this chunk' : `${chunkCount} chunks`}.`}
+                    </AlertDialogDescription>
+                </AlertDialogHeader>
+
+                <AlertDialogFooter>
+                    <AlertDialogCancel className="shadow-none" disabled={isPending} onClick={onClose}>
+                        Cancel
+                    </AlertDialogCancel>
+
+                    <AlertDialogAction
+                        className="bg-surface-destructive-primary shadow-none hover:bg-surface-destructive-primary-hover active:bg-surface-destructive-primary-active"
+                        disabled={isPending}
+                        onClick={onConfirm}
+                    >
+                        {isPending ? 'Deleting...' : 'Delete'}
+                    </AlertDialogAction>
+                </AlertDialogFooter>
+            </AlertDialogContent>
+        </AlertDialog>
+    );
+};
+
+export default KnowledgeBaseDocumentChunkDeleteDialog;

--- a/client/src/pages/automation/knowledge-base/components/knowledge-base-document-list/KnowledgeBaseDocumentChunkList.tsx
+++ b/client/src/pages/automation/knowledge-base/components/knowledge-base-document-list/KnowledgeBaseDocumentChunkList.tsx
@@ -1,0 +1,154 @@
+import Button from '@/components/Button/Button';
+import {Checkbox} from '@/components/ui/checkbox';
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import KnowledgeBaseDocumentChunkEditDialog from '@/pages/automation/knowledge-base/components/KnowledgeBaseDocumentChunkEditDialog';
+import KnowledgeBaseDocumentChunkDeleteDialog from '@/pages/automation/knowledge-base/components/knowledge-base-document-list/KnowledgeBaseDocumentChunkDeleteDialog';
+import useKnowledgeBaseDocumentChunkList from '@/pages/automation/knowledge-base/components/knowledge-base-document-list/hooks/useKnowledgeBaseDocumentChunkList';
+import {KnowledgeBaseDocumentChunk} from '@/shared/middleware/graphql';
+import {EditIcon, EllipsisVerticalIcon, Trash2Icon} from 'lucide-react';
+
+interface KnowledgeBaseDocumentChunkListProps {
+    chunks: KnowledgeBaseDocumentChunk[];
+    documentName: string;
+    knowledgeBaseId: string;
+}
+
+const KnowledgeBaseDocumentChunkList = ({
+    chunks,
+    documentName,
+    knowledgeBaseId,
+}: KnowledgeBaseDocumentChunkListProps) => {
+    const {
+        chunksToDelete,
+        deleteMutation,
+        editingChunk,
+        handleClearSelection,
+        handleCloseDeleteDialog,
+        handleCloseEditDialog,
+        handleConfirmDelete,
+        handleDeleteChunk,
+        handleDeleteSelectedChunks,
+        handleSelectChunk,
+        handleStartEditing,
+        handleUpdateChunk,
+        handleUpdateEditingChunkContent,
+        selectedChunks,
+        showDeleteDialog,
+        updateMutation,
+    } = useKnowledgeBaseDocumentChunkList({knowledgeBaseId});
+
+    if (chunks.length === 0) {
+        return (
+            <div className="ml-7 border-l border-border/50 py-2 pl-4">
+                <p className="text-sm text-muted-foreground">No chunks available for this document.</p>
+            </div>
+        );
+    }
+
+    return (
+        <div className="ml-7 space-y-2 border-l border-border/50 py-2 pl-4">
+            {selectedChunks.length > 0 && (
+                <div className="flex items-center justify-between rounded-lg border border-blue-200 bg-blue-50 p-3">
+                    <span className="text-sm font-medium text-blue-900">{selectedChunks.length} chunk(s) selected</span>
+
+                    <div className="flex space-x-2">
+                        {selectedChunks.length >= 1 && (
+                            <Button onClick={handleDeleteSelectedChunks} size="sm" variant="destructive">
+                                <Trash2Icon className="mr-2 size-4" />
+                                Delete Selected
+                            </Button>
+                        )}
+
+                        <Button onClick={handleClearSelection} size="sm" variant="outline">
+                            Clear Selection
+                        </Button>
+                    </div>
+                </div>
+            )}
+
+            {chunks.map((chunk, index) => (
+                <div className="rounded-lg border border-gray-200 bg-white p-4" key={chunk.id}>
+                    <div className="mb-2 flex items-center justify-between">
+                        <div className="flex items-center space-x-3">
+                            <Checkbox
+                                checked={selectedChunks.includes(chunk.id)}
+                                onCheckedChange={() => handleSelectChunk(chunk.id)}
+                            />
+
+                            <div className="flex items-center space-x-2 text-sm text-gray-500">
+                                <span className="font-medium">{documentName}</span>
+
+                                <span>•</span>
+
+                                <span>Chunk {index + 1}</span>
+                            </div>
+                        </div>
+
+                        <DropdownMenu>
+                            <DropdownMenuTrigger asChild>
+                                <Button
+                                    aria-label="More Chunk Actions"
+                                    icon={<EllipsisVerticalIcon />}
+                                    size="icon"
+                                    variant="ghost"
+                                />
+                            </DropdownMenuTrigger>
+
+                            <DropdownMenuContent align="end" className="p-0">
+                                <DropdownMenuItem
+                                    className="dropdown-menu-item"
+                                    onClick={() => handleStartEditing(chunk)}
+                                >
+                                    <EditIcon /> Edit
+                                </DropdownMenuItem>
+
+                                <DropdownMenuSeparator className="m-0" />
+
+                                <DropdownMenuItem
+                                    className="dropdown-menu-item-destructive"
+                                    onClick={() => handleDeleteChunk(chunk.id)}
+                                >
+                                    <Trash2Icon /> Delete
+                                </DropdownMenuItem>
+                            </DropdownMenuContent>
+                        </DropdownMenu>
+                    </div>
+
+                    <p className="ml-7 text-sm text-gray-700">{chunk.content}</p>
+
+                    {chunk.metadata && (
+                        <div className="ml-7 mt-2 text-xs text-gray-400">
+                            <span className="font-medium">Metadata: </span>
+
+                            {JSON.stringify(chunk.metadata)}
+                        </div>
+                    )}
+                </div>
+            ))}
+
+            <KnowledgeBaseDocumentChunkEditDialog
+                editingChunk={editingChunk ? {content: editingChunk.content ?? '', id: editingChunk.id} : null}
+                isPending={updateMutation.isPending}
+                onClose={handleCloseEditDialog}
+                onContentChange={handleUpdateEditingChunkContent}
+                onSave={handleUpdateChunk}
+            />
+
+            <KnowledgeBaseDocumentChunkDeleteDialog
+                chunkCount={chunksToDelete.length}
+                isPending={deleteMutation.isPending}
+                onClose={handleCloseDeleteDialog}
+                onConfirm={handleConfirmDelete}
+                open={showDeleteDialog}
+            />
+        </div>
+    );
+};
+
+export default KnowledgeBaseDocumentChunkList;

--- a/client/src/pages/automation/knowledge-base/components/knowledge-base-document-list/KnowledgeBaseDocumentList.tsx
+++ b/client/src/pages/automation/knowledge-base/components/knowledge-base-document-list/KnowledgeBaseDocumentList.tsx
@@ -1,0 +1,77 @@
+import {Collapsible, CollapsibleContent} from '@/components/ui/collapsible';
+import {
+    KnowledgeBaseDocument,
+    Tag,
+    useKnowledgeBaseDocumentTagsByDocumentQuery,
+    useKnowledgeBaseDocumentTagsQuery,
+} from '@/shared/middleware/graphql';
+import {useMemo} from 'react';
+
+import KnowledgeBaseDocumentChunkList from './KnowledgeBaseDocumentChunkList';
+import KnowledgeBaseDocumentListItem from './KnowledgeBaseDocumentListItem';
+
+interface KnowledgeBaseDocumentListProps {
+    documents: KnowledgeBaseDocument[];
+    knowledgeBaseId: string;
+}
+
+const KnowledgeBaseDocumentList = ({documents, knowledgeBaseId}: KnowledgeBaseDocumentListProps) => {
+    const {data: tagsByDocumentData} = useKnowledgeBaseDocumentTagsByDocumentQuery();
+    const {data: allTagsData} = useKnowledgeBaseDocumentTagsQuery();
+
+    const tagsByDocument = useMemo(
+        () => tagsByDocumentData?.knowledgeBaseDocumentTagsByDocument ?? [],
+        [tagsByDocumentData?.knowledgeBaseDocumentTagsByDocument]
+    );
+
+    const allTags = useMemo(
+        () => allTagsData?.knowledgeBaseDocumentTags ?? [],
+        [allTagsData?.knowledgeBaseDocumentTags]
+    );
+
+    const getTagsForDocument = (documentId: string): Tag[] => {
+        const entry = tagsByDocument.find((tagEntry) => tagEntry.knowledgeBaseDocumentId === documentId);
+
+        return (entry?.tags as Tag[]) ?? [];
+    };
+
+    const getRemainingTagsForDocument = (documentId: string): Tag[] => {
+        const documentTags = getTagsForDocument(documentId);
+        const documentTagIds = new Set(documentTags.map((tag) => tag.id));
+
+        return allTags.filter((tag) => !documentTagIds.has(tag.id));
+    };
+
+    return (
+        <div className="w-full divide-y divide-border/50">
+            {documents.length === 0 ? (
+                <div className="rounded-lg border border-gray-200 bg-gray-50 p-8 text-center">
+                    <p className="text-gray-500">No documents available. Upload documents to get started.</p>
+                </div>
+            ) : (
+                documents.map((document) => (
+                    <Collapsible className="group" key={document.id}>
+                        <KnowledgeBaseDocumentListItem
+                            document={document}
+                            knowledgeBaseId={knowledgeBaseId}
+                            remainingTags={getRemainingTagsForDocument(document.id)}
+                            tags={getTagsForDocument(document.id)}
+                        />
+
+                        <CollapsibleContent>
+                            <KnowledgeBaseDocumentChunkList
+                                chunks={(document.chunks || [])
+                                    .filter((chunk): chunk is NonNullable<typeof chunk> => chunk !== null)
+                                    .sort((a, b) => a.id.localeCompare(b.id))}
+                                documentName={document.name}
+                                knowledgeBaseId={knowledgeBaseId}
+                            />
+                        </CollapsibleContent>
+                    </Collapsible>
+                ))
+            )}
+        </div>
+    );
+};
+
+export default KnowledgeBaseDocumentList;

--- a/client/src/pages/automation/knowledge-base/components/knowledge-base-document-list/KnowledgeBaseDocumentListItem.tsx
+++ b/client/src/pages/automation/knowledge-base/components/knowledge-base-document-list/KnowledgeBaseDocumentListItem.tsx
@@ -1,0 +1,130 @@
+import Button from '@/components/Button/Button';
+import {CollapsibleTrigger} from '@/components/ui/collapsible';
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import KnowledgeBaseDocumentListItemDeleteDialog from '@/pages/automation/knowledge-base/components/knowledge-base-document-list/KnowledgeBaseDocumentListItemDeleteDialog';
+import KnowledgeBaseDocumentListItemTagList from '@/pages/automation/knowledge-base/components/knowledge-base-document-list/KnowledgeBaseDocumentListItemTagList';
+import useKnowledgeBaseDocumentListItem from '@/pages/automation/knowledge-base/components/knowledge-base-document-list/hooks/useKnowledgeBaseDocumentListItem';
+import {KnowledgeBaseDocument, Tag} from '@/shared/middleware/graphql';
+import {ChevronDownIcon, EllipsisVerticalIcon, Trash2Icon} from 'lucide-react';
+
+interface KnowledgeBaseDocumentListItemProps {
+    document: KnowledgeBaseDocument;
+    knowledgeBaseId: string;
+    remainingTags?: Tag[];
+    tags: Tag[];
+}
+
+const KnowledgeBaseDocumentListItem = ({
+    document,
+    knowledgeBaseId,
+    remainingTags,
+    tags,
+}: KnowledgeBaseDocumentListItemProps) => {
+    const {
+        chunkCount,
+        chunksCollapsibleTriggerRef,
+        currentStatus,
+        displayName,
+        documentIcon,
+        getStatusBadge,
+        handleCloseDeleteDialog,
+        handleDocumentListItemClick,
+        handleShowDeleteDialog,
+        showDeleteDialog,
+    } = useKnowledgeBaseDocumentListItem({document});
+
+    const handleTagListClick = (event: React.MouseEvent) => {
+        event.stopPropagation();
+    };
+
+    return (
+        <>
+            <div
+                className="flex w-full cursor-pointer items-center justify-between rounded-md px-2 hover:bg-muted/50"
+                onClick={handleDocumentListItemClick}
+            >
+                <div className="flex flex-1 items-center py-4">
+                    <div className="flex-1">
+                        <div className="flex items-center gap-2">
+                            {documentIcon}
+
+                            <span className="text-base font-semibold">{displayName}</span>
+                        </div>
+
+                        <div className="mt-2 flex items-center gap-4">
+                            <CollapsibleTrigger
+                                className="group flex items-center text-xs font-semibold text-muted-foreground"
+                                ref={chunksCollapsibleTriggerRef}
+                            >
+                                <div className="mr-1">
+                                    {chunkCount === 1 ? `${chunkCount} chunk` : `${chunkCount} chunks`}
+                                </div>
+
+                                <ChevronDownIcon className="size-4 duration-300 group-data-[state=open]:rotate-180" />
+                            </CollapsibleTrigger>
+
+                            {document.createdDate && (
+                                <span className="text-xs text-muted-foreground">
+                                    Created {new Date(document.createdDate).toLocaleDateString()}
+                                </span>
+                            )}
+
+                            <div onClick={handleTagListClick}>
+                                <KnowledgeBaseDocumentListItemTagList
+                                    knowledgeBaseDocumentId={document.id}
+                                    remainingTags={remainingTags}
+                                    tags={tags}
+                                />
+                            </div>
+                        </div>
+                    </div>
+
+                    <div className="flex items-center justify-end gap-x-4">
+                        {getStatusBadge(currentStatus)}
+
+                        <DropdownMenu>
+                            <DropdownMenuTrigger asChild onClick={(event) => event.stopPropagation()}>
+                                <Button
+                                    aria-label="More Document Actions"
+                                    icon={<EllipsisVerticalIcon />}
+                                    size="icon"
+                                    variant="ghost"
+                                />
+                            </DropdownMenuTrigger>
+
+                            <DropdownMenuContent align="end" className="p-0">
+                                <DropdownMenuSeparator className="m-0" />
+
+                                <DropdownMenuItem
+                                    className="dropdown-menu-item-destructive"
+                                    onClick={(event) => {
+                                        event.stopPropagation();
+
+                                        handleShowDeleteDialog();
+                                    }}
+                                >
+                                    <Trash2Icon /> Delete
+                                </DropdownMenuItem>
+                            </DropdownMenuContent>
+                        </DropdownMenu>
+                    </div>
+                </div>
+            </div>
+
+            <KnowledgeBaseDocumentListItemDeleteDialog
+                documentId={document.id}
+                knowledgeBaseId={knowledgeBaseId}
+                onClose={handleCloseDeleteDialog}
+                open={showDeleteDialog}
+            />
+        </>
+    );
+};
+
+export default KnowledgeBaseDocumentListItem;

--- a/client/src/pages/automation/knowledge-base/components/knowledge-base-document-list/KnowledgeBaseDocumentListItemDeleteDialog.tsx
+++ b/client/src/pages/automation/knowledge-base/components/knowledge-base-document-list/KnowledgeBaseDocumentListItemDeleteDialog.tsx
@@ -1,0 +1,61 @@
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import useKnowledgeBaseDocumentListItemDeleteDialog from '@/pages/automation/knowledge-base/components/knowledge-base-document-list/hooks/useKnowledgeBaseDocumentListItemDeleteDialog';
+
+interface KnowledgeBaseDocumentListItemDeleteDialogProps {
+    documentId: string;
+    knowledgeBaseId: string;
+    onClose: () => void;
+    open: boolean;
+}
+
+const KnowledgeBaseDocumentListItemDeleteDialog = ({
+    documentId,
+    knowledgeBaseId,
+    onClose,
+    open,
+}: KnowledgeBaseDocumentListItemDeleteDialogProps) => {
+    const {handleCancelClick, handleDeleteClick, isPending} = useKnowledgeBaseDocumentListItemDeleteDialog({
+        documentId,
+        knowledgeBaseId,
+        onClose,
+    });
+
+    return (
+        <AlertDialog open={open}>
+            <AlertDialogContent>
+                <AlertDialogHeader>
+                    <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
+
+                    <AlertDialogDescription>
+                        This action cannot be undone. This will permanently delete the document and all its chunks.
+                    </AlertDialogDescription>
+                </AlertDialogHeader>
+
+                <AlertDialogFooter>
+                    <AlertDialogCancel className="shadow-none" disabled={isPending} onClick={handleCancelClick}>
+                        Cancel
+                    </AlertDialogCancel>
+
+                    <AlertDialogAction
+                        className="bg-surface-destructive-primary shadow-none hover:bg-surface-destructive-primary-hover active:bg-surface-destructive-primary-active"
+                        disabled={isPending}
+                        onClick={handleDeleteClick}
+                    >
+                        {isPending ? 'Deleting...' : 'Delete'}
+                    </AlertDialogAction>
+                </AlertDialogFooter>
+            </AlertDialogContent>
+        </AlertDialog>
+    );
+};
+
+export default KnowledgeBaseDocumentListItemDeleteDialog;

--- a/client/src/pages/automation/knowledge-base/components/knowledge-base-document-list/KnowledgeBaseDocumentListItemTagList.tsx
+++ b/client/src/pages/automation/knowledge-base/components/knowledge-base-document-list/KnowledgeBaseDocumentListItemTagList.tsx
@@ -1,0 +1,38 @@
+import useKnowledgeBaseDocumentListItemTagList from '@/pages/automation/knowledge-base/components/knowledge-base-document-list/hooks/useKnowledgeBaseDocumentListItemTagList';
+import TagList from '@/shared/components/TagList';
+import {Tag} from '@/shared/middleware/graphql';
+
+interface KnowledgeBaseDocumentListItemTagListProps {
+    knowledgeBaseDocumentId: string;
+    remainingTags?: Tag[];
+    tags: Tag[];
+}
+
+const KnowledgeBaseDocumentListItemTagList = ({
+    knowledgeBaseDocumentId,
+    remainingTags,
+    tags,
+}: KnowledgeBaseDocumentListItemTagListProps) => {
+    const {convertedRemainingTags, convertedTags, updateTagsMutation} = useKnowledgeBaseDocumentListItemTagList({
+        knowledgeBaseDocumentId,
+        remainingTags,
+        tags,
+    });
+
+    return (
+        <TagList
+            getRequest={(_id, newTags) => ({
+                input: {
+                    knowledgeBaseDocumentId,
+                    tags: newTags.map((tag) => ({id: tag.id, name: tag.name})),
+                },
+            })}
+            id={+knowledgeBaseDocumentId}
+            remainingTags={convertedRemainingTags}
+            tags={convertedTags}
+            updateTagsMutation={updateTagsMutation}
+        />
+    );
+};
+
+export default KnowledgeBaseDocumentListItemTagList;

--- a/client/src/pages/automation/knowledge-base/components/knowledge-base-document-list/hooks/useKnowledgeBaseDocumentChunkList.ts
+++ b/client/src/pages/automation/knowledge-base/components/knowledge-base-document-list/hooks/useKnowledgeBaseDocumentChunkList.ts
@@ -1,0 +1,118 @@
+import {
+    KnowledgeBaseDocumentChunk,
+    useDeleteKnowledgeBaseDocumentChunkMutation,
+    useUpdateKnowledgeBaseDocumentChunkMutation,
+} from '@/shared/middleware/graphql';
+import {useQueryClient} from '@tanstack/react-query';
+import {useState} from 'react';
+
+interface UseKnowledgeBaseDocumentChunkListProps {
+    knowledgeBaseId: string;
+}
+
+export default function useKnowledgeBaseDocumentChunkList({knowledgeBaseId}: UseKnowledgeBaseDocumentChunkListProps) {
+    const queryClient = useQueryClient();
+
+    const [selectedChunks, setSelectedChunks] = useState<string[]>([]);
+    const [editingChunk, setEditingChunk] = useState<KnowledgeBaseDocumentChunk | null>(null);
+    const [chunksToDelete, setChunksToDelete] = useState<string[]>([]);
+    const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+
+    const updateMutation = useUpdateKnowledgeBaseDocumentChunkMutation({
+        onSuccess: () => {
+            queryClient.invalidateQueries({queryKey: ['knowledgeBase', {id: knowledgeBaseId}]});
+            setEditingChunk(null);
+        },
+    });
+
+    const deleteMutation = useDeleteKnowledgeBaseDocumentChunkMutation({
+        onSuccess: () => {
+            queryClient.invalidateQueries({queryKey: ['knowledgeBase', {id: knowledgeBaseId}]});
+            setSelectedChunks([]);
+        },
+    });
+
+    const handleSelectChunk = (chunkId: string) => {
+        setSelectedChunks((prev) =>
+            prev.includes(chunkId) ? prev.filter((id) => id !== chunkId) : [...prev, chunkId]
+        );
+    };
+
+    const handleDeleteChunk = (chunkId: string) => {
+        setChunksToDelete([chunkId]);
+        setShowDeleteDialog(true);
+    };
+
+    const handleDeleteSelectedChunks = () => {
+        if (selectedChunks.length === 0) {
+            return;
+        }
+
+        setChunksToDelete([...selectedChunks]);
+        setShowDeleteDialog(true);
+    };
+
+    const handleConfirmDelete = () => {
+        chunksToDelete.forEach((chunkId) => {
+            deleteMutation.mutate({id: chunkId});
+        });
+
+        setShowDeleteDialog(false);
+        setChunksToDelete([]);
+    };
+
+    const handleCloseDeleteDialog = () => {
+        setShowDeleteDialog(false);
+        setChunksToDelete([]);
+    };
+
+    const handleUpdateChunk = () => {
+        if (!editingChunk) {
+            return;
+        }
+
+        updateMutation.mutate({
+            id: editingChunk.id,
+            knowledgeBaseDocumentChunk: {
+                content: editingChunk.content ?? '',
+            },
+        });
+    };
+
+    const handleStartEditing = (chunk: KnowledgeBaseDocumentChunk) => {
+        setEditingChunk(chunk);
+    };
+
+    const handleClearSelection = () => {
+        setSelectedChunks([]);
+    };
+
+    const handleCloseEditDialog = () => {
+        setEditingChunk(null);
+    };
+
+    const handleUpdateEditingChunkContent = (content: string) => {
+        if (editingChunk) {
+            setEditingChunk({...editingChunk, content});
+        }
+    };
+
+    return {
+        chunksToDelete,
+        deleteMutation,
+        editingChunk,
+        handleClearSelection,
+        handleCloseDeleteDialog,
+        handleCloseEditDialog,
+        handleConfirmDelete,
+        handleDeleteChunk,
+        handleDeleteSelectedChunks,
+        handleSelectChunk,
+        handleStartEditing,
+        handleUpdateChunk,
+        handleUpdateEditingChunkContent,
+        selectedChunks,
+        showDeleteDialog,
+        updateMutation,
+    };
+}

--- a/client/src/pages/automation/knowledge-base/components/knowledge-base-document-list/hooks/useKnowledgeBaseDocumentListItem.tsx
+++ b/client/src/pages/automation/knowledge-base/components/knowledge-base-document-list/hooks/useKnowledgeBaseDocumentListItem.tsx
@@ -1,0 +1,189 @@
+import Badge from '@/components/Badge/Badge';
+import {useKnowledgeBaseDocumentStatusPolling} from '@/pages/automation/knowledge-base/hooks/useKnowledgeBaseDocumentStatusPolling';
+import {
+    STATUS_ERROR,
+    STATUS_PROCESSING,
+    STATUS_READY,
+    STATUS_UPLOADED,
+    getStatusLabel,
+} from '@/pages/automation/knowledge-base/util/knowledge-base-utils';
+import {KnowledgeBaseDocument} from '@/shared/middleware/graphql';
+import {useQueryClient} from '@tanstack/react-query';
+import {
+    FileCodeIcon,
+    FileIcon,
+    FileImageIcon,
+    FileSpreadsheetIcon,
+    FileTextIcon,
+    FileTypeIcon,
+    LoaderCircleIcon,
+    PresentationIcon,
+} from 'lucide-react';
+import {useCallback, useRef, useState} from 'react';
+
+interface UseKnowledgeBaseDocumentListItemProps {
+    document: KnowledgeBaseDocument;
+}
+
+const getDocumentIcon = (extension?: string, mimeType?: string) => {
+    const ext = extension?.toLowerCase();
+    const mime = mimeType?.toLowerCase() || '';
+
+    // Image files
+    if (mime.startsWith('image/') || ['png', 'jpg', 'jpeg', 'gif', 'svg', 'webp', 'bmp', 'ico'].includes(ext || '')) {
+        return <FileImageIcon className="size-5 text-green-600" />;
+    }
+
+    // PDF files
+    if (mime === 'application/pdf' || ext === 'pdf') {
+        return <FileTextIcon className="size-5 text-red-600" />;
+    }
+
+    // Word documents
+    if (mime.includes('msword') || mime.includes('wordprocessingml') || ['doc', 'docx', 'odt'].includes(ext || '')) {
+        return <FileTypeIcon className="size-5 text-blue-600" />;
+    }
+
+    // Excel/Spreadsheet files
+    if (
+        mime.includes('spreadsheetml') ||
+        mime.includes('ms-excel') ||
+        ['xls', 'xlsx', 'csv', 'ods'].includes(ext || '')
+    ) {
+        return <FileSpreadsheetIcon className="size-5 text-green-700" />;
+    }
+
+    // PowerPoint/Presentation files
+    if (
+        mime.includes('presentationml') ||
+        mime.includes('ms-powerpoint') ||
+        ['ppt', 'pptx', 'odp'].includes(ext || '')
+    ) {
+        return <PresentationIcon className="size-5 text-orange-600" />;
+    }
+
+    // Code files
+    if (
+        mime.includes('javascript') ||
+        mime.includes('typescript') ||
+        mime.includes('json') ||
+        mime.includes('xml') ||
+        mime.includes('html') ||
+        ['js', 'ts', 'jsx', 'tsx', 'json', 'xml', 'html', 'css', 'py', 'java', 'rb', 'go', 'rs'].includes(ext || '')
+    ) {
+        return <FileCodeIcon className="size-5 text-purple-600" />;
+    }
+
+    // Text files
+    if (mime.startsWith('text/') || ['txt', 'md', 'rtf'].includes(ext || '')) {
+        return <FileTextIcon className="size-5 text-muted-foreground" />;
+    }
+
+    // Default file icon
+    return <FileIcon className="size-5 text-muted-foreground" />;
+};
+
+export default function useKnowledgeBaseDocumentListItem({document}: UseKnowledgeBaseDocumentListItemProps) {
+    const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+
+    const chunksCollapsibleTriggerRef = useRef<HTMLButtonElement | null>(null);
+    const queryClient = useQueryClient();
+
+    const needsPolling = document.status !== STATUS_READY && document.status !== STATUS_ERROR;
+
+    const {status: polledStatus} = useKnowledgeBaseDocumentStatusPolling({
+        documentId: document.id,
+        enabled: needsPolling,
+        onStatusChange: (status) => {
+            if (status === STATUS_READY || status === STATUS_ERROR) {
+                queryClient.invalidateQueries({queryKey: ['knowledgeBase']});
+            }
+        },
+    });
+
+    const currentStatus = needsPolling && polledStatus !== undefined ? polledStatus : document.status;
+
+    const handleDocumentListItemClick = useCallback((event: React.MouseEvent) => {
+        const target = event.target as HTMLElement;
+
+        const interactiveSelectors = [
+            '[data-interactive]',
+            '.dropdown-menu-item',
+            '[data-radix-dropdown-menu-item]',
+            '[data-radix-dropdown-menu-trigger]',
+            '[data-radix-collapsible-trigger]',
+        ].join(', ');
+
+        if (target.closest(interactiveSelectors)) {
+            return;
+        }
+
+        if (chunksCollapsibleTriggerRef.current?.contains(target)) {
+            return;
+        }
+
+        chunksCollapsibleTriggerRef.current?.click();
+    }, []);
+
+    const handleShowDeleteDialog = () => {
+        setShowDeleteDialog(true);
+    };
+
+    const handleCloseDeleteDialog = () => {
+        setShowDeleteDialog(false);
+    };
+
+    const getStatusBadge = (status: number) => {
+        const statusLabel = getStatusLabel(status);
+
+        switch (status) {
+            case STATUS_READY:
+                return (
+                    <Badge styleType="success-outline" weight="semibold">
+                        {statusLabel}
+                    </Badge>
+                );
+            case STATUS_UPLOADED:
+            case STATUS_PROCESSING:
+                return (
+                    <Badge styleType="secondary-filled" weight="semibold">
+                        <LoaderCircleIcon className="size-3 animate-spin" />
+
+                        {statusLabel}
+                    </Badge>
+                );
+            case STATUS_ERROR:
+                return (
+                    <Badge styleType="destructive-outline" weight="semibold">
+                        {statusLabel}
+                    </Badge>
+                );
+            default:
+                return (
+                    <Badge styleType="secondary-filled" weight="semibold">
+                        {statusLabel}
+                    </Badge>
+                );
+        }
+    };
+
+    const chunkCount = document.chunks?.length || 0;
+    const documentIcon = getDocumentIcon(
+        document.document?.extension ?? undefined,
+        document.document?.mimeType ?? undefined
+    );
+    const displayName = document.document?.name || document.name;
+
+    return {
+        chunkCount,
+        chunksCollapsibleTriggerRef,
+        currentStatus,
+        displayName,
+        documentIcon,
+        getStatusBadge,
+        handleCloseDeleteDialog,
+        handleDocumentListItemClick,
+        handleShowDeleteDialog,
+        showDeleteDialog,
+    };
+}

--- a/client/src/pages/automation/knowledge-base/components/knowledge-base-document-list/hooks/useKnowledgeBaseDocumentListItemDeleteDialog.ts
+++ b/client/src/pages/automation/knowledge-base/components/knowledge-base-document-list/hooks/useKnowledgeBaseDocumentListItemDeleteDialog.ts
@@ -1,0 +1,46 @@
+import {useToast} from '@/hooks/use-toast';
+import {useDeleteKnowledgeBaseDocumentMutation} from '@/shared/middleware/graphql';
+import {useQueryClient} from '@tanstack/react-query';
+
+interface UseKnowledgeBaseDocumentListItemDeleteDialogProps {
+    documentId: string;
+    knowledgeBaseId: string;
+    onClose: () => void;
+}
+
+export default function useKnowledgeBaseDocumentListItemDeleteDialog({
+    documentId,
+    knowledgeBaseId,
+    onClose,
+}: UseKnowledgeBaseDocumentListItemDeleteDialogProps) {
+    const queryClient = useQueryClient();
+    const {toast} = useToast();
+
+    const deleteMutation = useDeleteKnowledgeBaseDocumentMutation({
+        onError: () => {
+            toast({description: 'Failed to delete document. Please try again.', variant: 'destructive'});
+        },
+        onSuccess: () => {
+            queryClient.invalidateQueries({queryKey: ['knowledgeBase', {id: knowledgeBaseId}]});
+            queryClient.invalidateQueries({queryKey: ['knowledgeBases']});
+
+            toast({description: 'Document deleted successfully.'});
+
+            onClose();
+        },
+    });
+
+    const handleDeleteClick = () => {
+        deleteMutation.mutate({id: documentId});
+    };
+
+    const handleCancelClick = () => {
+        onClose();
+    };
+
+    return {
+        handleCancelClick,
+        handleDeleteClick,
+        isPending: deleteMutation.isPending,
+    };
+}

--- a/client/src/pages/automation/knowledge-base/components/knowledge-base-document-list/hooks/useKnowledgeBaseDocumentListItemTagList.ts
+++ b/client/src/pages/automation/knowledge-base/components/knowledge-base-document-list/hooks/useKnowledgeBaseDocumentListItemTagList.ts
@@ -1,0 +1,91 @@
+import {
+    KnowledgeBaseDocumentTagsEntry,
+    Tag,
+    TagInput,
+    UpdateKnowledgeBaseDocumentTagsInput,
+    useUpdateKnowledgeBaseDocumentTagsMutation,
+} from '@/shared/middleware/graphql';
+import {useQueryClient} from '@tanstack/react-query';
+import {useMemo} from 'react';
+
+interface UpdateKnowledgeBaseDocumentTagsVarsI {
+    input: UpdateKnowledgeBaseDocumentTagsInput;
+}
+
+interface UseKnowledgeBaseDocumentListItemTagListProps {
+    knowledgeBaseDocumentId: string;
+    remainingTags?: Tag[];
+    tags: Tag[];
+}
+
+export default function useKnowledgeBaseDocumentListItemTagList({
+    knowledgeBaseDocumentId,
+    remainingTags,
+    tags,
+}: UseKnowledgeBaseDocumentListItemTagListProps) {
+    const queryClient = useQueryClient();
+
+    const updateTagsMutation = useUpdateKnowledgeBaseDocumentTagsMutation({
+        onError: (_err, _vars, ctx) => {
+            if (ctx?.previous) {
+                queryClient.setQueryData(['knowledgeBaseDocumentTagsByDocument'], ctx.previous);
+            }
+        },
+        onMutate: async (variables: UpdateKnowledgeBaseDocumentTagsVarsI) => {
+            await queryClient.cancelQueries({queryKey: ['knowledgeBaseDocumentTagsByDocument']});
+
+            const previous = queryClient.getQueryData<{
+                knowledgeBaseDocumentTagsByDocument: KnowledgeBaseDocumentTagsEntry[];
+            }>(['knowledgeBaseDocumentTagsByDocument']);
+
+            const next = (() => {
+                if (!previous?.knowledgeBaseDocumentTagsByDocument) return previous;
+
+                const withTempIds = (variables.input.tags ?? []).map((tag: TagInput) => ({
+                    ...tag,
+                    id: tag.id ?? -Math.floor(Date.now() + Math.random() * 1000),
+                }));
+
+                const updated = previous.knowledgeBaseDocumentTagsByDocument.map((entry) =>
+                    entry.knowledgeBaseDocumentId === knowledgeBaseDocumentId ? {...entry, tags: withTempIds} : entry
+                );
+
+                const hasEntry = previous.knowledgeBaseDocumentTagsByDocument.some(
+                    (entry) => entry.knowledgeBaseDocumentId === knowledgeBaseDocumentId
+                );
+
+                return hasEntry
+                    ? {...previous, knowledgeBaseDocumentTagsByDocument: updated}
+                    : {
+                          ...previous,
+                          knowledgeBaseDocumentTagsByDocument: [
+                              ...previous.knowledgeBaseDocumentTagsByDocument,
+                              {knowledgeBaseDocumentId, tags: withTempIds},
+                          ],
+                      };
+            })();
+
+            queryClient.setQueryData(['knowledgeBaseDocumentTagsByDocument'], next);
+
+            return {previous};
+        },
+        onSettled: () => {
+            queryClient.invalidateQueries({queryKey: ['knowledgeBaseDocumentTags']});
+            queryClient.invalidateQueries({queryKey: ['knowledgeBaseDocumentTagsByDocument']});
+            queryClient.invalidateQueries({queryKey: ['knowledgeBases']});
+        },
+    });
+
+    const convertedTags = useMemo(() => tags.map((tag) => ({...tag, id: Number(tag.id)})), [tags]);
+
+    const convertedRemainingTags = useMemo(
+        () => remainingTags?.map((tag) => ({...tag, id: Number(tag.id)})),
+        [remainingTags]
+    );
+
+    return {
+        convertedRemainingTags,
+        convertedTags,
+        updateTagsMutation,
+    };
+}

--- a/client/src/pages/automation/knowledge-base/hooks/useKnowledgeBaseDocumentStatusPolling.ts
+++ b/client/src/pages/automation/knowledge-base/hooks/useKnowledgeBaseDocumentStatusPolling.ts
@@ -1,0 +1,57 @@
+import {STATUS_ERROR, STATUS_READY} from '@/pages/automation/knowledge-base/util/knowledge-base-utils';
+import {useKnowledgeBaseDocumentStatusQuery} from '@/shared/middleware/graphql';
+import {useEffect, useState} from 'react';
+
+interface UseKnowledgeBaseDocumentStatusPollingOptionsI {
+    documentId?: string;
+    enabled: boolean;
+    onStatusChange?: (status: number, message?: string) => void;
+    pollingInterval?: number;
+}
+
+export const useKnowledgeBaseDocumentStatusPolling = ({
+    documentId,
+    enabled,
+    onStatusChange,
+    pollingInterval = 2000,
+}: UseKnowledgeBaseDocumentStatusPollingOptionsI) => {
+    const [isPolling, setIsPolling] = useState(false);
+
+    const {data, isLoading} = useKnowledgeBaseDocumentStatusQuery(
+        {id: documentId || ''},
+        {
+            enabled: enabled && !!documentId,
+            refetchInterval: (query) => {
+                const status = query.state.data?.knowledgeBaseDocumentStatus?.status;
+
+                if (status === undefined || status === STATUS_READY || status === STATUS_ERROR) {
+                    return false;
+                }
+
+                return pollingInterval;
+            },
+            refetchIntervalInBackground: false,
+        }
+    );
+
+    useEffect(() => {
+        if (data?.knowledgeBaseDocumentStatus) {
+            const {message, status} = data.knowledgeBaseDocumentStatus;
+
+            onStatusChange?.(status, message || undefined);
+
+            if (status === STATUS_READY || status === STATUS_ERROR) {
+                setIsPolling(false);
+            } else {
+                setIsPolling(true);
+            }
+        }
+    }, [data, onStatusChange]);
+
+    return {
+        isLoading,
+        isPolling,
+        message: data?.knowledgeBaseDocumentStatus?.message,
+        status: data?.knowledgeBaseDocumentStatus?.status,
+    };
+};

--- a/client/src/pages/automation/knowledge-base/util/knowledge-base-utils.ts
+++ b/client/src/pages/automation/knowledge-base/util/knowledge-base-utils.ts
@@ -1,0 +1,19 @@
+export const STATUS_UPLOADED = 0;
+export const STATUS_PROCESSING = 1;
+export const STATUS_READY = 2;
+export const STATUS_ERROR = 3;
+
+export const getStatusLabel = (status: number): string => {
+    switch (status) {
+        case STATUS_UPLOADED:
+            return 'Uploaded';
+        case STATUS_PROCESSING:
+            return 'Processing';
+        case STATUS_READY:
+            return 'Ready';
+        case STATUS_ERROR:
+            return 'Error';
+        default:
+            return 'Unknown';
+    }
+};


### PR DESCRIPTION
- **4000 KnowledgeBase - client - Add document list components**
- **4000 KnowledgeBase - client - Add `useKnowledgeBaseDocumentStatusPolling` hook for document status polling**
- **4000 KnowledgeBase - client - Add `knowledge-base-utils` for mapping document statuses to labels**
