### PR TITLE
4404 client - Remove invalidateWorkflowQueries prop from saveWorkflowDefinition callers

### DIFF
--- a/client/src/pages/automation/workflow-executions/components/workflow-execution-sheet/WorkflowExecutionSheetWorkflowPanel.tsx
+++ b/client/src/pages/automation/workflow-executions/components/workflow-execution-sheet/WorkflowExecutionSheetWorkflowPanel.tsx
@@ -39,7 +39,6 @@ const WorkflowExecutionSheetWorkflowPanel = ({workflowExecution}: {workflowExecu
                         <WorkflowEditor
                             componentDefinitions={componentDefinitions}
                             customCanvasWidth={canvasWidth}
-                            invalidateWorkflowQueries={() => {}}
                             readOnlyWorkflow={workflowDetails}
                             taskDispatcherDefinitions={taskDispatcherDefinitions}
                         />

--- a/client/src/pages/platform/cluster-element-editor/ai-agent-editor/AiAgentEditor.tsx
+++ b/client/src/pages/platform/cluster-element-editor/ai-agent-editor/AiAgentEditor.tsx
@@ -37,7 +37,7 @@ export default function AiAgentEditor({
     );
     const dataPillPanelOpen = useDataPillPanelStore((state) => state.dataPillPanelOpen);
 
-    const {invalidateWorkflowQueries, updateWorkflowMutation} = useWorkflowEditor();
+    const {updateWorkflowMutation} = useWorkflowEditor();
 
     const handleNodeDetailsPanelClose = useCallback(() => {
         useWorkflowNodeDetailsPanelStore.getState().setAiAgentNodeDetailsPanelOpen(false);
@@ -89,7 +89,6 @@ export default function AiAgentEditor({
                             <div className="absolute inset-y-0 left-0 w-[460px] overflow-hidden rounded-lg border border-stroke-neutral-secondary bg-background shadow-lg">
                                 <WorkflowNodeDetailsPanel
                                     className="relative inset-auto z-0 size-full max-w-none rounded-none border-0"
-                                    invalidateWorkflowQueries={invalidateWorkflowQueries!}
                                     onClose={handleNodeDetailsPanelClose}
                                     panelOpen
                                     previousComponentDefinitions={previousComponentDefinitions}

--- a/client/src/pages/platform/cluster-element-editor/data-stream-editor/hooks/useClusterElementStep.ts
+++ b/client/src/pages/platform/cluster-element-editor/data-stream-editor/hooks/useClusterElementStep.ts
@@ -62,7 +62,7 @@ export default function useClusterElementStep(elementType: ClusterElementStepTyp
         }))
     );
 
-    const {invalidateWorkflowQueries, updateWorkflowMutation} = useWorkflowEditor();
+    const {updateWorkflowMutation} = useWorkflowEditor();
 
     const queryClient = useQueryClient();
 
@@ -309,7 +309,6 @@ export default function useClusterElementStep(elementType: ClusterElementStepTyp
             }
 
             saveWorkflowDefinition({
-                invalidateWorkflowQueries,
                 nodeData: {
                     ...updatedNodeData,
                     componentName: rootClusterElementNodeData.componentName,
@@ -334,7 +333,6 @@ export default function useClusterElementStep(elementType: ClusterElementStepTyp
         [
             currentNode,
             elementType,
-            invalidateWorkflowQueries,
             mainClusterRootComponentDefinition,
             queryClient,
             rootClusterElementNodeData,

--- a/client/src/pages/platform/cluster-element-editor/hooks/useClusterElementsWorkflowEditor.ts
+++ b/client/src/pages/platform/cluster-element-editor/hooks/useClusterElementsWorkflowEditor.ts
@@ -24,7 +24,7 @@ const useClusterElementsWorkflowEditor = () => {
     );
     const workflow = useWorkflowDataStore((state) => state.workflow);
 
-    const {invalidateWorkflowQueries, updateWorkflowMutation} = useWorkflowEditor();
+    const {updateWorkflowMutation} = useWorkflowEditor();
 
     const previousNodePositionsRef = useRef<Record<string, {x: number; y: number}>>({});
 
@@ -72,7 +72,6 @@ const useClusterElementsWorkflowEditor = () => {
                     setTimeout(() => {
                         if (!updateWorkflowMutation.isPending) {
                             saveClusterElementNodesPosition({
-                                invalidateWorkflowQueries,
                                 movedClusterElementId: change.id,
                                 updateWorkflowMutation,
                                 workflow,
@@ -111,10 +110,9 @@ const useClusterElementsWorkflowEditor = () => {
         resetPendingRef.current = true;
 
         clearAllClusterElementPositions({
-            invalidateWorkflowQueries,
             updateWorkflowMutation,
         });
-    }, [invalidateWorkflowQueries, updateWorkflowMutation]);
+    }, [updateWorkflowMutation]);
 
     useClusterElementsLayout();
 

--- a/client/src/pages/platform/workflow-editor/WorkflowEditorLayout.tsx
+++ b/client/src/pages/platform/workflow-editor/WorkflowEditorLayout.tsx
@@ -79,6 +79,7 @@ const WorkflowEditorLayout = ({
         handleWorkflowCodeEditorClick,
         handleWorkflowInputsClick,
         handleWorkflowOutputsClick,
+        isWorkflowNodeOutputsPending,
         previousComponentDefinitions,
         taskDispatcherDefinitions,
         testConfigurationDisabled,
@@ -107,7 +108,6 @@ const WorkflowEditorLayout = ({
                     <Suspense>
                         <WorkflowEditor
                             componentDefinitions={componentDefinitions}
-                            invalidateWorkflowQueries={invalidateWorkflowQueries!}
                             leftSidebarOpen={leftSidebarOpen}
                             taskDispatcherDefinitions={taskDispatcherDefinitions}
                         />
@@ -143,7 +143,6 @@ const WorkflowEditorLayout = ({
 
             {currentComponent && !isMainRootClusterElement && !clusterElementsCanvasOpen && (
                 <WorkflowNodeDetailsPanel
-                    invalidateWorkflowQueries={invalidateWorkflowQueries!}
                     previousComponentDefinitions={previousComponentDefinitions}
                     updateWorkflowMutation={updateWorkflowMutation!}
                     workflowNodeOutputs={filteredWorkflowNodeOutputs ?? []}
@@ -152,7 +151,6 @@ const WorkflowEditorLayout = ({
 
             {clusterElementsCanvasOpen && (
                 <ClusterElementsCanvasDialog
-                    invalidateWorkflowQueries={invalidateWorkflowQueries!}
                     onOpenChange={handleClusterElementsCanvasOpenChange}
                     open={clusterElementsCanvasOpen}
                     previousComponentDefinitions={previousComponentDefinitions}
@@ -166,6 +164,7 @@ const WorkflowEditorLayout = ({
             {currentComponent && !isMainRootClusterElement && !clusterElementsCanvasOpen && dataPillPanelOpen && (
                 <Suspense fallback={<DataPillPanelSkeleton />}>
                     <DataPillPanel
+                        loading={isWorkflowNodeOutputsPending}
                         previousComponentDefinitions={previousComponentDefinitions}
                         workflowNodeOutputs={filteredWorkflowNodeOutputs ?? []}
                     />

--- a/client/src/pages/platform/workflow-editor/components/ClusterElementsCanvasDialog.tsx
+++ b/client/src/pages/platform/workflow-editor/components/ClusterElementsCanvasDialog.tsx
@@ -23,7 +23,6 @@ import {useShallow} from 'zustand/react/shallow';
 const DataPillPanel = lazy(() => import('./datapills/DataPillPanel'));
 
 interface ClusterElementsCanvasDialogProps {
-    invalidateWorkflowQueries: () => void;
     onOpenChange: (open: boolean) => void;
     open: boolean;
     previousComponentDefinitions: ComponentDefinitionBasic[];
@@ -32,7 +31,6 @@ interface ClusterElementsCanvasDialogProps {
 }
 
 const ClusterElementsCanvasDialog = ({
-    invalidateWorkflowQueries,
     onOpenChange,
     open,
     previousComponentDefinitions,
@@ -190,7 +188,6 @@ const ClusterElementsCanvasDialog = ({
                                     <Button icon={<XIcon />} size="icon" title="Close the canvas" variant="ghost" />
                                 </DialogClose>
                             }
-                            invalidateWorkflowQueries={invalidateWorkflowQueries}
                             previousComponentDefinitions={previousComponentDefinitions}
                             updateWorkflowMutation={updateWorkflowMutation}
                             workflowNodeOutputs={workflowNodeOutputs}

--- a/client/src/pages/platform/workflow-editor/components/WorkflowEditor.tsx
+++ b/client/src/pages/platform/workflow-editor/components/WorkflowEditor.tsx
@@ -26,7 +26,6 @@ type ConditionalWorkflowEditorPropsType =
 type WorkflowEditorPropsType = {
     componentDefinitions: ComponentDefinitionBasic[];
     customCanvasWidth?: number;
-    invalidateWorkflowQueries: () => void;
     leftSidebarOpen?: boolean;
     taskDispatcherDefinitions: TaskDispatcherDefinitionBasic[];
 };
@@ -34,7 +33,6 @@ type WorkflowEditorPropsType = {
 const WorkflowEditor = ({
     componentDefinitions,
     customCanvasWidth,
-    invalidateWorkflowQueries,
     leftSidebarOpen,
     readOnlyWorkflow,
     taskDispatcherDefinitions,
@@ -65,7 +63,6 @@ const WorkflowEditor = ({
     } = useWorkflowEditorCanvas({
         componentDefinitions,
         customCanvasWidth,
-        invalidateWorkflowQueries,
         leftSidebarOpen,
         readOnlyWorkflow,
         taskDispatcherDefinitions,

--- a/client/src/pages/platform/workflow-editor/components/WorkflowNodeDetailsPanel.tsx
+++ b/client/src/pages/platform/workflow-editor/components/WorkflowNodeDetailsPanel.tsx
@@ -25,7 +25,6 @@ import useWorkflowNodeDetailsPanel from './hooks/useWorkflowNodeDetailsPanel';
 interface WorkflowNodeDetailsPanelProps {
     className?: string;
     closeButton?: ReactNode;
-    invalidateWorkflowQueries: () => void;
     onClose?: () => void;
     panelOpen?: boolean;
     previousComponentDefinitions: Array<ComponentDefinitionBasic>;
@@ -36,7 +35,6 @@ interface WorkflowNodeDetailsPanelProps {
 const WorkflowNodeDetailsPanel = ({
     className,
     closeButton,
-    invalidateWorkflowQueries,
     onClose,
     panelOpen,
     previousComponentDefinitions,
@@ -72,7 +70,6 @@ const WorkflowNodeDetailsPanel = ({
         workflowNodeDetailsPanelOpen,
         workflowTestConfigurationConnections,
     } = useWorkflowNodeDetailsPanel({
-        invalidateWorkflowQueries,
         previousComponentDefinitions,
         updateWorkflowMutation,
         workflowNodeOutputs,
@@ -217,7 +214,6 @@ const WorkflowNodeDetailsPanel = ({
                                     {activeTab === 'description' &&
                                         (nodeDefinition ? (
                                             <DescriptionTab
-                                                invalidateWorkflowQueries={invalidateWorkflowQueries}
                                                 key={`${currentNode?.componentName}-${currentNode?.type}_description`}
                                                 nodeDefinition={nodeDefinition}
                                                 updateWorkflowMutation={updateWorkflowMutation}

--- a/client/src/pages/platform/workflow-editor/components/WorkflowNodesPopoverMenu.tsx
+++ b/client/src/pages/platform/workflow-editor/components/WorkflowNodesPopoverMenu.tsx
@@ -46,8 +46,6 @@ const WorkflowNodesPopoverMenu = ({
     const [popoverOpen, setPopoverOpen] = useState(false);
     const [trigger, setTrigger] = useState(false);
 
-    const {invalidateWorkflowQueries} = useWorkflowEditor();
-
     const workflow = useWorkflowDataStore((state) => state.workflow);
     const {edges, nodes} = useWorkflowDataStore(
         useShallow((state) => ({
@@ -83,7 +81,6 @@ const WorkflowNodesPopoverMenu = ({
 
                 await handleTaskDispatcherClick({
                     edge,
-                    invalidateWorkflowQueries: invalidateWorkflowQueries!,
                     queryClient,
                     sourceNodeId,
                     taskDispatcherContext,
@@ -185,7 +182,6 @@ const WorkflowNodesPopoverMenu = ({
                             clusterElementType={clusterElementType}
                             componentDefinition={componentDefinitionToBeAdded}
                             edgeId={edgeId}
-                            invalidateWorkflowQueries={invalidateWorkflowQueries!}
                             multipleClusterElementsNode={multipleClusterElementsNode}
                             setPopoverOpen={setPopoverOpen}
                             sourceNodeId={sourceNodeId}

--- a/client/src/pages/platform/workflow-editor/components/hooks/useWorkflowNodeDetailsPanel.ts
+++ b/client/src/pages/platform/workflow-editor/components/hooks/useWorkflowNodeDetailsPanel.ts
@@ -96,14 +96,12 @@ const TABS: Array<{label: string; name: TabNameType}> = [
 ];
 
 interface UseWorkflowNodeDetailsPanelProps {
-    invalidateWorkflowQueries: () => void;
     previousComponentDefinitions: Array<ComponentDefinitionBasic>;
     updateWorkflowMutation: UpdateWorkflowMutationType;
     workflowNodeOutputs: WorkflowNodeOutput[];
 }
 
 export default function useWorkflowNodeDetailsPanel({
-    invalidateWorkflowQueries,
     previousComponentDefinitions,
     updateWorkflowMutation,
     workflowNodeOutputs,
@@ -880,7 +878,6 @@ export default function useWorkflowNodeDetailsPanel({
                         field: 'operation',
                         value: newOperationName,
                     },
-                    invalidateWorkflowQueries,
                     updateWorkflowMutation,
                 });
 
@@ -895,7 +892,6 @@ export default function useWorkflowNodeDetailsPanel({
                         field: 'operation',
                         value: newOperationName,
                     },
-                    invalidateWorkflowQueries,
                     updateWorkflowMutation,
                 });
 
@@ -903,7 +899,6 @@ export default function useWorkflowNodeDetailsPanel({
             }
 
             saveWorkflowDefinition({
-                invalidateWorkflowQueries,
                 nodeData,
                 onSuccess: () => {
                     setCurrentComponent({
@@ -947,7 +942,6 @@ export default function useWorkflowNodeDetailsPanel({
             deleteWorkflowNodeTestOutputMutation,
             workflow.id,
             queryClient,
-            invalidateWorkflowQueries,
             updateWorkflowMutation,
             fetchTriggerDefinition,
             fetchClusterElementDefinition,

--- a/client/src/pages/platform/workflow-editor/components/node-details-tabs/DescriptionTab.tsx
+++ b/client/src/pages/platform/workflow-editor/components/node-details-tabs/DescriptionTab.tsx
@@ -22,12 +22,11 @@ import saveTaskDispatcherSubtaskFieldChange from '../../utils/saveTaskDispatcher
 import saveWorkflowDefinition from '../../utils/saveWorkflowDefinition';
 
 interface DescriptionTabProps {
-    invalidateWorkflowQueries: () => void;
     nodeDefinition: ComponentDefinition | ClusterElementDefinition | TaskDispatcherDefinition | TriggerDefinition;
     updateWorkflowMutation: UpdateWorkflowMutationType;
 }
 
-const DescriptionTab = ({invalidateWorkflowQueries, nodeDefinition, updateWorkflowMutation}: DescriptionTabProps) => {
+const DescriptionTab = ({nodeDefinition, updateWorkflowMutation}: DescriptionTabProps) => {
     const {currentComponent, currentNode, setCurrentComponent, setCurrentNode} = useWorkflowNodeDetailsPanelStore(
         useShallow((state) => ({
             currentComponent: state.currentComponent,
@@ -63,7 +62,6 @@ const DescriptionTab = ({invalidateWorkflowQueries, nodeDefinition, updateWorkfl
                     field: 'label',
                     value: event.target.value,
                 },
-                invalidateWorkflowQueries,
                 updateWorkflowMutation,
             });
 
@@ -77,7 +75,6 @@ const DescriptionTab = ({invalidateWorkflowQueries, nodeDefinition, updateWorkfl
                     field: 'label',
                     value: event.target.value,
                 },
-                invalidateWorkflowQueries,
                 updateWorkflowMutation,
             });
 
@@ -86,7 +83,6 @@ const DescriptionTab = ({invalidateWorkflowQueries, nodeDefinition, updateWorkfl
 
         saveWorkflowDefinition({
             decorative: true,
-            invalidateWorkflowQueries,
             nodeData: {
                 ...currentNode,
                 label: event.target.value,
@@ -130,7 +126,6 @@ const DescriptionTab = ({invalidateWorkflowQueries, nodeDefinition, updateWorkfl
                     field: 'description',
                     value: event.target.value,
                 },
-                invalidateWorkflowQueries,
                 updateWorkflowMutation,
             });
 
@@ -144,7 +139,6 @@ const DescriptionTab = ({invalidateWorkflowQueries, nodeDefinition, updateWorkfl
                     field: 'description',
                     value: event.target.value,
                 },
-                invalidateWorkflowQueries,
                 updateWorkflowMutation,
             });
 
@@ -153,7 +147,6 @@ const DescriptionTab = ({invalidateWorkflowQueries, nodeDefinition, updateWorkfl
 
         saveWorkflowDefinition({
             decorative: true,
-            invalidateWorkflowQueries,
             nodeData: {
                 ...currentNode,
                 description: event.target.value,

--- a/client/src/pages/platform/workflow-editor/hooks/useHandleDrop.tsx
+++ b/client/src/pages/platform/workflow-editor/hooks/useHandleDrop.tsx
@@ -135,7 +135,6 @@ async function createWorkflowNodeData(
 
 interface SaveDroppedNodeProps {
     captureComponentUsed: (name: string, actionName?: string, triggerName?: string) => void;
-    invalidateWorkflowQueries: () => void;
     nodeData: NodeDataType;
     operationName?: string;
     options?: {
@@ -149,7 +148,6 @@ interface SaveDroppedNodeProps {
 
 async function saveDroppedNode({
     captureComponentUsed,
-    invalidateWorkflowQueries,
     nodeData,
     operationName,
     options,
@@ -165,17 +163,14 @@ async function saveDroppedNode({
 
     saveWorkflowDefinition({
         ...options,
-        invalidateWorkflowQueries,
         nodeData,
         updateWorkflowMutation,
     });
 }
 
 export default function useHandleDrop({
-    invalidateWorkflowQueries,
     taskDispatcherDefinitions,
 }: {
-    invalidateWorkflowQueries: () => void;
     taskDispatcherDefinitions: TaskDispatcherDefinition[];
 }): [
     (targetNode: Node, droppedNode: ClickedDefinitionType) => void,
@@ -195,7 +190,6 @@ export default function useHandleDrop({
 
         await saveDroppedNode({
             captureComponentUsed,
-            invalidateWorkflowQueries,
             nodeData,
             operationName,
             options: {
@@ -218,7 +212,6 @@ export default function useHandleDrop({
 
         await saveDroppedNode({
             captureComponentUsed,
-            invalidateWorkflowQueries,
             nodeData,
             operationName,
             options: {
@@ -238,7 +231,6 @@ export default function useHandleDrop({
 
         await saveDroppedNode({
             captureComponentUsed,
-            invalidateWorkflowQueries,
             nodeData,
             operationName,
             updateWorkflowMutation: updateWorkflowMutation!,

--- a/client/src/pages/platform/workflow-editor/hooks/useWorkflowEditorCanvas.ts
+++ b/client/src/pages/platform/workflow-editor/hooks/useWorkflowEditorCanvas.ts
@@ -50,7 +50,6 @@ import {isWorkflowMutating} from '../utils/workflowMutationGuard';
 interface UseWorkflowEditorCanvasParamsI {
     componentDefinitions: ComponentDefinitionBasic[];
     customCanvasWidth?: number;
-    invalidateWorkflowQueries: () => void;
     leftSidebarOpen?: boolean;
     readOnlyWorkflow?: Workflow;
     taskDispatcherDefinitions: TaskDispatcherDefinitionBasic[];
@@ -59,7 +58,6 @@ interface UseWorkflowEditorCanvasParamsI {
 const useWorkflowEditorCanvas = ({
     componentDefinitions,
     customCanvasWidth,
-    invalidateWorkflowQueries,
     leftSidebarOpen,
     readOnlyWorkflow,
     taskDispatcherDefinitions,
@@ -96,7 +94,6 @@ const useWorkflowEditorCanvas = ({
     const {invalidateWorkflowQueries: editorInvalidateWorkflowQueries, updateWorkflowMutation} = useWorkflowEditor();
 
     const [handleDropOnPlaceholderNode, handleDropOnWorkflowEdge, handleDropOnTriggerNode] = useHandleDrop({
-        invalidateWorkflowQueries,
         taskDispatcherDefinitions,
     });
 

--- a/client/src/pages/platform/workflow-editor/nodes/WorkflowNode.tsx
+++ b/client/src/pages/platform/workflow-editor/nodes/WorkflowNode.tsx
@@ -171,7 +171,6 @@ const WorkflowNode = ({data, id}: {data: NodeDataType; id: string}) => {
 
         saveClusterElementNodesPosition({
             clickedNodeName,
-            invalidateWorkflowQueries,
             updateWorkflowMutation,
             workflow,
         });

--- a/client/src/pages/platform/workflow-editor/utils/clearAllClusterElementPositions.ts
+++ b/client/src/pages/platform/workflow-editor/utils/clearAllClusterElementPositions.ts
@@ -7,7 +7,6 @@ import {getTask} from './getTask';
 import saveWorkflowDefinition from './saveWorkflowDefinition';
 
 interface ClearAllClusterElementPositionsProps {
-    invalidateWorkflowQueries: () => void;
     updateWorkflowMutation: UpdateWorkflowMutationType;
 }
 
@@ -58,7 +57,6 @@ export function clearClusterElementPositions(clusterElements: ClusterElementsTyp
 }
 
 export default function clearAllClusterElementPositions({
-    invalidateWorkflowQueries,
     updateWorkflowMutation,
 }: ClearAllClusterElementPositionsProps) {
     const {workflow} = useWorkflowDataStore.getState();
@@ -94,7 +92,6 @@ export default function clearAllClusterElementPositions({
     } as typeof rootClusterElementNodeData);
 
     saveWorkflowDefinition({
-        invalidateWorkflowQueries,
         nodeData: {
             ...updatedNodeData,
             componentName: rootClusterElementNodeData.componentName,

--- a/client/src/pages/platform/workflow-editor/utils/handleTaskDispatcherClick.tsx
+++ b/client/src/pages/platform/workflow-editor/utils/handleTaskDispatcherClick.tsx
@@ -22,7 +22,6 @@ const fallbackIcon = <ComponentIcon className="size-9 text-gray-700" />;
 
 interface HandleTaskDispatcherClickProps {
     edge?: Edge;
-    invalidateWorkflowQueries: () => void;
     queryClient: QueryClient;
     sourceNodeId?: string;
     taskDispatcherContext?: TaskDispatcherContextType;
@@ -34,7 +33,6 @@ interface HandleTaskDispatcherClickProps {
 
 export default async function handleTaskDispatcherClick({
     edge,
-    invalidateWorkflowQueries,
     queryClient,
     sourceNodeId,
     taskDispatcherContext,
@@ -123,7 +121,6 @@ export default async function handleTaskDispatcherClick({
     }
 
     saveWorkflowDefinition({
-        invalidateWorkflowQueries,
         nodeData: {
             ...newNodeData,
             parameters: config.getInitialParameters(taskDispatcherDefinition?.properties as Array<PropertyAllType>),

--- a/client/src/pages/platform/workflow-editor/utils/handleTaskDispatcherSubtaskOperationClick.tsx
+++ b/client/src/pages/platform/workflow-editor/utils/handleTaskDispatcherSubtaskOperationClick.tsx
@@ -18,7 +18,6 @@ import saveWorkflowDefinition from './saveWorkflowDefinition';
 import {TASK_DISPATCHER_CONFIG} from './taskDispatcherConfig';
 
 interface HandleTaskDispatcherSubtaskOperationClickProps {
-    invalidateWorkflowQueries: () => void;
     operation: ClickedOperationType;
     operationDefinition: ActionDefinition;
     placeholderId?: string;
@@ -29,7 +28,6 @@ interface HandleTaskDispatcherSubtaskOperationClickProps {
 }
 
 export default function handleTaskDispatcherSubtaskOperationClick({
-    invalidateWorkflowQueries,
     operation,
     operationDefinition,
     placeholderId,
@@ -79,7 +77,6 @@ export default function handleTaskDispatcherSubtaskOperationClick({
     const taskAfterCurrentIndex = workflow.tasks?.length;
 
     saveWorkflowDefinition({
-        invalidateWorkflowQueries,
         nodeData: {
             ...newWorkflowNodeData,
             parameters: getParametersWithDefaultValues({

--- a/client/src/pages/platform/workflow-editor/utils/saveClusterElementFieldChange.ts
+++ b/client/src/pages/platform/workflow-editor/utils/saveClusterElementFieldChange.ts
@@ -1,6 +1,5 @@
-import {ComponentDefinition, Workflow} from '@/shared/middleware/platform/configuration';
-import {ClusterElementsType, NodeDataType, PropertyAllType} from '@/shared/types';
-import {UseMutationResult} from '@tanstack/react-query';
+import {ComponentDefinition} from '@/shared/middleware/platform/configuration';
+import {ClusterElementsType, NodeDataType, PropertyAllType, UpdateWorkflowMutationType} from '@/shared/types';
 
 import useWorkflowDataStore from '../stores/useWorkflowDataStore';
 import useWorkflowEditorStore from '../stores/useWorkflowEditorStore';
@@ -19,15 +18,13 @@ interface SaveClusterElementFieldChangeProps {
     currentComponentDefinition: ComponentDefinition;
     currentOperationProperties?: Array<PropertyAllType>;
     fieldUpdate: FieldUpdateType;
-    invalidateWorkflowQueries: () => void;
-    updateWorkflowMutation: UseMutationResult<void, Error, {id: string; workflow: Workflow}, unknown>;
+    updateWorkflowMutation: UpdateWorkflowMutationType;
 }
 
 export default function saveClusterElementFieldChange({
     currentComponentDefinition,
     currentOperationProperties,
     fieldUpdate,
-    invalidateWorkflowQueries,
     updateWorkflowMutation,
 }: SaveClusterElementFieldChangeProps): void {
     const {currentComponent, currentNode, setCurrentComponent, setCurrentNode} =
@@ -108,7 +105,6 @@ export default function saveClusterElementFieldChange({
 
     saveWorkflowDefinition({
         decorative: true,
-        invalidateWorkflowQueries,
         nodeData: updatedMainRootData,
         onSuccess: () => {
             let commonUpdates: NodeDataType = {

--- a/client/src/pages/platform/workflow-editor/utils/saveClusterElementNodesPosition.ts
+++ b/client/src/pages/platform/workflow-editor/utils/saveClusterElementNodesPosition.ts
@@ -10,7 +10,6 @@ import updateClusterElementsPositions from './updateClusterElementsPositions';
 
 interface SaveClusterElementNodesPositionProps {
     clickedNodeName?: string;
-    invalidateWorkflowQueries: () => void;
     movedClusterElementId?: string;
     updateWorkflowMutation: UpdateWorkflowMutationType;
     workflow: Workflow;
@@ -18,7 +17,6 @@ interface SaveClusterElementNodesPositionProps {
 
 export default function saveClusterElementNodesPosition({
     clickedNodeName,
-    invalidateWorkflowQueries,
     movedClusterElementId,
     updateWorkflowMutation,
     workflow,
@@ -83,7 +81,6 @@ export default function saveClusterElementNodesPosition({
 
         // Save updated data but reset the position saving flag even when there are errors
         saveWorkflowDefinition({
-            invalidateWorkflowQueries,
             nodeData: {
                 ...updatedNodeData,
                 componentName: rootClusterElementNodeData.componentName,
@@ -114,7 +111,6 @@ export default function saveClusterElementNodesPosition({
         } as typeof rootClusterElementNodeData);
 
         saveWorkflowDefinition({
-            invalidateWorkflowQueries,
             nodeData: {
                 ...updatedNodeData,
                 componentName: rootClusterElementNodeData.componentName,

--- a/client/src/pages/platform/workflow-editor/utils/saveTaskDispatcherSubtaskFieldChange.ts
+++ b/client/src/pages/platform/workflow-editor/utils/saveTaskDispatcherSubtaskFieldChange.ts
@@ -1,7 +1,6 @@
 import {TASK_DISPATCHER_DATA_KEY_MAP} from '@/shared/constants';
-import {ComponentDefinition, Workflow, WorkflowTask} from '@/shared/middleware/platform/configuration';
-import {NodeDataType, PropertyAllType, TaskDispatcherContextType} from '@/shared/types';
-import {UseMutationResult} from '@tanstack/react-query';
+import {ComponentDefinition, WorkflowTask} from '@/shared/middleware/platform/configuration';
+import {NodeDataType, PropertyAllType, TaskDispatcherContextType, UpdateWorkflowMutationType} from '@/shared/types';
 
 import useWorkflowDataStore from '../stores/useWorkflowDataStore';
 import useWorkflowNodeDetailsPanelStore from '../stores/useWorkflowNodeDetailsPanelStore';
@@ -20,8 +19,7 @@ interface SaveTaskDispatcherSubtaskFieldChangeProps {
     currentNodeIndex: number;
     currentOperationProperties?: Array<PropertyAllType>;
     fieldUpdate: FieldUpdateType;
-    invalidateWorkflowQueries: () => void;
-    updateWorkflowMutation: UseMutationResult<void, Error, {id: string; workflow: Workflow}, unknown>;
+    updateWorkflowMutation: UpdateWorkflowMutationType;
 }
 
 export default function saveTaskDispatcherSubtaskFieldChange({
@@ -29,7 +27,6 @@ export default function saveTaskDispatcherSubtaskFieldChange({
     currentNodeIndex,
     currentOperationProperties,
     fieldUpdate,
-    invalidateWorkflowQueries,
     updateWorkflowMutation,
 }: SaveTaskDispatcherSubtaskFieldChangeProps): void {
     const {currentComponent, currentNode, setCurrentComponent, setCurrentNode} =
@@ -262,7 +259,6 @@ export default function saveTaskDispatcherSubtaskFieldChange({
     }
 
     saveWorkflowDefinition({
-        invalidateWorkflowQueries,
         onSuccess: () => {
             let commonUpdates: NodeDataType = {
                 componentName,

--- a/client/src/shared/components/read-only-workflow-editor/ReadOnlyWorkflowSheet.tsx
+++ b/client/src/shared/components/read-only-workflow-editor/ReadOnlyWorkflowSheet.tsx
@@ -52,7 +52,6 @@ const ReadOnlyWorkflowSheet = () => {
                                 <WorkflowEditor
                                     componentDefinitions={componentDefinitions}
                                     customCanvasWidth={WIDTHS.WORKFLOW_READ_ONLY_SHEET_WIDTH}
-                                    invalidateWorkflowQueries={() => {}}
                                     readOnlyWorkflow={workflow}
                                     taskDispatcherDefinitions={taskDispatcherDefinitions}
                                 />


### PR DESCRIPTION
Now that executeWorkflowMutation uses the server response directly,
invalidateWorkflowQueries is no longer needed in the save path. Remove
the prop from all components and utilities that pass it through:

- WorkflowEditor, WorkflowNodesPopoverMenu, WorkflowNodeDetailsPanel
- ClusterElementsCanvasDialog, DescriptionTab, useWorkflowNodeDetailsPanel
- useHandleDrop, useWorkflowEditorCanvas, WorkflowNode
- clearAllClusterElementPositions, handleTaskDispatcherClick
- handleTaskDispatcherSubtaskOperationClick, saveClusterElementFieldChange
- saveClusterElementNodesPosition, saveTaskDispatcherSubtaskFieldChange
- WorkflowEditorLayout, AiAgentEditor, useClusterElementStep
- useClusterElementsWorkflowEditor, ReadOnlyWorkflowSheet
- WorkflowExecutionSheetWorkflowPanel

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
