### PR TITLE
4404 client - Add backward chain alignment for newly inserted nodes

### DIFF
--- a/client/src/pages/platform/workflow-editor/utils/postDagreConstraints.test.ts
+++ b/client/src/pages/platform/workflow-editor/utils/postDagreConstraints.test.ts
@@ -2856,6 +2856,72 @@ describe('alignChainNodesCrossAxis', () => {
         // accelo_1 should be at 750 - 150 = 600
         expect(allNodes[0].position.y).toBe(900 - 150 - 150);
     });
+
+    it('should NOT backward-propagate task dispatcher nodes', () => {
+        const dispatcherNode: Node = {
+            data: {componentName: 'condition', taskDispatcher: true, workflowNodeName: 'condition_1'},
+            id: 'condition_1',
+            position: {x: 500, y: 200},
+            type: 'workflow',
+        };
+        const savedNode: Node = {
+            data: {
+                componentName: 'httpClient',
+                metadata: {ui: {nodePosition: {x: 500, y: 600}}},
+                workflowNodeName: 'httpClient_1',
+            },
+            id: 'httpClient_1',
+            position: {x: 500, y: 600},
+            type: 'workflow',
+        };
+        const edges: Edge[] = [{id: 'condition_1=>httpClient_1', source: 'condition_1', target: 'httpClient_1'}];
+        const allNodes = [dispatcherNode, savedNode];
+
+        alignChainNodesCrossAxis(allNodes, edges, 'x', 'TB');
+
+        // Task dispatcher should NOT be repositioned by backward propagation
+        expect(allNodes[0].position).toEqual({x: 500, y: 200});
+    });
+
+    it('should NOT backward-propagate when node has multiple anchored successors', () => {
+        const sourceNode: Node = {
+            data: {componentName: 'accelo', workflowNodeName: 'accelo_1'},
+            id: 'accelo_1',
+            position: {x: 500, y: 100},
+            type: 'workflow',
+        };
+        const savedNodeA: Node = {
+            data: {
+                componentName: 'httpClient',
+                metadata: {ui: {nodePosition: {x: 300, y: 400}}},
+                workflowNodeName: 'httpClient_1',
+            },
+            id: 'httpClient_1',
+            position: {x: 300, y: 400},
+            type: 'workflow',
+        };
+        const savedNodeB: Node = {
+            data: {
+                componentName: 'slack',
+                metadata: {ui: {nodePosition: {x: 700, y: 400}}},
+                workflowNodeName: 'slack_1',
+            },
+            id: 'slack_1',
+            position: {x: 700, y: 400},
+            type: 'workflow',
+        };
+        const edges: Edge[] = [
+            {id: 'accelo_1=>httpClient_1', source: 'accelo_1', target: 'httpClient_1'},
+            {id: 'accelo_1=>slack_1', source: 'accelo_1', target: 'slack_1'},
+        ];
+        const allNodes = [sourceNode, savedNodeA, savedNodeB];
+
+        alignChainNodesCrossAxis(allNodes, edges, 'x', 'TB');
+
+        // With multiple anchored successors, backward propagation should be skipped
+        // to avoid ambiguous positioning
+        expect(allNodes[0].position).toEqual({x: 500, y: 100});
+    });
 });
 
 describe('alignTrailingPlaceholder', () => {

--- a/client/src/pages/platform/workflow-editor/utils/postDagreConstraints.ts
+++ b/client/src/pages/platform/workflow-editor/utils/postDagreConstraints.ts
@@ -1779,6 +1779,13 @@ export function alignChainNodesCrossAxis(
     const dispatcherDeltas = new Map<string, {x: number; y: number}>();
     const mainAxis = crossAxis === 'x' ? 'y' : 'x';
 
+    // Precompute id→index map to avoid O(N) find() calls inside fixpoint loops
+    const nodeIndexById = new Map<string, number>();
+
+    for (let nodeIndex = 0; nodeIndex < allNodes.length; nodeIndex++) {
+        nodeIndexById.set(allNodes[nodeIndex].id, nodeIndex);
+    }
+
     // Seed anchored set with nodes that have saved positions
     for (const node of allNodes) {
         if (containsNodePosition((node.data as NodeDataType).metadata)) {
@@ -1805,11 +1812,13 @@ export function alignChainNodesCrossAxis(
                 continue;
             }
 
-            const predecessorNode = allNodes.find((searchNode) => searchNode.id === predecessorId);
+            const predecessorIndex = nodeIndexById.get(predecessorId);
 
-            if (!predecessorNode) {
+            if (predecessorIndex === undefined) {
                 continue;
             }
+
+            const predecessorNode = allNodes[predecessorIndex];
 
             const predecessorData = predecessorNode.data as NodeDataType;
             const predecessorHasPosition = containsNodePosition(predecessorData.metadata);
@@ -1906,10 +1915,17 @@ export function alignChainNodesCrossAxis(
     // Backward propagation: if a node's successor is anchored but the node
     // itself is not (e.g. newly inserted node before a saved-position node),
     // position the node relative to its successor's position minus the gap.
-    const successorMap = new Map<string, string>();
+    // Track all successors per source since a node can have multiple outgoing edges.
+    const successorMap = new Map<string, string[]>();
 
     for (const [targetId, sourceId] of predecessorMap.entries()) {
-        successorMap.set(sourceId, targetId);
+        const existing = successorMap.get(sourceId);
+
+        if (existing) {
+            existing.push(targetId);
+        } else {
+            successorMap.set(sourceId, [targetId]);
+        }
     }
 
     let backwardChanged = true;
@@ -1925,25 +1941,35 @@ export function alignChainNodesCrossAxis(
                 continue;
             }
 
-            const successorId = successorMap.get(node.id);
-
-            if (!successorId || !anchored.has(successorId)) {
+            // Task dispatchers should not be repositioned by backward propagation —
+            // their position governs branch layout and must only be set by forward
+            // propagation or their own saved position.
+            if (nodeData.taskDispatcher) {
                 continue;
             }
 
-            const successorNode = allNodes.find((searchNode) => searchNode.id === successorId);
+            const successorIds = successorMap.get(node.id);
 
-            if (!successorNode) {
+            if (!successorIds) {
                 continue;
             }
 
-            const successorData = successorNode.data as NodeDataType;
+            // Only backward-propagate when exactly one successor is anchored,
+            // to avoid ambiguous positioning when multiple branches diverge.
+            const anchoredSuccessorIds = successorIds.filter((successorId) => anchored.has(successorId));
 
-            if (nodeData.taskDispatcher && !containsNodePosition(successorData.metadata)) {
-                skipped.add(node.id);
-
+            if (anchoredSuccessorIds.length !== 1) {
                 continue;
             }
+
+            const successorId = anchoredSuccessorIds[0];
+            const successorIndex = nodeIndexById.get(successorId);
+
+            if (successorIndex === undefined) {
+                continue;
+            }
+
+            const successorNode = allNodes[successorIndex];
 
             const clusterCrossOffset =
                 getClusterRootCrossOffset(node, direction) - getClusterRootCrossOffset(successorNode, direction);
@@ -1969,13 +1995,6 @@ export function alignChainNodesCrossAxis(
                 },
                 position: newPosition,
             };
-
-            if (nodeData.taskDispatcher) {
-                dispatcherDeltas.set(node.id, {
-                    x: newPosition.x - node.position.x,
-                    y: newPosition.y - node.position.y,
-                });
-            }
 
             anchored.add(node.id);
             backwardChanged = true;


### PR DESCRIPTION
When a node is manually moved and a new node is inserted before it,
the new node now respects the saved position by backward-propagating
from anchored successors in alignChainNodesCrossAxis.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
