### PR TITLE
4290 client - Fix datapill detection to use includes instead of startsWith and add tests

### DIFF
--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/PropertyMentionsInputEditor.tsx
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/PropertyMentionsInputEditor.tsx
@@ -296,7 +296,7 @@ const PropertyMentionsInputEditor = forwardRef<Editor, PropertyMentionsInputEdit
                 !isFormulaMode &&
                 (type === 'INTEGER' || type === 'NUMBER') &&
                 typeof transformedValue === 'string' &&
-                !transformedValue.startsWith('${')
+                !transformedValue.includes('${')
             ) {
                 transformedValue = parseInt(transformedValue);
             }

--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/tests/numericCoercionGuard.test.ts
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/tests/numericCoercionGuard.test.ts
@@ -1,0 +1,167 @@
+import {describe, expect, it} from 'vitest';
+
+/**
+ * Helper function to replicate the numeric coercion logic from
+ * PropertyMentionsInputEditor.tsx's saveMentionInputValue callback.
+ *
+ * This tests the fix that uses includes('${') instead of startsWith('${')
+ * to prevent parseInt() from being applied to strings that contain datapill
+ * references embedded anywhere (not just at the start).
+ *
+ * The original bug: a value like "text ${trigger_1.output} more" would pass
+ * the startsWith('${') check and get parseInt()'d, corrupting it to NaN.
+ */
+const applyNumericCoercion = ({
+    isFormulaMode,
+    type,
+    value,
+}: {
+    isFormulaMode: boolean;
+    type: string;
+    value: string | number | null;
+}): string | number | null => {
+    let transformedValue: string | number | null = value;
+
+    if (
+        !isFormulaMode &&
+        (type === 'INTEGER' || type === 'NUMBER') &&
+        typeof transformedValue === 'string' &&
+        !transformedValue.includes('${')
+    ) {
+        transformedValue = parseInt(transformedValue);
+    }
+
+    return transformedValue;
+};
+
+describe('numericCoercionGuard', () => {
+    describe('should NOT coerce strings containing datapill references', () => {
+        it('should preserve value when datapill is at the start', () => {
+            const result = applyNumericCoercion({
+                isFormulaMode: false,
+                type: 'INTEGER',
+                value: '${trigger_1.output}',
+            });
+
+            expect(result).toBe('${trigger_1.output}');
+        });
+
+        it('should preserve value when datapill is in the middle', () => {
+            const result = applyNumericCoercion({
+                isFormulaMode: false,
+                type: 'INTEGER',
+                value: 'prefix ${trigger_1.output} suffix',
+            });
+
+            expect(result).toBe('prefix ${trigger_1.output} suffix');
+        });
+
+        it('should preserve value when datapill is at the end', () => {
+            const result = applyNumericCoercion({
+                isFormulaMode: false,
+                type: 'NUMBER',
+                value: 'total: ${step_1.amount}',
+            });
+
+            expect(result).toBe('total: ${step_1.amount}');
+        });
+
+        it('should preserve value with multiple datapill references', () => {
+            const result = applyNumericCoercion({
+                isFormulaMode: false,
+                type: 'INTEGER',
+                value: '${a_1.x} + ${b_1.y}',
+            });
+
+            expect(result).toBe('${a_1.x} + ${b_1.y}');
+        });
+    });
+
+    describe('should coerce plain numeric strings', () => {
+        it('should coerce a plain integer string for INTEGER type', () => {
+            const result = applyNumericCoercion({
+                isFormulaMode: false,
+                type: 'INTEGER',
+                value: '42',
+            });
+
+            expect(result).toBe(42);
+        });
+
+        it('should coerce a plain numeric string for NUMBER type', () => {
+            const result = applyNumericCoercion({
+                isFormulaMode: false,
+                type: 'NUMBER',
+                value: '99',
+            });
+
+            expect(result).toBe(99);
+        });
+
+        it('should coerce negative integer string', () => {
+            const result = applyNumericCoercion({
+                isFormulaMode: false,
+                type: 'INTEGER',
+                value: '-7',
+            });
+
+            expect(result).toBe(-7);
+        });
+    });
+
+    describe('should skip coercion in formula mode', () => {
+        it('should not coerce when isFormulaMode is true', () => {
+            const result = applyNumericCoercion({
+                isFormulaMode: true,
+                type: 'INTEGER',
+                value: '42',
+            });
+
+            expect(result).toBe('42');
+        });
+    });
+
+    describe('should skip coercion for non-numeric types', () => {
+        it('should not coerce STRING type', () => {
+            const result = applyNumericCoercion({
+                isFormulaMode: false,
+                type: 'STRING',
+                value: '42',
+            });
+
+            expect(result).toBe('42');
+        });
+
+        it('should not coerce BOOLEAN type', () => {
+            const result = applyNumericCoercion({
+                isFormulaMode: false,
+                type: 'BOOLEAN',
+                value: 'true',
+            });
+
+            expect(result).toBe('true');
+        });
+    });
+
+    describe('should handle non-string values', () => {
+        it('should pass through numeric values unchanged', () => {
+            const result = applyNumericCoercion({
+                isFormulaMode: false,
+                type: 'INTEGER',
+                value: 42,
+            });
+
+            expect(result).toBe(42);
+        });
+
+        it('should pass through null unchanged', () => {
+            const result = applyNumericCoercion({
+                isFormulaMode: false,
+                type: 'INTEGER',
+                value: null,
+            });
+
+            expect(result).toBeNull();
+        });
+    });
+});

--- a/client/src/pages/platform/workflow-editor/components/properties/hooks/tests/validatePropertyValue.test.ts
+++ b/client/src/pages/platform/workflow-editor/components/properties/hooks/tests/validatePropertyValue.test.ts
@@ -1,0 +1,337 @@
+import {describe, expect, it} from 'vitest';
+
+/**
+ * Helper function to replicate the validatePropertyValue logic from useProperty.ts.
+ * This tests the validation that determines whether a property value is acceptable
+ * before saving, including the fix that uses includes('${') instead of startsWith('${')
+ * to correctly handle datapill references embedded anywhere in the string.
+ */
+const validatePropertyValue = ({
+    controlType,
+    maxLength,
+    maxNumberPrecision,
+    maxValue,
+    minLength,
+    minNumberPrecision,
+    minValue,
+    numberPrecision,
+    regex,
+    type,
+    value,
+}: {
+    controlType?: string;
+    maxLength?: number;
+    maxNumberPrecision?: number;
+    maxValue?: number;
+    minLength?: number;
+    minNumberPrecision?: number;
+    minValue?: number;
+    numberPrecision?: number;
+    regex?: string;
+    type?: string;
+    value: string | number;
+}): boolean => {
+    const stringValue = typeof value === 'string' ? value : String(value);
+
+    if (typeof value === 'string' && (value.startsWith('=') || value.includes('${'))) {
+        return true;
+    }
+
+    if ((type === 'INTEGER' || type === 'NUMBER') && typeof value === 'string' && !value.includes('${')) {
+        const numericValue = parseFloat(value);
+
+        if (minValue != null && numericValue < minValue) {
+            return false;
+        }
+
+        if (maxValue != null && numericValue > maxValue) {
+            return false;
+        }
+
+        if (controlType === 'INTEGER' && !/^-?\d+$/.test(value)) {
+            return false;
+        }
+
+        if (controlType === 'NUMBER' && !/^-?\d+(\.\d+)?$/.test(value)) {
+            return false;
+        }
+
+        if (numberPrecision != null && value.includes('.')) {
+            const decimalLength = value.split('.')[1]?.length ?? 0;
+
+            if (numberPrecision === 0 || decimalLength > numberPrecision) {
+                return false;
+            }
+        }
+
+        if (value.includes('.')) {
+            const decimalLength = value.split('.')[1]?.length ?? 0;
+
+            if (minNumberPrecision != null && decimalLength < minNumberPrecision) {
+                return false;
+            }
+
+            if (maxNumberPrecision != null && decimalLength > maxNumberPrecision) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    if (minLength != null && stringValue.length < minLength) {
+        return false;
+    }
+
+    if (maxLength != null && stringValue.length > maxLength) {
+        return false;
+    }
+
+    if (regex) {
+        try {
+            if (new RegExp(regex).test(stringValue)) {
+                return false;
+            }
+        } catch {
+            // Invalid regex from backend; skip regex validation
+        }
+    }
+
+    return true;
+};
+
+describe('validatePropertyValue', () => {
+    const baseNumericParams = {
+        controlType: 'INTEGER' as string,
+        type: 'INTEGER' as string,
+    };
+
+    describe('datapill expression bypass', () => {
+        it('should bypass validation when value starts with ${', () => {
+            const result = validatePropertyValue({
+                ...baseNumericParams,
+                value: '${trigger_1.output}',
+            });
+
+            expect(result).toBe(true);
+        });
+
+        it('should bypass validation when value contains ${ in the middle', () => {
+            const result = validatePropertyValue({
+                ...baseNumericParams,
+                value: 'prefix ${trigger_1.output} suffix',
+            });
+
+            expect(result).toBe(true);
+        });
+
+        it('should bypass validation when value contains multiple datapill references', () => {
+            const result = validatePropertyValue({
+                ...baseNumericParams,
+                value: '${airtable_1.id} and ${airtable_1.name}',
+            });
+
+            expect(result).toBe(true);
+        });
+
+        it('should bypass validation for formula expressions starting with =', () => {
+            const result = validatePropertyValue({
+                ...baseNumericParams,
+                value: '=someExpression()',
+            });
+
+            expect(result).toBe(true);
+        });
+
+        it('should bypass validation for formula with embedded datapill', () => {
+            const result = validatePropertyValue({
+                ...baseNumericParams,
+                value: '=${trigger_1.output} + 1',
+            });
+
+            expect(result).toBe(true);
+        });
+    });
+
+    describe('numeric validation when no datapill is present', () => {
+        it('should validate a plain integer string', () => {
+            const result = validatePropertyValue({
+                ...baseNumericParams,
+                value: '42',
+            });
+
+            expect(result).toBe(true);
+        });
+
+        it('should reject non-integer string for INTEGER control type', () => {
+            const result = validatePropertyValue({
+                ...baseNumericParams,
+                value: '42.5',
+            });
+
+            expect(result).toBe(false);
+        });
+
+        it('should reject value below minValue', () => {
+            const result = validatePropertyValue({
+                ...baseNumericParams,
+                minValue: 10,
+                value: '5',
+            });
+
+            expect(result).toBe(false);
+        });
+
+        it('should reject value above maxValue', () => {
+            const result = validatePropertyValue({
+                ...baseNumericParams,
+                maxValue: 100,
+                value: '150',
+            });
+
+            expect(result).toBe(false);
+        });
+
+        it('should validate NUMBER type with decimal', () => {
+            const result = validatePropertyValue({
+                controlType: 'NUMBER',
+                type: 'NUMBER',
+                value: '42.5',
+            });
+
+            expect(result).toBe(true);
+        });
+
+        it('should reject NUMBER with invalid format', () => {
+            const result = validatePropertyValue({
+                controlType: 'NUMBER',
+                type: 'NUMBER',
+                value: '42.5.3',
+            });
+
+            expect(result).toBe(false);
+        });
+
+        it('should reject when numberPrecision is 0 and value has decimal', () => {
+            const result = validatePropertyValue({
+                controlType: 'NUMBER',
+                numberPrecision: 0,
+                type: 'NUMBER',
+                value: '42.5',
+            });
+
+            expect(result).toBe(false);
+        });
+
+        it('should reject when decimal places exceed numberPrecision', () => {
+            const result = validatePropertyValue({
+                controlType: 'NUMBER',
+                numberPrecision: 2,
+                type: 'NUMBER',
+                value: '42.555',
+            });
+
+            expect(result).toBe(false);
+        });
+
+        it('should reject when decimal places are below minNumberPrecision', () => {
+            const result = validatePropertyValue({
+                controlType: 'NUMBER',
+                minNumberPrecision: 2,
+                type: 'NUMBER',
+                value: '42.5',
+            });
+
+            expect(result).toBe(false);
+        });
+
+        it('should reject when decimal places exceed maxNumberPrecision', () => {
+            const result = validatePropertyValue({
+                controlType: 'NUMBER',
+                maxNumberPrecision: 2,
+                type: 'NUMBER',
+                value: '42.555',
+            });
+
+            expect(result).toBe(false);
+        });
+    });
+
+    describe('string validation', () => {
+        it('should reject when value is shorter than minLength', () => {
+            const result = validatePropertyValue({
+                minLength: 5,
+                type: 'STRING',
+                value: 'abc',
+            });
+
+            expect(result).toBe(false);
+        });
+
+        it('should reject when value exceeds maxLength', () => {
+            const result = validatePropertyValue({
+                maxLength: 5,
+                type: 'STRING',
+                value: 'abcdefgh',
+            });
+
+            expect(result).toBe(false);
+        });
+
+        it('should reject when value matches regex pattern', () => {
+            const result = validatePropertyValue({
+                regex: '^\\d+$',
+                type: 'STRING',
+                value: '12345',
+            });
+
+            expect(result).toBe(false);
+        });
+
+        it('should accept when value does not match regex pattern', () => {
+            const result = validatePropertyValue({
+                regex: '^\\d+$',
+                type: 'STRING',
+                value: 'hello',
+            });
+
+            expect(result).toBe(true);
+        });
+
+        it('should handle invalid regex gracefully', () => {
+            const result = validatePropertyValue({
+                regex: '[invalid',
+                type: 'STRING',
+                value: 'hello',
+            });
+
+            expect(result).toBe(true);
+        });
+    });
+
+    describe('number type value with embedded datapill should not enter numeric validation', () => {
+        it('should not fail numeric validation for NUMBER type with embedded datapill', () => {
+            const result = validatePropertyValue({
+                controlType: 'NUMBER',
+                maxValue: 100,
+                minValue: 0,
+                type: 'NUMBER',
+                value: 'total is ${trigger_1.amount}',
+            });
+
+            expect(result).toBe(true);
+        });
+
+        it('should not fail numeric validation for INTEGER type with embedded datapill', () => {
+            const result = validatePropertyValue({
+                controlType: 'INTEGER',
+                maxValue: 100,
+                minValue: 0,
+                type: 'INTEGER',
+                value: 'count: ${step_1.count}',
+            });
+
+            expect(result).toBe(true);
+        });
+    });
+});

--- a/client/src/pages/platform/workflow-editor/components/properties/hooks/useProperty.ts
+++ b/client/src/pages/platform/workflow-editor/components/properties/hooks/useProperty.ts
@@ -335,11 +335,11 @@ export const useProperty = ({
         (value: string | number): boolean => {
             const stringValue = typeof value === 'string' ? value : String(value);
 
-            if (typeof value === 'string' && (value.startsWith('=') || value.startsWith('${'))) {
+            if (typeof value === 'string' && (value.startsWith('=') || value.includes('${'))) {
                 return true;
             }
 
-            if ((type === 'INTEGER' || type === 'NUMBER') && typeof value === 'string' && !value.startsWith('${')) {
+            if ((type === 'INTEGER' || type === 'NUMBER') && typeof value === 'string' && !value.includes('${')) {
                 const numericValue = parseFloat(value);
 
                 if (minValue != null && numericValue < minValue) {


### PR DESCRIPTION
Datapill references (${...}) can appear anywhere in a string value, not
just at the beginning. Using startsWith('${') caused embedded datapills
to be incorrectly coerced with parseInt() or to fail numeric validation.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
