### PR TITLE
4261 client - Prevent WorkflowExecutionSheet from closing on resize handle interaction

### DIFF
--- a/client/src/ee/pages/embedded/workflow-executions/components/workflow-execution-sheet/WorkflowExecutionSheet.tsx
+++ b/client/src/ee/pages/embedded/workflow-executions/components/workflow-execution-sheet/WorkflowExecutionSheet.tsx
@@ -51,7 +51,10 @@ const WorkflowExecutionSheet = () => {
 
     return (
         <Sheet onOpenChange={handleOpenChange} open={workflowExecutionSheetOpen}>
-            <SheetContent className="flex h-full w-[90%] gap-0 p-0 sm:max-w-[90%]">
+            <SheetContent
+                className="flex h-full w-[90%] gap-0 p-0 sm:max-w-[90%]"
+                onPointerDownOutside={(event) => event.preventDefault()}
+            >
                 {workflowExecutionLoading ? (
                     <div className="flex size-full items-center justify-center">
                         <Spinner className="size-6" />

--- a/client/src/pages/automation/workflow-executions/components/workflow-execution-sheet/WorkflowExecutionSheet.tsx
+++ b/client/src/pages/automation/workflow-executions/components/workflow-execution-sheet/WorkflowExecutionSheet.tsx
@@ -34,7 +34,10 @@ const WorkflowExecutionSheet = () => {
                 <SheetTitle>{`${workflowExecution?.project?.name}/${workflowExecution?.workflow?.label}`}</SheetTitle>
             </VisuallyHidden.Root>
 
-            <SheetContent className="absolute bottom-4 right-4 top-3 flex h-auto w-[90%] flex-row gap-0 rounded-md bg-surface-neutral-secondary p-0 sm:max-w-[90%]">
+            <SheetContent
+                className="absolute bottom-4 right-4 top-3 flex h-auto w-[90%] flex-row gap-0 rounded-md bg-surface-neutral-secondary p-0 sm:max-w-[90%]"
+                onPointerDownOutside={(event) => event.preventDefault()}
+            >
                 <div className="flex min-w-0 flex-1 flex-col">
                     {workflowExecutionLoading ? (
                         <div className="flex size-full items-center justify-center">


### PR DESCRIPTION
Add onPointerDownOutside event prevention to SheetContent in both
automation and embedded WorkflowExecutionSheet components, matching the
pattern used by other Sheet components in the codebase.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
