### PR TITLE
4289 client - Deduplicate error toasts

### DIFF
--- a/client/src/config/tests/useFetchInterceptor.test.ts
+++ b/client/src/config/tests/useFetchInterceptor.test.ts
@@ -203,7 +203,7 @@ describe('useFetchInterceptor', () => {
 
             expect(hoisted.toastError).toHaveBeenCalledWith('Error', {
                 description: 'Something went wrong',
-                id: 'http://localhost/internal/api/test-500',
+                id: '/internal/api/test-500',
             });
         });
 
@@ -265,7 +265,7 @@ describe('useFetchInterceptor', () => {
             });
 
             expect(hoisted.toastError).toHaveBeenCalledWith('Request failed with status 502', {
-                id: 'http://localhost/internal/api/test-502',
+                id: '/internal/api/test-502',
             });
         });
     });
@@ -288,7 +288,7 @@ describe('useFetchInterceptor', () => {
 
             expect(hoisted.toastError).toHaveBeenCalledWith('Error', {
                 description: 'Field not found\nPermission denied',
-                id: 'http://localhost/graphql-200',
+                id: '/graphql-200',
             });
         });
 
@@ -345,7 +345,7 @@ describe('useFetchInterceptor', () => {
 
             expect(hoisted.toastError).toHaveBeenCalledWith('Error', {
                 description: 'Unknown error\nValid error',
-                id: 'http://localhost/graphql-200',
+                id: '/graphql-200',
             });
         });
 
@@ -365,7 +365,7 @@ describe('useFetchInterceptor', () => {
             });
 
             expect(hoisted.toastError).toHaveBeenCalledWith('Request failed with status 500', {
-                id: 'http://localhost/graphql-500',
+                id: '/graphql-500',
             });
         });
 

--- a/client/src/config/useFetchInterceptor.ts
+++ b/client/src/config/useFetchInterceptor.ts
@@ -15,9 +15,16 @@ export function clearRecentToasts() {
 
 function showErrorToast(toastId: string, title: string, options?: {description?: string}) {
     const now = Date.now();
+
+    for (const [id, timestamp] of recentToastIds) {
+        if (now - timestamp >= TOAST_COOLDOWN_MS) {
+            recentToastIds.delete(id);
+        }
+    }
+
     const lastShown = recentToastIds.get(toastId);
 
-    if (lastShown && now - lastShown < TOAST_COOLDOWN_MS) {
+    if (lastShown !== undefined && now - lastShown < TOAST_COOLDOWN_MS) {
         return;
     }
 
@@ -80,7 +87,7 @@ export default function useFetchInterceptor() {
                     return response;
                 }
 
-                const toastId = `${response.url}-${response.status}`;
+                const toastId = `${new URL(response.url).pathname}-${response.status}`;
 
                 if (response.url.includes('/graphql')) {
                     const clonedResponse = response.clone();

--- a/client/src/ee/pages/embedded/automation-workflows/workflow-builder/config/tests/useFetchInterceptor.test.ts
+++ b/client/src/ee/pages/embedded/automation-workflows/workflow-builder/config/tests/useFetchInterceptor.test.ts
@@ -1,7 +1,7 @@
 import {act, renderHook} from '@testing-library/react';
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 
-import useFetchInterceptor from '../useFetchInterceptor';
+import useFetchInterceptor, {clearRecentToasts} from '../useFetchInterceptor';
 
 const hoisted = vi.hoisted(() => {
     return {
@@ -70,6 +70,7 @@ function createMockResponse(overrides: Record<string, unknown> = {}) {
 describe('useFetchInterceptor (embedded)', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        clearRecentToasts();
         hoisted.registeredHandlers = null;
         import.meta.env.VITE_API_BASE_PATH = '';
     });
@@ -166,7 +167,7 @@ describe('useFetchInterceptor (embedded)', () => {
 
             expect(hoisted.toastError).toHaveBeenCalledWith('Error', {
                 description: 'Something went wrong',
-                id: 'http://localhost/internal/api/test-500',
+                id: '/internal/api/test-500',
             });
         });
 
@@ -187,6 +188,32 @@ describe('useFetchInterceptor (embedded)', () => {
             expect(hoisted.toastError).not.toHaveBeenCalled();
         });
 
+        it('suppresses duplicate error toasts within cooldown period', async () => {
+            renderHook(() => useFetchInterceptor());
+
+            const createResponse = () =>
+                createMockResponse({
+                    jsonData: {detail: 'Something went wrong', title: 'Error'},
+                    status: 500,
+                });
+
+            hoisted.registeredHandlers!.response(createResponse());
+
+            await act(async () => {
+                await new Promise((resolve) => setTimeout(resolve, 0));
+            });
+
+            expect(hoisted.toastError).toHaveBeenCalledTimes(1);
+
+            hoisted.registeredHandlers!.response(createResponse());
+
+            await act(async () => {
+                await new Promise((resolve) => setTimeout(resolve, 0));
+            });
+
+            expect(hoisted.toastError).toHaveBeenCalledTimes(1);
+        });
+
         it('shows fallback error toast when response body is not JSON', async () => {
             renderHook(() => useFetchInterceptor());
 
@@ -202,7 +229,7 @@ describe('useFetchInterceptor (embedded)', () => {
             });
 
             expect(hoisted.toastError).toHaveBeenCalledWith('Request failed with status 502', {
-                id: 'http://localhost/internal/api/test-502',
+                id: '/internal/api/test-502',
             });
         });
     });

--- a/client/src/ee/pages/embedded/automation-workflows/workflow-builder/config/useFetchInterceptor.ts
+++ b/client/src/ee/pages/embedded/automation-workflows/workflow-builder/config/useFetchInterceptor.ts
@@ -8,11 +8,22 @@ import {toast} from 'sonner';
 const TOAST_COOLDOWN_MS = 10_000;
 const recentToastIds = new Map<string, number>();
 
+export function clearRecentToasts() {
+    recentToastIds.clear();
+}
+
 function showErrorToast(toastId: string, title: string, options?: {description?: string}) {
     const now = Date.now();
+
+    for (const [id, timestamp] of recentToastIds) {
+        if (now - timestamp >= TOAST_COOLDOWN_MS) {
+            recentToastIds.delete(id);
+        }
+    }
+
     const lastShown = recentToastIds.get(toastId);
 
-    if (lastShown && now - lastShown < TOAST_COOLDOWN_MS) {
+    if (lastShown !== undefined && now - lastShown < TOAST_COOLDOWN_MS) {
         return;
     }
 
@@ -77,7 +88,7 @@ export default function useFetchInterceptor() {
                     return response;
                 }
 
-                const toastId = `${response.url}-${response.status}`;
+                const toastId = `${new URL(response.url).pathname}-${response.status}`;
 
                 if (response.status < 200 || response.status > 299) {
                     const clonedResponse = response.clone();


### PR DESCRIPTION
Add cooldown-based toast deduplication in fetch
interceptor to suppress repeated error toasts from React Query retries.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
