### PR TITLE
3570 client - Fix embedded ConnectDialog state management, CSS isolation, and OAuth2 scopes

### DIFF
--- a/client/public/oauth.html
+++ b/client/public/oauth.html
@@ -41,15 +41,35 @@
             return Object.fromEntries(parameters.entries());
         }
 
+        // Extract the opener's origin from the OAuth state parameter
+        function getOpenerOrigin(payload) {
+            try {
+                const state = payload.state;
+
+                if (state) {
+                    const decoded = decodeURIComponent(atob(state));
+                    const stateObj = JSON.parse(decoded);
+
+                    if (stateObj.origin) {
+                        return stateObj.origin;
+                    }
+                }
+            } catch (error) {
+                console.warn('Failed to decode state for opener origin:', error);
+            }
+
+            return window.location.origin;
+        }
+
         // Send message using available methods (postMessage, BroadcastChannel, localStorage)
         // Uses all available methods to ensure message delivery across different browser contexts
-        function sendOAuthMessage(message, messageElement) {
+        function sendOAuthMessage(message, messageElement, targetOrigin) {
             let messageSent = false;
 
             // Method 1: Try window.opener.postMessage (preferred)
             if (window.opener) {
                 try {
-                    window.opener.postMessage(message, window.location.origin);
+                    window.opener.postMessage(message, targetOrigin);
                     messageSent = true;
                 } catch (error) {
                     console.warn('Failed to send message via window.opener:', error);
@@ -102,6 +122,7 @@
             };
 
             const error = payload.error;
+            const targetOrigin = getOpenerOrigin(payload);
 
             // Handle error case
             if (error) {
@@ -111,7 +132,7 @@
                 sendOAuthMessage({
                     error: errorMessage,
                     type: OAUTH_RESPONSE
-                }, messageElement);
+                }, messageElement, targetOrigin);
             }
             // Handle success case - let parent window validate state
             else {
@@ -120,7 +141,7 @@
                 sendOAuthMessage({
                     payload,
                     type: OAUTH_RESPONSE
-                }, messageElement);
+                }, messageElement, targetOrigin);
             }
         }
 

--- a/sdks/frontend/embedded/library/react/src/components/connect-dialog/ConnectDialog.tsx
+++ b/sdks/frontend/embedded/library/react/src/components/connect-dialog/ConnectDialog.tsx
@@ -50,6 +50,7 @@ interface DialogProps {
     integration?: IntegrationType;
     isOAuth2?: boolean;
     isOpen: boolean;
+    loading?: boolean;
     properties?: PropertyType[];
     registerFormSubmit?: RegisterFormSubmitFunction;
     mergedWorkflows: MergedWorkflowType[];
@@ -65,6 +66,7 @@ const ConnectDialog = ({
     integration,
     isOAuth2 = false,
     isOpen,
+    loading = false,
     properties,
     registerFormSubmit,
     mergedWorkflows,
@@ -94,7 +96,11 @@ const ConnectDialog = ({
             <div className={styles.dialogContainer} onClick={(event) => event.stopPropagation()}>
                 <DialogHeader closeDialog={closeDialog} integration={integration} />
 
-                {integration ? (
+                {loading ? (
+                    <main className={styles.dialogContentFallback}>
+                        <p>Loading...</p>
+                    </main>
+                ) : integration ? (
                     <DialogContent
                         closeDialog={closeDialog}
                         workflowsView={workflowsView}
@@ -118,7 +124,7 @@ const ConnectDialog = ({
                     </main>
                 )}
 
-                {integration && (
+                {integration && !loading && (
                     <DialogFooter workflowsView={workflowsView} handleClick={handleClick} isOAuth2={isOAuth2} />
                 )}
 

--- a/sdks/frontend/embedded/library/react/src/components/connect-dialog/index.tsx
+++ b/sdks/frontend/embedded/library/react/src/components/connect-dialog/index.tsx
@@ -141,7 +141,7 @@ export default function useConnectDialog({
 
         return integration.workflows.map((workflow) => {
             const instanceWorkflow = currentInstance?.workflows?.find(
-                (instanceWorkflow) => instanceWorkflow.workflowUuid === workflow.workflowUuid
+                (currentWorkflow) => currentWorkflow.workflowUuid === workflow.workflowUuid
             );
 
             const serverEnabled = instanceWorkflow?.enabled ?? workflow.enabled ?? false;
@@ -302,6 +302,23 @@ export default function useConnectDialog({
         [saveOAuth2Connection]
     );
 
+    const oauth2Scope = useMemo(() => {
+        const scopes = integration?.connectionConfig?.oauth2?.scopes;
+
+        if (Array.isArray(scopes)) {
+            return scopes.join(' ');
+        }
+
+        if (scopes && typeof scopes === 'object') {
+            return Object.entries(scopes)
+                .filter(([, enabled]) => String(enabled) === 'true')
+                .map(([scopeName]) => scopeName)
+                .join(' ');
+        }
+
+        return typeof scopes === 'string' ? scopes : '';
+    }, [integration?.connectionConfig?.oauth2?.scopes]);
+
     const {getAuth} = useOAuth2({
         ...integration?.connectionConfig?.oauth2,
         authorizationUrl: integration?.connectionConfig?.oauth2?.authorizationUrl || '',
@@ -311,22 +328,7 @@ export default function useConnectDialog({
         onError: (error: string) => console.error(error),
         onTokenSuccess: handleOnTokenSuccess,
         responseType: isOAuth2AuthorizationType ? 'code' : 'token',
-        scope: (() => {
-            const scopes = integration?.connectionConfig?.oauth2?.scopes;
-
-            if (Array.isArray(scopes)) {
-                return scopes.join(' ');
-            }
-
-            if (scopes && typeof scopes === 'object') {
-                return Object.entries(scopes)
-                    .filter(([, enabled]) => String(enabled) === 'true')
-                    .map(([scopeName]) => scopeName)
-                    .join(' ');
-            }
-
-            return typeof scopes === 'string' ? scopes : '';
-        })(),
+        scope: oauth2Scope,
     });
 
     const createValidationRules = useCallback((properties: PropertyType[]): Record<string, ValidationRuleType> => {
@@ -336,10 +338,10 @@ export default function useConnectDialog({
 
         const rules: Record<string, ValidationRuleType> = {};
 
-        properties.forEach((prop) => {
-            rules[prop.name] = {
-                required: !!prop.required,
-                requiredMessage: prop.required ? `${prop.label} is required` : undefined,
+        properties.forEach((property) => {
+            rules[property.name] = {
+                required: !!property.required,
+                requiredMessage: property.required ? `${property.label} is required` : undefined,
             };
         });
 
@@ -386,7 +388,7 @@ export default function useConnectDialog({
                 onInput: (event: React.FormEvent<HTMLInputElement>) => {
                     const value = event.currentTarget.value;
 
-                    setFormValues((prev: Record<string, string>) => ({...prev, [name]: value}));
+                    setFormValues((previous: Record<string, string>) => ({...previous, [name]: value}));
                 },
             }),
             handleSubmit: (callback: (data: {[key: string]: unknown}) => void) => (event?: React.FormEvent) => {
@@ -395,10 +397,10 @@ export default function useConnectDialog({
                 }
 
                 const currentValues = Object.entries(inputRefs.current).reduce(
-                    (acc, [name, ref]) => {
-                        acc[name] = ref.value;
+                    (values, [name, ref]) => {
+                        values[name] = ref.value;
 
-                        return acc;
+                        return values;
                     },
                     {} as Record<string, string>
                 );

--- a/sdks/frontend/embedded/library/react/src/components/connect-dialog/index.tsx
+++ b/sdks/frontend/embedded/library/react/src/components/connect-dialog/index.tsx
@@ -117,6 +117,7 @@ export default function useConnectDialog({
     const [formErrors, setFormErrors] = useState<Record<string, {message: string}>>({});
     const [enabledOverrides, setEnabledOverrides] = useState<Record<string, boolean | undefined>>({});
     const [inputOverrides, setInputOverrides] = useState<Record<string, Record<string, string>>>({});
+    const [isLoading, setIsLoading] = useState(false);
     const [workflowsView, setWorkflowsView] = useState(!!integrationInstanceId);
     const [currentIntegrationInstanceId, setCurrentIntegrationInstanceId] = useState<number | undefined>(
         integrationInstanceId ? Number(integrationInstanceId) : undefined
@@ -173,7 +174,7 @@ export default function useConnectDialog({
     const saveOAuth2Connection = useCallback(
         async (payload: CodePayloadI | TokenPayloadI) => {
             try {
-                await fetch(
+                const newIntegrationInstanceId: number = await fetch(
                     `/api/embedded/v1/integrations/${integrationId}/instances`,
                     {
                         method: 'POST',
@@ -189,10 +190,12 @@ export default function useConnectDialog({
                     `/api/embedded/v1/integrations/${integrationId}`
                 );
 
-                const existingInstance = integrationData.integrationInstances?.[0];
+                const createdInstance = integrationData.integrationInstances?.find(
+                    (instance) => instance.id === newIntegrationInstanceId
+                ) || integrationData.integrationInstances?.[0];
 
-                if (existingInstance) {
-                    setCurrentIntegrationInstanceId(existingInstance.id);
+                if (createdInstance) {
+                    setCurrentIntegrationInstanceId(createdInstance.id);
                 }
 
                 setIntegration(integrationData);
@@ -207,7 +210,7 @@ export default function useConnectDialog({
     const saveNonOAuth2Connection = useCallback(
         async (formData: Record<string, string>) => {
             try {
-                await fetch(
+                const newIntegrationInstanceId: number = await fetch(
                     `/api/embedded/v1/integrations/${integrationId}/instances`,
                     {
                         method: 'POST',
@@ -223,10 +226,12 @@ export default function useConnectDialog({
                     `/api/embedded/v1/integrations/${integrationId}`
                 );
 
-                const existingInstance = integrationData.integrationInstances?.[0];
+                const createdInstance = integrationData.integrationInstances?.find(
+                    (instance) => instance.id === newIntegrationInstanceId
+                ) || integrationData.integrationInstances?.[0];
 
-                if (existingInstance) {
-                    setCurrentIntegrationInstanceId(existingInstance.id);
+                if (createdInstance) {
+                    setCurrentIntegrationInstanceId(createdInstance.id);
                 }
 
                 setIntegration(integrationData);
@@ -429,21 +434,39 @@ export default function useConnectDialog({
         setIntegration(undefined);
         setEnabledOverrides({});
         setInputOverrides({});
+        setIsLoading(true);
         setIsOpen(true);
 
-        const integrationData: IntegrationType = await fetch(`/api/embedded/v1/integrations/${integrationId}`);
+        try {
+            const integrationData: IntegrationType = await fetch(`/api/embedded/v1/integrations/${integrationId}`);
 
-        const existingInstance = integrationData.integrationInstances?.[0];
+            let targetInstance: IntegrationInstanceType | undefined;
 
-        if (existingInstance) {
-            setCurrentIntegrationInstanceId(existingInstance.id);
-            setWorkflowsView(true);
-        } else {
-            setCurrentIntegrationInstanceId(undefined);
-            setWorkflowsView(false);
+            if (integrationInstanceId && integrationData.integrationInstances) {
+                targetInstance = integrationData.integrationInstances.find(
+                    (instance) => instance.id === Number(integrationInstanceId)
+                );
+            }
+
+            if (!targetInstance) {
+                targetInstance = integrationData.integrationInstances?.[0];
+            }
+
+            if (targetInstance) {
+                setCurrentIntegrationInstanceId(targetInstance.id);
+                setWorkflowsView(true);
+            } else if (integrationInstanceId) {
+                setCurrentIntegrationInstanceId(Number(integrationInstanceId));
+                setWorkflowsView(true);
+            } else {
+                setCurrentIntegrationInstanceId(undefined);
+                setWorkflowsView(false);
+            }
+
+            setIntegration(integrationData);
+        } finally {
+            setIsLoading(false);
         }
-
-        setIntegration(integrationData);
     };
 
     const closeDialog = () => {
@@ -459,25 +482,24 @@ export default function useConnectDialog({
             return;
         }
 
-        try {
-            await fetch(`/api/embedded/v1/integration-instances/${currentIntegrationInstanceId}`, {
-                method: 'DELETE',
-            });
+        await fetch(`/api/embedded/v1/integration-instances/${currentIntegrationInstanceId}`, {
+            method: 'DELETE',
+        });
 
-            setCurrentIntegrationInstanceId(undefined);
-            setFormValues({});
-            setInputOverrides({});
-            setEnabledOverrides({});
-            setWorkflowsView(false);
-        } catch (error) {
-            console.error('Failed to disconnect:', error);
-        }
+        setCurrentIntegrationInstanceId(undefined);
+        setFormValues({});
+        setInputOverrides({});
+        setEnabledOverrides({});
+        debouncedFetchesRef.current = {};
+        setWorkflowsView(false);
     }, [fetch, currentIntegrationInstanceId]);
 
     const handleClick = useCallback(
         (event: React.MouseEvent<HTMLButtonElement>) => {
             if ((event.target as HTMLButtonElement).name === 'disconnectButton') {
-                handleDisconnect().then(() => closeDialog());
+                handleDisconnect()
+                    .then(() => closeDialog())
+                    .catch((error) => console.error('Failed to disconnect:', error));
 
                 return;
             }
@@ -548,7 +570,7 @@ export default function useConnectDialog({
                         ...inputOverridesRef.current[workflowUuid],
                     };
 
-                    fetch(
+                    void fetch(
                         `/api/embedded/v1/integration-instances/${instanceId}/workflows/${workflowUuid}`,
                         {
                             body: {
@@ -556,7 +578,7 @@ export default function useConnectDialog({
                             },
                             method: 'PUT',
                         }
-                    );
+                    ).catch((error) => console.error('Failed to save workflow inputs:', error));
                 }, 600);
             }
 
@@ -616,7 +638,7 @@ export default function useConnectDialog({
                     integration={integration}
                     isOAuth2={isOAuth2}
                     isOpen={isOpen}
-                    loading={!integration}
+                    loading={isLoading}
                     properties={integration?.connectionConfig?.inputs}
                     registerFormSubmit={registerFormSubmit}
                     workflowsView={workflowsView}

--- a/sdks/frontend/embedded/library/react/src/components/connect-dialog/index.tsx
+++ b/sdks/frontend/embedded/library/react/src/components/connect-dialog/index.tsx
@@ -7,8 +7,8 @@ import {
     FormSubmitHandler,
     FormType,
     IntegrationInstanceType,
+    IntegrationInstanceWorkflowType,
     IntegrationType,
-    IntegrationWorkflowType,
     MergedWorkflowType,
     PropertyType,
     RegisterFormSubmitFunction,
@@ -131,39 +131,30 @@ export default function useConnectDialog({
 
     // Merge integration workflows with instance workflows to get complete workflow data, because the backend is incomplete
     const mergedWorkflows: MergedWorkflowType[] = useMemo(() => {
-        if (!integration?.workflows || !integration?.integrationInstances) {
+        if (!integration?.workflows) {
             return [];
         }
 
-        const currentInstance = integration.integrationInstances.find(
+        const currentInstance = integration.integrationInstances?.find(
             (instance: IntegrationInstanceType) => instance.id === currentIntegrationInstanceId
         );
 
-        const workflows = currentInstance?.workflows || integration.workflows;
-
-        return workflows.map((workflow) => {
+        return integration.workflows.map((workflow) => {
             const instanceWorkflow = currentInstance?.workflows?.find(
                 (instanceWorkflow) => instanceWorkflow.workflowUuid === workflow.workflowUuid
             );
 
-            const baseWorkflow = integration.workflows?.find(
-                (integrationWorkflow) => integrationWorkflow.workflowUuid === workflow.workflowUuid
-            );
-
-            const serverEnabled =
-                instanceWorkflow?.enabled ?? (baseWorkflow as IntegrationWorkflowType | undefined)?.enabled ?? false;
+            const serverEnabled = instanceWorkflow?.enabled ?? workflow.enabled ?? false;
 
             const effectiveEnabled = enabledOverrides[workflow.workflowUuid] ?? serverEnabled;
 
             const workflowInputOverrides = inputOverrides[workflow.workflowUuid];
 
             return {
-                ...baseWorkflow,
-                label: baseWorkflow?.label,
-                workflowUuid: baseWorkflow?.workflowUuid ?? workflow.workflowUuid,
+                ...workflow,
                 enabled: effectiveEnabled,
-                inputs: Array.isArray(baseWorkflow?.inputs)
-                    ? baseWorkflow!.inputs.map((input: WorkflowInputType) => ({
+                inputs: Array.isArray(workflow.inputs)
+                    ? workflow.inputs.map((input: WorkflowInputType) => ({
                           ...input,
                           value:
                               workflowInputOverrides?.[input.name] ??
@@ -182,7 +173,7 @@ export default function useConnectDialog({
     const saveOAuth2Connection = useCallback(
         async (payload: CodePayloadI | TokenPayloadI) => {
             try {
-                const newIntegrationInstanceId: number = await fetch(
+                await fetch(
                     `/api/embedded/v1/integrations/${integrationId}/instances`,
                     {
                         method: 'POST',
@@ -194,12 +185,17 @@ export default function useConnectDialog({
                     }
                 );
 
-                if (typeof newIntegrationInstanceId !== 'number' || isNaN(newIntegrationInstanceId)) {
-                    throw new Error('Invalid integration instance ID received from API');
+                const integrationData: IntegrationType = await fetch(
+                    `/api/embedded/v1/integrations/${integrationId}`
+                );
+
+                const existingInstance = integrationData.integrationInstances?.[0];
+
+                if (existingInstance) {
+                    setCurrentIntegrationInstanceId(existingInstance.id);
                 }
 
-                setCurrentIntegrationInstanceId(newIntegrationInstanceId);
-
+                setIntegration(integrationData);
                 setWorkflowsView(true);
             } catch (error) {
                 console.error('Failed to save OAuth2 connection:', error);
@@ -211,7 +207,7 @@ export default function useConnectDialog({
     const saveNonOAuth2Connection = useCallback(
         async (formData: Record<string, string>) => {
             try {
-                const newIntegrationInstanceId: number = await fetch(
+                await fetch(
                     `/api/embedded/v1/integrations/${integrationId}/instances`,
                     {
                         method: 'POST',
@@ -223,11 +219,17 @@ export default function useConnectDialog({
                     }
                 );
 
-                if (typeof newIntegrationInstanceId !== 'number' || isNaN(newIntegrationInstanceId)) {
-                    throw new Error('Invalid integration instance ID received from API');
+                const integrationData: IntegrationType = await fetch(
+                    `/api/embedded/v1/integrations/${integrationId}`
+                );
+
+                const existingInstance = integrationData.integrationInstances?.[0];
+
+                if (existingInstance) {
+                    setCurrentIntegrationInstanceId(existingInstance.id);
                 }
 
-                setCurrentIntegrationInstanceId(newIntegrationInstanceId);
+                setIntegration(integrationData);
                 setWorkflowsView(true);
             } catch (error) {
                 console.error('Failed to save non-OAuth2 connection:', error);
@@ -309,7 +311,22 @@ export default function useConnectDialog({
         onError: (error: string) => console.error(error),
         onTokenSuccess: handleOnTokenSuccess,
         responseType: isOAuth2AuthorizationType ? 'code' : 'token',
-        scope: integration?.connectionConfig?.oauth2?.scopes?.join(' ') || '',
+        scope: (() => {
+            const scopes = integration?.connectionConfig?.oauth2?.scopes;
+
+            if (Array.isArray(scopes)) {
+                return scopes.join(' ');
+            }
+
+            if (scopes && typeof scopes === 'object') {
+                return Object.entries(scopes)
+                    .filter(([, enabled]) => String(enabled) === 'true')
+                    .map(([scopeName]) => scopeName)
+                    .join(' ');
+            }
+
+            return typeof scopes === 'string' ? scopes : '';
+        })(),
     });
 
     const createValidationRules = useCallback((properties: PropertyType[]): Record<string, ValidationRuleType> => {
@@ -407,9 +424,22 @@ export default function useConnectDialog({
     }, [formErrors, formValues, validateForm, validationRules]);
 
     const openDialog = async () => {
+        setIntegration(undefined);
+        setEnabledOverrides({});
+        setInputOverrides({});
         setIsOpen(true);
 
         const integrationData: IntegrationType = await fetch(`/api/embedded/v1/integrations/${integrationId}`);
+
+        const existingInstance = integrationData.integrationInstances?.[0];
+
+        if (existingInstance) {
+            setCurrentIntegrationInstanceId(existingInstance.id);
+            setWorkflowsView(true);
+        } else {
+            setCurrentIntegrationInstanceId(undefined);
+            setWorkflowsView(false);
+        }
 
         setIntegration(integrationData);
     };
@@ -432,8 +462,10 @@ export default function useConnectDialog({
                 method: 'DELETE',
             });
 
+            setCurrentIntegrationInstanceId(undefined);
             setFormValues({});
             setInputOverrides({});
+            setEnabledOverrides({});
             setWorkflowsView(false);
         } catch (error) {
             console.error('Failed to disconnect:', error);
@@ -443,7 +475,7 @@ export default function useConnectDialog({
     const handleClick = useCallback(
         (event: React.MouseEvent<HTMLButtonElement>) => {
             if ((event.target as HTMLButtonElement).name === 'disconnectButton') {
-                handleDisconnect();
+                handleDisconnect().then(() => closeDialog());
 
                 return;
             }
@@ -459,45 +491,76 @@ export default function useConnectDialog({
 
     const debouncedFetchesRef = useRef<Record<string, (...args: unknown[]) => void>>({});
 
+    const currentIntegrationInstanceIdRef = useRef(currentIntegrationInstanceId);
+    const inputOverridesRef = useRef(inputOverrides);
+    const integrationRef = useRef(integration);
+
+    currentIntegrationInstanceIdRef.current = currentIntegrationInstanceId;
+    inputOverridesRef.current = inputOverrides;
+    integrationRef.current = integration;
+
     const handleWorkflowInputChange = useCallback(
         (workflowUuid: string, inputName: string, value: string) => {
-            setInputOverrides((previous) => ({
-                ...previous,
-                [workflowUuid]: {
-                    ...previous[workflowUuid],
-                    [inputName]: value,
-                },
-            }));
+            setInputOverrides((previous) => {
+                const updated = {
+                    ...previous,
+                    [workflowUuid]: {
+                        ...previous[workflowUuid],
+                        [inputName]: value,
+                    },
+                };
 
-            if (!currentIntegrationInstanceId || isNaN(currentIntegrationInstanceId)) {
+                inputOverridesRef.current = updated;
+
+                return updated;
+            });
+
+            if (!currentIntegrationInstanceIdRef.current || isNaN(currentIntegrationInstanceIdRef.current)) {
                 console.error('Invalid integration instance ID');
 
                 return;
             }
 
-            const body = {
-                inputs: {
-                    [inputName]: value,
-                },
-            };
-
-            const debouncedFetchKey = `${workflowUuid}_${inputName}`;
+            const debouncedFetchKey = workflowUuid;
 
             if (!debouncedFetchesRef.current[debouncedFetchKey]) {
-                debouncedFetchesRef.current[debouncedFetchKey] = debounce((payload) => {
+                debouncedFetchesRef.current[debouncedFetchKey] = debounce(() => {
+                    const instanceId = currentIntegrationInstanceIdRef.current;
+
+                    if (!instanceId) {
+                        return;
+                    }
+
+                    const currentIntegration = integrationRef.current;
+                    const currentInstance = currentIntegration?.integrationInstances?.find(
+                        (instance: IntegrationInstanceType) => instance.id === instanceId
+                    );
+                    const serverInputs =
+                        (currentInstance?.workflows?.find(
+                            (workflow: IntegrationInstanceWorkflowType) =>
+                                workflow.workflowUuid === workflowUuid
+                        )?.inputs as Record<string, string> | undefined) || {};
+
+                    const mergedInputs = {
+                        ...serverInputs,
+                        ...inputOverridesRef.current[workflowUuid],
+                    };
+
                     fetch(
-                        `/api/embedded/v1/integration-instances/${currentIntegrationInstanceId}/workflows/${workflowUuid}`,
+                        `/api/embedded/v1/integration-instances/${instanceId}/workflows/${workflowUuid}`,
                         {
-                            body: payload as object,
+                            body: {
+                                inputs: mergedInputs,
+                            },
                             method: 'PUT',
                         }
                     );
                 }, 600);
             }
 
-            debouncedFetchesRef.current[debouncedFetchKey](body);
+            debouncedFetchesRef.current[debouncedFetchKey]();
         },
-        [fetch, currentIntegrationInstanceId]
+        [fetch]
     );
 
     // Create portal container only once
@@ -551,6 +614,7 @@ export default function useConnectDialog({
                     integration={integration}
                     isOAuth2={isOAuth2}
                     isOpen={isOpen}
+                    loading={!integration}
                     properties={integration?.connectionConfig?.inputs}
                     registerFormSubmit={registerFormSubmit}
                     workflowsView={workflowsView}

--- a/sdks/frontend/embedded/library/react/src/components/connect-dialog/styles.module.css
+++ b/sdks/frontend/embedded/library/react/src/components/connect-dialog/styles.module.css
@@ -32,6 +32,7 @@ p {
     font-size: 0.875rem;
     font-weight: 500;
     color: white;
+    margin: 0;
     padding: 8px 16px;
     line-height: 1.25rem;
     outline: none;
@@ -136,6 +137,8 @@ p {
     border: none;
     border-radius: 0.375rem;
     cursor: pointer;
+    margin-left: auto;
+    margin-right: 0;
     padding: 0.5rem;
     transition: all 0.2s;
     background-color: transparent;
@@ -217,6 +220,7 @@ p {
 
 .dialogInputField input,
 .dialogInputField select {
+    box-sizing: border-box;
     display: flex;
     border-radius: 0.375rem;
     border: 1px solid #e5e7eb;
@@ -224,6 +228,7 @@ p {
     padding: 0.5rem 0.75rem;
     line-height: 1.25rem;
     font-size: 0.875rem;
+    width: 100%;
 }
 
 .dialogInputField .inputError {
@@ -343,7 +348,6 @@ p {
 
 .workflowInputsContainer ul {
     width: 100%;
-    max-width: 75%;
 }
 
 .workflowInputsContainer .noInputsMessage {

--- a/sdks/frontend/embedded/library/react/src/components/connect-dialog/types.ts
+++ b/sdks/frontend/embedded/library/react/src/components/connect-dialog/types.ts
@@ -5,7 +5,7 @@ export interface IntegrationType {
         inputs?: PropertyType[];
         oauth2?: {
             authorizationUrl: string;
-            scopes: string[];
+            scopes: Record<string, string> | string[] | string;
             redirectUri: string;
             clientId: string;
         };

--- a/sdks/frontend/embedded/package-lock.json
+++ b/sdks/frontend/embedded/package-lock.json
@@ -13,6 +13,7 @@
             ],
             "devDependencies": {
                 "concurrently": "^9.1.2",
+                "prettier": "3.5.2",
                 "verdaccio": "^6.2.4"
             }
         },


### PR DESCRIPTION
## Summary
- Fix ConnectDialog state management for instance sync, disconnect, and workflow inputs
- Add CSS resets to protect embedded ConnectDialog from host page styles
- Fix OAuth2 scopes parsing and cross-origin postMessage in embedded SDK
- Update embedded SDK package-lock.json

## Test plan
- [ ] Test embedded ConnectDialog opens and renders correctly in host pages with custom CSS
- [ ] Test OAuth2 connection flow with scopes (both array and object formats)
- [ ] Test instance sync, disconnect, and reconnect flows
- [ ] Test workflow input changes are debounced and saved correctly
- [ ] Test cross-origin postMessage works for OAuth2 redirect

🤖 Generated with [Claude Code](https://claude.com/claude-code)