### PR TITLE
4404 client - Use server response from updateWorkflow instead of refetching

### DIFF
--- a/client/src/ee/shared/mutations/embedded/workflows.mutations.ts
+++ b/client/src/ee/shared/mutations/embedded/workflows.mutations.ts
@@ -3,6 +3,7 @@ import {
     DeleteWorkflowRequest,
     IntegrationApi,
     UpdateWorkflowRequest,
+    Workflow,
     WorkflowApi,
 } from '@/ee/shared/middleware/embedded/configuration';
 import {useMutation} from '@tanstack/react-query';
@@ -36,7 +37,7 @@ export const useDeleteWorkflowMutation = (mutationProps?: DeleteWorkflowMutation
     });
 
 interface UpdateWorkflowMutationProps {
-    onSuccess?: (result: void, variables: UpdateWorkflowRequest) => void;
+    onSuccess?: (result: Workflow, variables: UpdateWorkflowRequest) => void;
     onError?: (error: Error, variables: UpdateWorkflowRequest) => void;
 }
 

--- a/client/src/pages/platform/workflow-editor/utils/saveWorkflowDefinition.test.ts
+++ b/client/src/pages/platform/workflow-editor/utils/saveWorkflowDefinition.test.ts
@@ -35,6 +35,7 @@ vi.mock('@/pages/platform/workflow-editor/stores/useWorkflowTestChatStore', () =
 
 function makeWorkflowState(tasks: Array<Record<string, unknown>> = [], triggers: Array<Record<string, unknown>> = []) {
     return {
+        setWorkflow: vi.fn(),
         workflow: {
             definition: JSON.stringify({tasks, triggers}, null, SPACE),
             id: 'workflow-1',

--- a/client/src/pages/platform/workflow-editor/utils/saveWorkflowDefinition.ts
+++ b/client/src/pages/platform/workflow-editor/utils/saveWorkflowDefinition.ts
@@ -1,7 +1,12 @@
 import {SPACE} from '@/shared/constants';
 import {Workflow, WorkflowTask, WorkflowTrigger} from '@/shared/middleware/platform/configuration';
-import {BranchCaseType, NodeDataType, TaskDispatcherContextType, WorkflowDefinitionType} from '@/shared/types';
-import {UseMutationResult} from '@tanstack/react-query';
+import {
+    BranchCaseType,
+    NodeDataType,
+    TaskDispatcherContextType,
+    UpdateWorkflowMutationType,
+    WorkflowDefinitionType,
+} from '@/shared/types';
 
 import useWorkflowDataStore from '../stores/useWorkflowDataStore';
 import getRecursivelyUpdatedTasks from './getRecursivelyUpdatedTasks';
@@ -9,26 +14,19 @@ import {getTask} from './getTask';
 import insertTaskDispatcherSubtask from './insertTaskDispatcherSubtask';
 import {isWorkflowMutating, setWorkflowMutating} from './workflowMutationGuard';
 
-type UpdateWorkflowRequestType = {
-    id: string;
-    workflow: Workflow;
-};
-
 interface SaveWorkflowDefinitionProps {
     decorative?: boolean;
-    invalidateWorkflowQueries?: () => void;
     nodeData?: NodeDataType;
     nodeIndex?: number;
     onSuccess?: () => void;
     placeholderId?: string;
     taskDispatcherContext?: TaskDispatcherContextType;
-    updateWorkflowMutation: UseMutationResult<void, Error, UpdateWorkflowRequestType, unknown>;
+    updateWorkflowMutation: UpdateWorkflowMutationType;
     updatedWorkflowTasks?: Array<WorkflowTask>;
 }
 
 export default async function saveWorkflowDefinition({
     decorative,
-    invalidateWorkflowQueries,
     nodeData,
     nodeIndex,
     onSuccess,
@@ -75,7 +73,6 @@ export default async function saveWorkflowDefinition({
 
         executeWorkflowMutation({
             definitionUpdate: {triggers: [newTrigger]},
-            invalidateWorkflowQueries,
             onSuccess: () => {
                 if (onSuccess) {
                     onSuccess();
@@ -230,7 +227,6 @@ export default async function saveWorkflowDefinition({
 
     executeWorkflowMutation({
         definitionUpdate: {tasks: updatedWorkflowDefinitionTasks},
-        invalidateWorkflowQueries,
         onSuccess,
         updateWorkflowMutation,
         workflow,
@@ -243,16 +239,14 @@ interface ExecuteWorkflowMutationProps {
         tasks?: Array<WorkflowTask>;
         triggers?: Array<WorkflowTrigger>;
     };
-    invalidateWorkflowQueries?: () => void;
     onSuccess?: () => void;
-    updateWorkflowMutation: UseMutationResult<void, Error, UpdateWorkflowRequestType, unknown>;
+    updateWorkflowMutation: UpdateWorkflowMutationType;
     workflow: Workflow;
     workflowDefinition: WorkflowDefinitionType;
 }
 
 function executeWorkflowMutation({
     definitionUpdate,
-    invalidateWorkflowQueries,
     onSuccess,
     updateWorkflowMutation,
     workflow,
@@ -262,34 +256,52 @@ function executeWorkflowMutation({
         return;
     }
 
+    const updatedDefinition = JSON.stringify(
+        {
+            ...workflowDefinition,
+            ...definitionUpdate,
+        },
+        null,
+        SPACE
+    );
+
+    // Optimistic UI: update definition string immediately so the store reflects the pending change.
+    // We do NOT update tasks/triggers optimistically because workflow.tasks is a flattened list
+    // (including sub-tasks extracted from task dispatcher parameters) while definitionUpdate.tasks
+    // is hierarchical (sub-tasks nested in parameters). Mapping between these structures would
+    // drop sub-tasks and break edge computation in the layout.
+    const previousWorkflow = workflow;
+
+    useWorkflowDataStore.getState().setWorkflow({
+        ...workflow,
+        definition: updatedDefinition,
+    });
+
     setWorkflowMutating(workflow.id!, true);
 
     updateWorkflowMutation.mutate(
         {
             id: workflow.id!,
             workflow: {
-                definition: JSON.stringify(
-                    {
-                        ...workflowDefinition,
-                        ...definitionUpdate,
-                    },
-                    null,
-                    SPACE
-                ),
+                definition: updatedDefinition,
                 version: workflow.version,
             },
         },
         {
+            onError: () => {
+                useWorkflowDataStore.getState().setWorkflow(previousWorkflow);
+            },
             onSettled: () => {
                 setWorkflowMutating(workflow.id!, false);
             },
-            onSuccess: () => {
+            onSuccess: (updatedWorkflow) => {
+                useWorkflowDataStore.getState().setWorkflow({
+                    ...updatedWorkflow,
+                    definition: updatedDefinition,
+                });
+
                 if (onSuccess) {
                     onSuccess();
-                }
-
-                if (invalidateWorkflowQueries) {
-                    invalidateWorkflowQueries();
                 }
             },
         }

--- a/client/src/shared/mutations/automation/workflows.mutations.ts
+++ b/client/src/shared/mutations/automation/workflows.mutations.ts
@@ -5,6 +5,7 @@ import {
     DuplicateWorkflow200Response,
     DuplicateWorkflowRequest,
     UpdateWorkflowRequest,
+    Workflow,
     WorkflowApi,
 } from '@/shared/middleware/automation/configuration';
 import {useMutation} from '@tanstack/react-query';
@@ -53,7 +54,7 @@ export const useDuplicateWorkflowMutation = (mutationProps?: DuplicateWorkflowMu
     });
 
 interface UpdateWorkflowMutationProps {
-    onSuccess?: (result: void, variables: UpdateWorkflowRequest) => void;
+    onSuccess?: (result: Workflow, variables: UpdateWorkflowRequest) => void;
     onError?: (error: Error, variables: UpdateWorkflowRequest) => void;
 }
 

--- a/client/src/shared/mutations/platform/workflows.mutations.ts
+++ b/client/src/shared/mutations/platform/workflows.mutations.ts
@@ -8,7 +8,7 @@ export interface UpdateWorkflowRequestI {
 }
 
 interface UpdateWorkflowMutationPropsI {
-    onSuccess?: (result: void, variables: UpdateWorkflowRequestI) => void;
+    onSuccess?: (result: Workflow, variables: UpdateWorkflowRequestI) => void;
     onError?: (error: Error, variables: UpdateWorkflowRequestI) => void;
 }
 
@@ -26,7 +26,7 @@ const useUpdatePlatformWorkflowMutation = ({
 }: {
     useUpdateWorkflowMutation: (
         mutationProps?: UpdateWorkflowMutationPropsI | undefined
-    ) => UseMutationResult<void, Error, UpdateWorkflowRequestI, unknown>;
+    ) => UseMutationResult<Workflow, Error, UpdateWorkflowRequestI, unknown>;
     workflowId: string;
     workflowKeys: WorkflowKeysI;
     onError?: () => void;
@@ -45,10 +45,6 @@ const useUpdatePlatformWorkflowMutation = ({
             }
         },
         onSuccess: () => {
-            queryClient.invalidateQueries({
-                queryKey: workflowKeys.workflow(workflowId),
-            });
-
             queryClient.invalidateQueries({
                 queryKey: WorkflowTestConfigurationKeys.workflowTestConfiguration(workflowId),
             });

--- a/client/src/shared/types.ts
+++ b/client/src/shared/types.ts
@@ -25,6 +25,7 @@ import {
     TriggerDefinition,
     TriggerType,
     ValueProperty,
+    Workflow,
     WorkflowInput,
     WorkflowTask,
 } from '@/shared/middleware/platform/configuration';
@@ -357,7 +358,7 @@ export type PropertyAllType = Omit<PropertyTypeAllType, 'controlType'> & {
     properties?: Array<PropertyAllType>;
 };
 
-export type UpdateWorkflowMutationType = UseMutationResult<void, Error, UpdateWorkflowRequestI, unknown>;
+export type UpdateWorkflowMutationType = UseMutationResult<Workflow, Error, UpdateWorkflowRequestI, unknown>;
 
 export type TaskDispatcherContextType = {
     branchIndex?: number;


### PR DESCRIPTION
Update the mutation hooks and saveWorkflowDefinition to use the Workflow
returned by the server PUT response. This eliminates the refetch that
previously happened after every workflow save.

- UpdateWorkflowMutationType now expects Workflow return from mutate
- useUpdatePlatformWorkflowMutation removes workflow query invalidation
  on success (keeps it on error for rollback safety)
- executeWorkflowMutation applies optimistic definition update before
  the mutation, then updates the store with the full server response
  on success, with rollback on error
- Automation/embedded mutation hooks updated for new return type

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
