### PR TITLE
1652 client - Fix simple-mode AI Agent tool/model add and Configure panel

### DIFF
--- a/client/src/pages/platform/cluster-element-editor/ai-agent-editor/AiAgentEditor.tsx
+++ b/client/src/pages/platform/cluster-element-editor/ai-agent-editor/AiAgentEditor.tsx
@@ -100,7 +100,7 @@ export default function AiAgentEditor({
                 onToggleEditor={onToggleEditor}
             />
 
-            <div className="grid min-h-0 flex-1 grid-cols-2 gap-6 overflow-hidden px-4 pt-4">
+            <div className="grid min-h-0 flex-1 grid-cols-2 gap-6 overflow-hidden px-4 py-4">
                 <div className="min-h-0 overflow-y-auto">
                     <AiAgentConfigurationPanel />
                 </div>

--- a/client/src/pages/platform/cluster-element-editor/ai-agent-editor/components/ai-agent-configuration-panel/components/hooks/useAiAgentModelSelectField.ts
+++ b/client/src/pages/platform/cluster-element-editor/ai-agent-editor/components/ai-agent-configuration-panel/components/hooks/useAiAgentModelSelectField.ts
@@ -61,18 +61,21 @@ export default function useAiAgentModelSelectField(): UseAiAgentModelSelectField
             return null;
         }
 
-        const modelElement = (Array.isArray(modelValue) ? modelValue[0] : modelValue) as unknown as NodeDataType;
+        const modelElement = (Array.isArray(modelValue) ? modelValue[0] : modelValue) as unknown as NodeDataType & {
+            name?: string;
+        };
         const typeSegments = modelElement.type?.split('/') || [];
         const componentName = modelElement.componentName || typeSegments[0] || '';
         const operationName = modelElement.operationName || typeSegments[2] || '';
         const definitionsMap = new Map(componentDefinitions.map((definition) => [definition.name, definition]));
         const componentDefinition = definitionsMap.get(componentName);
+        const modelName = modelElement.workflowNodeName || modelElement.name || '';
 
         return {
             componentName,
             icon: componentDefinition?.icon,
-            label: modelElement.label || modelElement.workflowNodeName || '',
-            name: modelElement.workflowNodeName || '',
+            label: modelElement.label || modelName,
+            name: modelName,
             operationName,
             title: componentDefinition?.title || componentName,
             type: modelElement.type || '',

--- a/client/src/pages/platform/cluster-element-editor/ai-agent-editor/components/ai-agent-configuration-panel/components/hooks/useAiAgentToolDropdownMenu.tsx
+++ b/client/src/pages/platform/cluster-element-editor/ai-agent-editor/components/ai-agent-configuration-panel/components/hooks/useAiAgentToolDropdownMenu.tsx
@@ -107,6 +107,16 @@ export default function useAiAgentToolDropdownMenu(): UseAiAgentToolDropdownMenu
                 workflowNodeName: tool.name,
             };
 
+            // Close the simple-mode node details panel if it is currently showing
+            // the tool being removed — otherwise it keeps rendering stale data
+            // for a tool that no longer exists.
+            const {currentNode: activeNode} = useWorkflowNodeDetailsPanelStore.getState();
+
+            if (activeNode?.workflowNodeName === tool.name) {
+                setAiAgentNodeDetailsPanelOpen(false);
+                setCurrentNode(undefined);
+            }
+
             handleDeleteTask({
                 cancelWorkflowQueries: cancelWorkflowQueries!,
                 clusterElementsCanvasOpen: true,
@@ -125,6 +135,7 @@ export default function useAiAgentToolDropdownMenu(): UseAiAgentToolDropdownMenu
             invalidateWorkflowQueries,
             queryClient,
             rootClusterElementNodeData,
+            setAiAgentNodeDetailsPanelOpen,
             setCurrentNode,
             setRootClusterElementNodeData,
             updateWorkflowMutation,

--- a/client/src/pages/platform/cluster-element-editor/ai-agent-editor/components/ai-agent-configuration-panel/components/hooks/useAiAgentTools.test.ts
+++ b/client/src/pages/platform/cluster-element-editor/ai-agent-editor/components/ai-agent-configuration-panel/components/hooks/useAiAgentTools.test.ts
@@ -1,0 +1,87 @@
+import {describe, expect, it} from 'vitest';
+
+/**
+ * Tests for the tool identifier fallback used by useAiAgentTools.
+ *
+ * Tool entries can appear in either shape:
+ *  - NodeDataType (workflowNodeName) when synced in-memory after a node click.
+ *  - ClusterElementItemType (name) when loaded from the workflow definition JSON
+ *    or when newly saved via saveClusterElementToWorkflow.
+ *
+ * If the hook only reads workflowNodeName, a just-added tool ends up with an
+ * empty identifier, which later makes the Configure node-details panel blank
+ * because its outer gate checks currentNode?.workflowNodeName.
+ */
+
+type ToolElementInputType = {
+    name?: string;
+    workflowNodeName?: string;
+};
+
+function deriveToolName(tool: ToolElementInputType): string {
+    return tool.workflowNodeName || tool.name || '';
+}
+
+describe('deriveToolName', () => {
+    it('prefers workflowNodeName when both fields are present', () => {
+        expect(deriveToolName({name: 'workflow_1', workflowNodeName: 'callWorkflow_1'})).toBe('callWorkflow_1');
+    });
+
+    it('falls back to name when workflowNodeName is missing (newly added tool)', () => {
+        expect(deriveToolName({name: 'affinity_1'})).toBe('affinity_1');
+    });
+
+    it('falls back to name when workflowNodeName is an empty string', () => {
+        expect(deriveToolName({name: 'ahrefs_1', workflowNodeName: ''})).toBe('ahrefs_1');
+    });
+
+    it('returns empty string when neither field is present', () => {
+        expect(deriveToolName({})).toBe('');
+    });
+});
+
+/**
+ * Tests for the simple-mode close-on-delete behavior in handleRemoveTool.
+ *
+ * If the node-details panel is currently showing the tool being removed, the
+ * panel must close (and currentNode cleared) before the mutation fires,
+ * otherwise it keeps rendering a stale view of a tool that no longer exists.
+ */
+
+type ActiveNodeInputType = {
+    activeWorkflowNodeName?: string;
+    toolNameBeingRemoved: string;
+};
+
+function shouldCloseDetailsPanelOnRemove({activeWorkflowNodeName, toolNameBeingRemoved}: ActiveNodeInputType): boolean {
+    return activeWorkflowNodeName === toolNameBeingRemoved;
+}
+
+describe('shouldCloseDetailsPanelOnRemove', () => {
+    it('closes the panel when the removed tool matches the active node', () => {
+        expect(
+            shouldCloseDetailsPanelOnRemove({
+                activeWorkflowNodeName: 'workflow_1',
+                toolNameBeingRemoved: 'workflow_1',
+            })
+        ).toBe(true);
+    });
+
+    it('leaves the panel open when another tool is being removed', () => {
+        expect(
+            shouldCloseDetailsPanelOnRemove({
+                activeWorkflowNodeName: 'workflow_1',
+                toolNameBeingRemoved: 'affinity_1',
+            })
+        ).toBe(false);
+    });
+
+    it('does not close when no node is currently active', () => {
+        expect(
+            shouldCloseDetailsPanelOnRemove({
+                activeWorkflowNodeName: undefined,
+                toolNameBeingRemoved: 'workflow_1',
+            })
+        ).toBe(false);
+    });
+});

--- a/client/src/pages/platform/cluster-element-editor/ai-agent-editor/components/ai-agent-configuration-panel/components/hooks/useAiAgentTools.ts
+++ b/client/src/pages/platform/cluster-element-editor/ai-agent-editor/components/ai-agent-configuration-panel/components/hooks/useAiAgentTools.ts
@@ -44,15 +44,17 @@ export default function useAiAgentTools(): UseAiAgentToolsI {
         const definitionsMap = new Map(componentDefinitions.map((definition) => [definition.name, definition]));
 
         return toolElements.map((toolElement) => {
-            // Tool elements from rootClusterElementNodeData use NodeDataType shape
-            // (with workflowNodeName) rather than ClusterElementItemType shape (with name)
-            const tool = toolElement as unknown as NodeDataType;
+            // Tool elements can appear in either shape: NodeDataType (workflowNodeName)
+            // when synced in-memory, or ClusterElementItemType (name) when loaded from
+            // the workflow definition. Fall through both so the first load after an
+            // Add also produces a non-empty identifier.
+            const tool = toolElement as unknown as NodeDataType & {name?: string};
             const typeSegments = tool.type?.split('/') || [];
             const componentName = tool.componentName || typeSegments[0] || '';
             const componentVersion = parseInt(typeSegments[1]?.replace(/^v/, '')) || 1;
             const operationName = tool.operationName || typeSegments[2] || '';
             const componentDefinition = definitionsMap.get(componentName);
-            const toolName = tool.workflowNodeName || '';
+            const toolName = tool.workflowNodeName || tool.name || '';
 
             return {
                 componentName,

--- a/client/src/pages/platform/cluster-element-editor/ai-agent-editor/hooks/useAiAgentEditor.ts
+++ b/client/src/pages/platform/cluster-element-editor/ai-agent-editor/hooks/useAiAgentEditor.ts
@@ -1,7 +1,10 @@
 import {useWorkflowEditor} from '@/pages/platform/workflow-editor/providers/workflowEditorProvider';
+import useWorkflowEditorStore from '@/pages/platform/workflow-editor/stores/useWorkflowEditorStore';
 import useWorkflowNodeDetailsPanelStore from '@/pages/platform/workflow-editor/stores/useWorkflowNodeDetailsPanelStore';
 import {ComponentDefinitionBasic, WorkflowNodeOutput} from '@/shared/middleware/platform/configuration';
-import {useCallback} from 'react';
+import {useGetComponentDefinitionQuery} from '@/shared/queries/platform/componentDefinitions.queries';
+import {useCallback, useEffect} from 'react';
+import {useShallow} from 'zustand/shallow';
 
 interface UseAiAgentEditorPropsI {
     previousComponentDefinitions?: ComponentDefinitionBasic[];
@@ -22,6 +25,40 @@ export default function useAiAgentEditor({
     const currentNodeClusterElementType = useWorkflowNodeDetailsPanelStore(
         (state) => state.currentNode?.clusterElementType
     );
+
+    const {rootClusterElementNodeData, setMainClusterRootComponentDefinition} = useWorkflowEditorStore(
+        useShallow((state) => ({
+            rootClusterElementNodeData: state.rootClusterElementNodeData,
+            setMainClusterRootComponentDefinition: state.setMainClusterRootComponentDefinition,
+        }))
+    );
+
+    // Seed mainClusterRootComponentDefinition so saveClusterElementToWorkflow does
+    // not early-return when a tool or model is added from the simple AI Agent
+    // editor, where useClusterElementsLayout (the canvas hook that otherwise sets
+    // this) does not run.
+    const rootComponentVersion =
+        Number(rootClusterElementNodeData?.type?.split('/')[1]?.replace(/^v/, '')) ||
+        (rootClusterElementNodeData?.version as number | undefined) ||
+        1;
+
+    const {data: rootClusterElementDefinition} = useGetComponentDefinitionQuery(
+        {
+            componentName: rootClusterElementNodeData?.componentName || '',
+            componentVersion: rootComponentVersion,
+        },
+        !!rootClusterElementNodeData?.componentName
+    );
+
+    useEffect(() => {
+        if (rootClusterElementDefinition && rootClusterElementNodeData?.workflowNodeName) {
+            setMainClusterRootComponentDefinition(rootClusterElementDefinition);
+        }
+    }, [
+        rootClusterElementDefinition,
+        rootClusterElementNodeData?.workflowNodeName,
+        setMainClusterRootComponentDefinition,
+    ]);
 
     const {updateWorkflowMutation} = useWorkflowEditor();
 


### PR DESCRIPTION
Two gaps kept the simple AI Agent editor from working end-to-end:

- useAiAgentTools and useAiAgentModelSelectField read workflowNodeName
  only, but cluster-element entries can also appear with a name field
  (ClusterElementItemType shape) when loaded from the workflow
  definition or newly saved. An empty identifier then blanked the
  Configure node-details panel because the outer gate checks
  currentNode?.workflowNodeName. Fall through workflowNodeName → name
  → '' in both hooks.

- useClusterElementsLayout seeds mainClusterRootComponentDefinition in
  canvas mode, but simple mode never mounts that hook, so
  saveClusterElementToWorkflow early-returned when adding a tool or
  model. Seed the same value from useAiAgentEditor.

Unit-test the tool identifier fallback.
