### PR TITLE
fix(properties): handle embedded datapills in numeric/validation flows

### DIFF
--- a/client/src/pages/platform/workflow-editor/components/properties/hooks/useProperty.ts
+++ b/client/src/pages/platform/workflow-editor/components/properties/hooks/useProperty.ts
@@ -737,7 +737,7 @@ export const useProperty = ({
             setMentionInputValue(typeof value === 'number' ? String(value) : value);
 
             const stringValue = typeof value === 'string' ? value : '';
-            const isExpression = typeof value === 'string' && (value.startsWith('=') || value.startsWith('${'));
+            const isExpression = typeof value === 'string' && (value.startsWith('=') || value.includes('${'));
 
             if (!stringValue || isExpression) {
                 setHasError(false);
@@ -888,9 +888,9 @@ export const useProperty = ({
 
             let actualValue: boolean | null | number | string = type === 'BOOLEAN' ? value === 'true' : value;
 
-            if (type === 'INTEGER' && typeof mentionInputValue === 'string' && !mentionInputValue.startsWith('${')) {
+            if (type === 'INTEGER' && typeof mentionInputValue === 'string' && !mentionInputValue.includes('${')) {
                 actualValue = parseInt(value);
-            } else if (type === 'NUMBER' && !mentionInputValue.startsWith('${')) {
+            } else if (type === 'NUMBER' && !mentionInputValue.includes('${')) {
                 actualValue = parseFloat(value);
             }
 
@@ -904,10 +904,10 @@ export const useProperty = ({
                     if (
                         type === 'INTEGER' &&
                         typeof mentionInputValue === 'string' &&
-                        !mentionInputValue.startsWith('${')
+                        !mentionInputValue.includes('${')
                     ) {
                         actualValue = parseInt(defaultValueString);
-                    } else if (type === 'NUMBER' && !mentionInputValue.startsWith('${')) {
+                    } else if (type === 'NUMBER' && !mentionInputValue.includes('${')) {
                         actualValue = parseFloat(defaultValueString);
                     }
 
@@ -1221,7 +1221,7 @@ export const useProperty = ({
 
         const isExpression =
             typeof mentionInputValue === 'string' &&
-            (mentionInputValue.startsWith('=') || mentionInputValue.startsWith('${'));
+            (mentionInputValue.startsWith('=') || mentionInputValue.includes('${'));
 
         if (!stringValue || isExpression) {
             setHasError(false);


### PR DESCRIPTION
## Description
This fixes embedded datapill references not being recognized when they appear mid-string (for example: `prefix ${trigger_1.output} suffix`).

Changes are intentionally minimal and only adjust datapill detection in property mention handling:
- treat `${...}` as expression-like when it appears anywhere in the string (not only at the start)
- skip numeric coercion (`parseInt`/`parseFloat`) for INTEGER/NUMBER mention values that contain embedded datapills
- bypass mention-input error state for strings containing embedded datapills

Fixes #4290

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- `pnpm -C client exec eslint src/pages/platform/workflow-editor/components/properties/hooks/useProperty.ts`

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes