### PR TITLE
2986 - Use node label instead of workflowNodeName in the deployment dialog for Connection select labels

### DIFF
--- a/client/src/pages/automation/project-deployments/components/project-deployment-dialog/ProjectDeploymentDialogWorkflowsStepItem.tsx
+++ b/client/src/pages/automation/project-deployments/components/project-deployment-dialog/ProjectDeploymentDialogWorkflowsStepItem.tsx
@@ -35,6 +35,20 @@ const ProjectDeploymentDialogWorkflowsStepItem = ({
         .flatMap((task) => task.connections ?? [])
         .concat((workflow?.triggers ?? []).flatMap((trigger) => trigger.connections ?? []));
 
+    const workflowNodeLabelMap = new Map<string, string>();
+
+    for (const task of workflow?.tasks ?? []) {
+        if (task.label) {
+            workflowNodeLabelMap.set(task.name, task.label);
+        }
+    }
+
+    for (const trigger of workflow?.triggers ?? []) {
+        if (trigger.label) {
+            workflowNodeLabelMap.set(trigger.name, trigger.label);
+        }
+    }
+
     return (
         <div>
             {!switchHidden && (
@@ -86,6 +100,7 @@ const ProjectDeploymentDialogWorkflowsStepItem = ({
                             componentConnections={componentConnections}
                             control={control}
                             workflowIndex={workflowIndex}
+                            workflowNodeLabelMap={workflowNodeLabelMap}
                         />
                     </li>
                 </ul>

--- a/client/src/pages/automation/project-deployments/components/project-deployment-dialog/ProjectDeploymentDialogWorkflowsStepItemConnection.tsx
+++ b/client/src/pages/automation/project-deployments/components/project-deployment-dialog/ProjectDeploymentDialogWorkflowsStepItemConnection.tsx
@@ -23,6 +23,7 @@ export interface ProjectDeploymentDialogWorkflowsStepItemConnectionProps {
     componentConnection: ComponentConnection;
     componentConnectionIndex: number;
     workflowIndex: number;
+    workflowNodeLabel?: string;
 }
 
 const ProjectDeploymentDialogWorkflowsStepItemConnection = ({
@@ -30,6 +31,7 @@ const ProjectDeploymentDialogWorkflowsStepItemConnection = ({
     componentConnectionIndex,
     control,
     workflowIndex,
+    workflowNodeLabel,
 }: ProjectDeploymentDialogWorkflowsStepItemConnectionProps) => {
     const currentEnvironmentId = useEnvironmentStore((state) => state.currentEnvironmentId);
     const currentWorkspaceId = useWorkspaceStore((state) => state.currentWorkspaceId);
@@ -63,7 +65,7 @@ const ProjectDeploymentDialogWorkflowsStepItemConnection = ({
                                 <InlineSVG className="size-4 flex-none" src={componentDefinition.icon} />
                             )}
 
-                            <span>{componentDefinition?.title} Connection</span>
+                            <span>{workflowNodeLabel || `${componentDefinition?.title} Connection`}</span>
 
                             <span className="text-xs text-gray-500">({componentConnection.workflowNodeName})</span>
                         </FormLabel>

--- a/client/src/pages/automation/project-deployments/components/project-deployment-dialog/ProjectDeploymentDialogWorkflowsStepItemConnections.tsx
+++ b/client/src/pages/automation/project-deployments/components/project-deployment-dialog/ProjectDeploymentDialogWorkflowsStepItemConnections.tsx
@@ -2,15 +2,19 @@ import ProjectDeploymentDialogWorkflowsStepItemConnection from '@/pages/automati
 import {ComponentConnection, ProjectDeployment} from '@/shared/middleware/automation/configuration';
 import {Control} from 'react-hook-form';
 
+interface ProjectDeploymentDialogWorkflowsStepItemConnectionsProps {
+    componentConnections: ComponentConnection[];
+    control: Control<ProjectDeployment>;
+    workflowIndex: number;
+    workflowNodeLabelMap: Map<string, string>;
+}
+
 const ProjectDeploymentDialogWorkflowsStepItemConnections = ({
     componentConnections,
     control,
     workflowIndex,
-}: {
-    control: Control<ProjectDeployment>;
-    componentConnections: ComponentConnection[];
-    workflowIndex: number;
-}) => (
+    workflowNodeLabelMap,
+}: ProjectDeploymentDialogWorkflowsStepItemConnectionsProps) => (
     <>
         {!componentConnections.length && <p className="text-sm">No defined connections.</p>}
 
@@ -22,6 +26,7 @@ const ProjectDeploymentDialogWorkflowsStepItemConnections = ({
                     control={control}
                     key={`${componentConnectionIndex}_${componentConnection.key}`}
                     workflowIndex={workflowIndex}
+                    workflowNodeLabel={workflowNodeLabelMap.get(componentConnection.workflowNodeName)}
                 />
             ))}
         </ul>


### PR DESCRIPTION
fixes: #2986 

[Screencast from 2026-02-18 15-22-24.webm](https://github.com/user-attachments/assets/817f3c53-cdc8-4772-bd04-e6923e795948)

## Summary
- Display user-defined workflow node labels in the deployment dialog's Connections section instead of the generic component name (e.g. "Forward to team (googleMail_2)" instead of "Gmail Connection (googleMail_2)")
- Build a name-to-label lookup map from workflow tasks and triggers in `ProjectDeploymentDialogWorkflowsStepItem` and thread it through to the individual connection select components
- Fall back to the original "ComponentTitle Connection" format when no user-defined label exists



## default:

<img width="1228" height="558" alt="image" src="https://github.com/user-attachments/assets/74717970-5b46-4643-b460-5123dcdb80b6" />
<img width="666" height="680" alt="image" src="https://github.com/user-attachments/assets/c06a0e84-7ef5-4ab1-92ca-c6aafbf83b63" />


## changed label case:
<img width="1261" height="614" alt="image" src="https://github.com/user-attachments/assets/e0a090eb-1e69-454b-ac88-f55a68f8ac22" />
<img width="691" height="571" alt="image" src="https://github.com/user-attachments/assets/3b1a843d-a46f-4e0c-a5d8-4316c2a37daf" />

## no label  case:
<img width="1234" height="465" alt="image" src="https://github.com/user-attachments/assets/9644e61a-9143-4e61-a6c0-2f2cfcf943ae" />

<img width="683" height="546" alt="image" src="https://github.com/user-attachments/assets/f512618a-aaf1-4703-9998-abc60293d466" />


