### PR TITLE
4223 client - Add server-side support for UserGuiding tutorial flag

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -170,7 +170,6 @@ function App() {
 
     useFetchInterceptor();
 
-    const ff_298 = useFeatureFlagsStore()('ff-298');
     const ff_732 = useFeatureFlagsStore()('ff-732');
     const ff_1023 = useFeatureFlagsStore()('ff-1023');
     const ff_1779 = useFeatureFlagsStore()('ff-1779');
@@ -244,12 +243,9 @@ function App() {
         if (account) {
             helpHub.boot(account);
             helpHub.addRouter();
-
-            if (ff_298) {
-                userGuiding.identify(account);
-            }
+            userGuiding.identify(account);
         }
-    }, [account, ff_298, helpHub, userGuiding]);
+    }, [account, helpHub, userGuiding]);
 
     useEffect(() => {
         document.title =
@@ -263,10 +259,7 @@ function App() {
             analytics.reset();
 
             helpHub.shutdown();
-
-            if (ff_298) {
-                userGuiding.shutdown();
-            }
+            userGuiding.shutdown();
 
             resetAuthentication();
 

--- a/client/src/hooks/useUserGuiding.ts
+++ b/client/src/hooks/useUserGuiding.ts
@@ -1,8 +1,7 @@
 import {UserI} from '@/shared/models/user.model';
 import {useApplicationInfoStore} from '@/shared/stores/useApplicationInfoStore';
 import {useRef} from 'react';
-// TODO: restore once /actuator/info exposes userGuiding
-// import {useShallow} from 'zustand/react/shallow';
+import {useShallow} from 'zustand/react/shallow';
 
 export function initUserGuiding(containerId: string) {
     window.userGuidingLayer = window.userGuidingLayer || [];
@@ -48,14 +47,12 @@ export interface UserGuidingI {
 }
 
 export const useUserGuiding = (): UserGuidingI => {
-    // TODO: restore userGuiding from store once /actuator/info exposes it
-    // const {application, userGuiding} = useApplicationInfoStore(
-    //     useShallow((state) => ({
-    //         application: state.application,
-    //         userGuiding: state.userGuiding,
-    //     }))
-    // );
-    const application = useApplicationInfoStore((state) => state.application);
+    const {application, userGuiding} = useApplicationInfoStore(
+        useShallow((state) => ({
+            application: state.application,
+            userGuiding: state.userGuiding,
+        }))
+    );
 
     const identifyRef = useRef(false);
 
@@ -65,9 +62,7 @@ export const useUserGuiding = (): UserGuidingI => {
                 return;
             }
 
-            // TODO: restore backend-driven gate once /actuator/info exposes userGuiding
-            // if (window.userGuiding && userGuiding.enabled) {
-            if (window.userGuiding) {
+            if (window.userGuiding && userGuiding.enabled) {
                 identifyRef.current = true;
 
                 window.userGuiding.identify(account.uuid, {

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -74,13 +74,10 @@ async function renderApp() {
         init(applicationInfoStore.getState().helpHub.commandBar.orgId!);
     }
 
-    // TODO: restore backend-driven config once /actuator/info exposes userGuiding
-    // const {userGuiding} = applicationInfoStore.getState();
-    // if (userGuiding.enabled && userGuiding.containerId) {
-    //     initUserGuiding(userGuiding.containerId);
-    // }
-    if (applicationInfoStore.getState().featureFlags['ff-298']) {
-        initUserGuiding('38U111210PF6ID');
+    const {userGuiding} = applicationInfoStore.getState();
+
+    if (userGuiding.enabled && userGuiding.containerId) {
+        initUserGuiding(userGuiding.containerId);
     }
 
     if (


### PR DESCRIPTION
Expose userGuiding.enabled and userGuiding.containerId via /actuator/info
so the client can be driven by server configuration instead of a hardcoded
container ID and feature flag. Update client to consume the new config and
remove the ff-298 feature flag gate.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
