### PR TITLE
4404 client - Fix cluster element property values not visible after tab switching

### DIFF
--- a/client/src/pages/platform/workflow-editor/components/properties/hooks/useProperty.ts
+++ b/client/src/pages/platform/workflow-editor/components/properties/hooks/useProperty.ts
@@ -226,7 +226,7 @@ export const useProperty = ({
 
     const controlledDynamicOnChangeRef = useRef<((value: string) => void) | null>(null);
     const editorRef = useRef<Editor>(null!);
-    const initialMountRef = useRef(true);
+
     const inputRef = useRef<HTMLInputElement>(null!);
     const latestValueRef = useRef<string | number | undefined>(property.defaultValue || '');
     const isSavingRef = useRef(false);
@@ -1434,15 +1434,10 @@ export const useProperty = ({
         }
     }, [control, controlType, expressionEnabled]);
 
-    // Sync propertyParameterValue from workflow definition on change; skip initial mount (mount effect already set from store).
+    // Sync propertyParameterValue from workflow definition whenever it changes (including on mount,
+    // so that remounted Property components pick up the latest saved values after tab switching).
     useEffect(() => {
         if (control) {
-            return;
-        }
-
-        if (initialMountRef.current) {
-            initialMountRef.current = false;
-
             return;
         }
 

--- a/client/src/pages/platform/workflow-editor/stores/useWorkflowDataStore.ts
+++ b/client/src/pages/platform/workflow-editor/stores/useWorkflowDataStore.ts
@@ -60,6 +60,37 @@ interface WorkflowDataStateI {
     ) => void;
 }
 
+function updateClusterElementParameters(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    clusterElements: Record<string, any>,
+    workflowNodeName: string,
+    parameters: Record<string, object>
+): boolean {
+    for (const elementValue of Object.values(clusterElements)) {
+        if (!elementValue) {
+            continue;
+        }
+
+        const elements = Array.isArray(elementValue) ? elementValue : [elementValue];
+
+        for (const element of elements) {
+            if (element.name === workflowNodeName) {
+                element.parameters = parameters;
+
+                return true;
+            }
+
+            if (element.clusterElements) {
+                if (updateClusterElementParameters(element.clusterElements, workflowNodeName, parameters)) {
+                    return true;
+                }
+            }
+        }
+    }
+
+    return false;
+}
+
 function updateTaskParametersInTasks(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     tasks: any[],
@@ -71,6 +102,12 @@ function updateTaskParametersInTasks(
             task.parameters = parameters;
 
             return true;
+        }
+
+        if (task.clusterElements) {
+            if (updateClusterElementParameters(task.clusterElements, workflowNodeName, parameters)) {
+                return true;
+            }
         }
 
         if (task.parameters) {


### PR DESCRIPTION
Remove initialMountRef guard from workflow-definition sync effect so
remounted Property components read saved values from the definition.
Add clusterElements traversal to updateTaskParametersInTasks so the
client store definition is patched when cluster element child
parameters are saved.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
