### PR TITLE
2893 client - Hide fromAi button except for tools cluster element type

### DIFF
--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/PropertyMentionsInputEditor.tsx
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/PropertyMentionsInputEditor.tsx
@@ -737,6 +737,7 @@ const PropertyMentionsInputEditor = forwardRef<Editor, PropertyMentionsInputEdit
 
                 {fromAiExtension &&
                     handleFromAiClick &&
+                    currentNode?.clusterElementType === 'tools' &&
                     (isFromAi ? (
                         <Button
                             className="self-center"


### PR DESCRIPTION
Only show the fromAi button in property mention input when the
current node's clusterElementType is 'tools'.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
