### PR TITLE
4404 client - Add open/close animation to cluster element editor dialog

### DIFF
--- a/client/src/pages/platform/workflow-editor/WorkflowEditorLayout.tsx
+++ b/client/src/pages/platform/workflow-editor/WorkflowEditorLayout.tsx
@@ -149,15 +149,13 @@ const WorkflowEditorLayout = ({
                 />
             )}
 
-            {clusterElementsCanvasOpen && (
-                <ClusterElementsCanvasDialog
-                    onOpenChange={handleClusterElementsCanvasOpenChange}
-                    open={clusterElementsCanvasOpen}
-                    previousComponentDefinitions={previousComponentDefinitions}
-                    updateWorkflowMutation={updateWorkflowMutation!}
-                    workflowNodeOutputs={filteredWorkflowNodeOutputs ?? []}
-                />
-            )}
+            <ClusterElementsCanvasDialog
+                onOpenChange={handleClusterElementsCanvasOpenChange}
+                open={clusterElementsCanvasOpen}
+                previousComponentDefinitions={previousComponentDefinitions}
+                updateWorkflowMutation={updateWorkflowMutation!}
+                workflowNodeOutputs={filteredWorkflowNodeOutputs ?? []}
+            />
 
             {workflow.id && <WorkflowTestChatPanel />}
 

--- a/client/src/pages/platform/workflow-editor/components/ClusterElementsCanvasDialog.tsx
+++ b/client/src/pages/platform/workflow-editor/components/ClusterElementsCanvasDialog.tsx
@@ -116,7 +116,7 @@ const ClusterElementsCanvasDialog = ({
             </DialogHeader>
 
             <DialogContent
-                className="absolute bottom-4 left-16 top-12 flex h-[calc(100vh-64px)] w-[calc(100vw-80px)] max-w-none translate-x-0 translate-y-0 flex-col gap-2 overflow-hidden bg-surface-main p-0"
+                className="absolute bottom-4 left-16 top-12 flex h-[calc(100vh-64px)] w-[calc(100vw-80px)] max-w-none translate-x-0 translate-y-0 flex-col gap-2 overflow-hidden bg-surface-main p-0 data-[state=closed]:zoom-out-[0.98] data-[state=open]:zoom-in-[0.98] data-[state=closed]:slide-out-to-left-0 data-[state=closed]:slide-out-to-top-0 data-[state=open]:slide-in-from-left-0 data-[state=open]:slide-in-from-top-0"
                 onPointerDownOutside={handlePointerDownOutside}
             >
                 {isDataStreamClusterRoot && showDataStreamEditor ? (


### PR DESCRIPTION
Remove conditional rendering guard so Radix Dialog can play exit
animations, and add scale+fade transition classes to DialogContent.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
