### PR TITLE
fix(workflow editor): allow space key input in code editor

### DIFF
--- a/client/src/pages/platform/workflow-editor/components/WorkflowEditor.tsx
+++ b/client/src/pages/platform/workflow-editor/components/WorkflowEditor.tsx
@@ -299,6 +299,7 @@ const WorkflowEditor = ({
                 onDrop={onDrop}
                 onEdgesChange={onEdgesChange}
                 onNodesChange={onNodesChange}
+                panActivationKeyCode={null}
                 panOnDrag
                 panOnScroll
                 proOptions={{hideAttribution: true}}


### PR DESCRIPTION
## Description
- disable React Flow's default spacebar pan activation in the workflow editor by setting `panActivationKeyCode={null}`
- this prevents space key presses from being intercepted while focus is inside embedded editors/inputs in the workflow builder
- this is a minimal, single-line fix directly addressing the reported regression

Fixes #4428

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- Attempted local client typecheck: `npm run typecheck` (from `client/`)
- Result: fails on existing unrelated TypeScript errors currently present on `develop` (e.g. `src/shared/constants.tsx` JSX namespace / other pre-existing typing failures), so full validation is not currently runnable from a clean develop checkout
- Manual verification rationale: change only disables React Flow's spacebar pan activation keybinding and does not alter node/edge data flow

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes