### PR TITLE
3964 Fix display condition matching string literals instead of variables

### DIFF
--- a/server/libs/platform/platform-configuration/platform-configuration-service/src/main/java/com/bytechef/platform/configuration/facade/WorkflowNodeParameterFacadeImpl.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-service/src/main/java/com/bytechef/platform/configuration/facade/WorkflowNodeParameterFacadeImpl.java
@@ -355,8 +355,9 @@ public class WorkflowNodeParameterFacadeImpl implements WorkflowNodeParameterFac
             return false;
         }
 
-        // Remove string literals (single and double quoted) to avoid matching variable names inside quotes
-        String conditionWithoutStrings = displayCondition.replaceAll("'[^']*'|\"[^\"]*\"", "");
+        // Remove string literals (single and double quoted, including those with escaped quotes)
+        String conditionWithoutStrings = displayCondition.replaceAll(
+            "'(?:[^'\\\\]|\\\\.)*'|\"(?:[^\"\\\\]|\\\\.)*\"", "");
 
         String regex = "(^|.*\\W)" + parameterPath + "(\\W.*|$)";
 

--- a/server/libs/platform/platform-configuration/platform-configuration-service/src/test/java/com/bytechef/platform/configuration/facade/WorkflowNodeParameterFacadeTest.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-service/src/test/java/com/bytechef/platform/configuration/facade/WorkflowNodeParameterFacadeTest.java
@@ -901,6 +901,14 @@ public class WorkflowNodeParameterFacadeTest {
 
         // Should return false when parameter name only appears in the string value part
         assertFalse(WorkflowNodeParameterFacadeImpl.hasExpressionVariable("someField == 'paramName'", "paramName"));
+
+        // Should handle escaped quotes in string literals
+        assertFalse(WorkflowNodeParameterFacadeImpl.hasExpressionVariable("field == 'it\\'s'", "s"));
+        assertFalse(
+            WorkflowNodeParameterFacadeImpl.hasExpressionVariable("field == \"He said \\\"hello\\\"\"", "hello"));
+
+        // Should still match variables outside escaped quote strings
+        assertTrue(WorkflowNodeParameterFacadeImpl.hasExpressionVariable("hello == 'He said \\\"hello\\\"'", "hello"));
     }
 
     @Test


### PR DESCRIPTION
The hasExpressionVariable method was incorrectly matching parameter names
inside quoted string literals, causing parameters to be removed when the
option value equaled the parameter name (e.g., type == 'type').

The fix strips single and double quoted string literals from the display
condition before checking for variable references.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
