### PR TITLE
1996-added toast messages for project and workflow duplication

### DIFF
--- a/client/src/pages/automation/project/components/project-header/components/settings-menu/hooks/useSettingsMenu.ts
+++ b/client/src/pages/automation/project/components/project-header/components/settings-menu/hooks/useSettingsMenu.ts
@@ -53,19 +53,38 @@ export const useSettingsMenu = ({project, workflow}: {project: Project; workflow
     });
 
     const duplicateProjectMutation = useDuplicateProjectMutation({
+        onError: () => {
+            toast({
+                description: `Project duplication failed.`,
+                variant: 'destructive',
+            });
+        },
         onSuccess: () => {
             queryClient.invalidateQueries({queryKey: ProjectKeys.projects});
 
             navigate(`/automation/projects/${project?.id}/project-workflows/${project?.projectWorkflowIds![0]}`);
+
+            toast({
+                description: 'Project duplicated successfully.',
+            });
         },
     });
 
     const duplicateWorkflowMutation = useDuplicateWorkflowMutation({
         onError: () => {
             queryClient.invalidateQueries({queryKey: ProjectKeys.projects});
+
+            toast({
+                description: 'Workflow duplication failed.',
+                variant: 'destructive',
+            });
         },
         onSuccess: () => {
             queryClient.invalidateQueries({queryKey: ProjectKeys.projects});
+
+            toast({
+                description: 'Workflow duplicated successfully.',
+            });
         },
     });
 

--- a/client/src/pages/automation/projects/components/project-list/ProjectListItem.tsx
+++ b/client/src/pages/automation/projects/components/project-list/ProjectListItem.tsx
@@ -101,10 +101,10 @@ const ProjectListItem = ({project, projectGitConfiguration, remainingTags}: Proj
     const queryClient = useQueryClient();
 
     const createProjectWorkflowMutation = useCreateProjectWorkflowMutation({
-        onSuccess: (projectWorkflowId) => {
+        onSuccess: (response) => {
             captureProjectWorkflowCreated();
 
-            navigate(`/automation/projects/${project.id}/project-workflows/${projectWorkflowId}`);
+            navigate(`/automation/projects/${project.id}/project-workflows/${response.projectWorkflowId}`);
         },
     });
 
@@ -124,8 +124,18 @@ const ProjectListItem = ({project, projectGitConfiguration, remainingTags}: Proj
     });
 
     const duplicateProjectMutation = useDuplicateProjectMutation({
+        onError: () => {
+            toast({
+                description: 'Project duplication failed.',
+                variant: 'destructive',
+            });
+        },
         onSuccess: () => {
             queryClient.invalidateQueries({queryKey: ProjectKeys.projects});
+
+            toast({
+                description: 'Project duplicated successfully.',
+            });
         },
     });
 

--- a/client/src/pages/automation/projects/components/project-workflow-list/ProjectWorkflowList.tsx
+++ b/client/src/pages/automation/projects/components/project-workflow-list/ProjectWorkflowList.tsx
@@ -57,10 +57,10 @@ const ProjectWorkflowList = ({project, queryEnabled}: {project: Project; queryEn
     const queryClient = useQueryClient();
 
     const createProjectWorkflowMutation = useCreateProjectWorkflowMutation({
-        onSuccess: (projectWorkflowId) => {
+        onSuccess: (response) => {
             captureProjectWorkflowCreated();
 
-            navigate(`/automation/projects/${project.id}/project-workflows/${projectWorkflowId}`);
+            navigate(`/automation/projects/${project.id}/project-workflows/${response.projectWorkflowId}`);
         },
     });
 

--- a/client/src/pages/automation/projects/components/project-workflow-list/ProjectWorkflowListItem.tsx
+++ b/client/src/pages/automation/projects/components/project-workflow-list/ProjectWorkflowListItem.tsx
@@ -23,6 +23,7 @@ import {WorkflowKeys, useGetWorkflowQuery} from '@/shared/queries/automation/wor
 import {WorkflowTestConfigurationKeys} from '@/shared/queries/platform/workflowTestConfigurations.queries';
 
 import '@/shared/styles/dropdownMenu.css';
+import {useToast} from '@/hooks/use-toast';
 import DeleteWorkflowAlertDialog from '@/shared/components/DeleteWorkflowAlertDialog';
 import {useApplicationInfoStore} from '@/shared/stores/useApplicationInfoStore';
 import {useFeatureFlagsStore} from '@/shared/stores/useFeatureFlagsStore';
@@ -61,6 +62,8 @@ const ProjectWorkflowListItem = ({
 
     const queryClient = useQueryClient();
 
+    const {toast} = useToast();
+
     const deleteWorkflowMutation = useDeleteWorkflowMutation({
         onSuccess: () => {
             queryClient.invalidateQueries({queryKey: ProjectKeys.projects});
@@ -72,9 +75,18 @@ const ProjectWorkflowListItem = ({
     const duplicateWorkflowMutation = useDuplicateWorkflowMutation({
         onError: () => {
             queryClient.invalidateQueries({queryKey: ProjectKeys.projects});
+
+            toast({
+                description: 'Workflow duplication failed.',
+                variant: 'destructive',
+            });
         },
         onSuccess: () => {
             queryClient.invalidateQueries({queryKey: ProjectKeys.projects});
+
+            toast({
+                description: 'Workflow duplicated successfully.',
+            });
         },
     });
 


### PR DESCRIPTION
- added success and error toast messages for project and workflow duplication
- messages are added to both settings menu duplicate buttons in the editor and duplicate buttons in the popover in the projects view
- styling from [figma](https://www.figma.com/design/Sqpe5tSQ0O2KMYwBbFJxrQ/-feature---Add-a-Toast-message-when-Duplicate-Project-and-Duplicate-Workflow-is-executed--1996?node-id=0-1&p=f&m=dev) design is not applied here as it will be applied once the deprecated toast component is switched to sonner 