### PR TITLE
4756 Fix deleting project deployment with subflow jobs

### DIFF
--- a/server/ee/libs/atlas/atlas-execution/atlas-execution-remote-client/src/main/java/com/bytechef/ee/atlas/execution/remote/client/service/RemoteJobServiceClient.java
+++ b/server/ee/libs/atlas/atlas-execution/atlas-execution-remote-client/src/main/java/com/bytechef/ee/atlas/execution/remote/client/service/RemoteJobServiceClient.java
@@ -77,6 +77,11 @@ public class RemoteJobServiceClient implements JobService {
     }
 
     @Override
+    public List<Long> getChildJobIds(long parentJobId) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public List<Job> getJobs(List<Long> ids) {
         throw new UnsupportedOperationException();
     }

--- a/server/libs/atlas/atlas-execution/atlas-execution-api/src/main/java/com/bytechef/atlas/execution/service/JobService.java
+++ b/server/libs/atlas/atlas-execution/atlas-execution-api/src/main/java/com/bytechef/atlas/execution/service/JobService.java
@@ -40,6 +40,8 @@ public interface JobService {
 
     Optional<Job> fetchLastWorkflowJob(List<String> workflowIds);
 
+    List<Long> getChildJobIds(long parentJobId);
+
     Job getJob(long id);
 
     List<Job> getJobs(List<Long> ids);

--- a/server/libs/atlas/atlas-execution/atlas-execution-repository/atlas-execution-repository-api/src/main/java/com/bytechef/atlas/execution/repository/JobRepository.java
+++ b/server/libs/atlas/atlas-execution/atlas-execution-repository/atlas-execution-repository-api/src/main/java/com/bytechef/atlas/execution/repository/JobRepository.java
@@ -46,6 +46,8 @@ public interface JobRepository {
 
     List<Job> findAllByIdIn(List<Long> ids);
 
+    List<Long> findAllIdsByParentJobId(Long parentJobId);
+
     List<Job> findAllByWorkflowId(String workflowId);
 
     Optional<Job> findById(Long id);

--- a/server/libs/atlas/atlas-execution/atlas-execution-repository/atlas-execution-repository-jdbc/src/main/java/com/bytechef/atlas/execution/repository/jdbc/JdbcJobRepository.java
+++ b/server/libs/atlas/atlas-execution/atlas-execution-repository/atlas-execution-repository-jdbc/src/main/java/com/bytechef/atlas/execution/repository/jdbc/JdbcJobRepository.java
@@ -65,5 +65,10 @@ public interface JdbcJobRepository
     @Query("SELECT * FROM job j WHERE j.id = (SELECT job_id FROM task_execution te WHERE te.id=:taskExecutionId)")
     Optional<Job> findByTaskExecutionId(@Param("taskExecutionId") Long taskExecutionId);
 
+    @Override
+    @Query("SELECT j.id FROM job j WHERE j.parent_task_execution_id IN "
+        + "(SELECT te.id FROM task_execution te WHERE te.job_id=:parentJobId)")
+    List<Long> findAllIdsByParentJobId(@Param("parentJobId") Long parentJobId);
+
     Job save(Job job);
 }

--- a/server/libs/atlas/atlas-execution/atlas-execution-repository/atlas-execution-repository-memory/src/main/java/com/bytechef/atlas/execution/repository/memory/InMemoryJobRepository.java
+++ b/server/libs/atlas/atlas-execution/atlas-execution-repository/atlas-execution-repository-memory/src/main/java/com/bytechef/atlas/execution/repository/memory/InMemoryJobRepository.java
@@ -91,6 +91,26 @@ public class InMemoryJobRepository implements JobRepository {
     }
 
     @Override
+    public List<Long> findAllIdsByParentJobId(Long parentJobId) {
+        List<Long> parentTaskExecutionIds = inMemoryTaskExecutionRepository.findAllByJobIdOrderByIdDesc(parentJobId)
+            .stream()
+            .map(TaskExecution::getId)
+            .filter(Objects::nonNull)
+            .toList();
+
+        return cache.values()
+            .stream()
+            .filter(job -> {
+                Long parentTaskExecutionId = job.getParentTaskExecutionId();
+
+                return parentTaskExecutionId != null && parentTaskExecutionIds.contains(parentTaskExecutionId);
+            })
+            .map(Job::getId)
+            .filter(Objects::nonNull)
+            .toList();
+    }
+
+    @Override
     public Optional<Job> findById(Long id) {
         return Optional.ofNullable(cache.get(TenantCacheKeyUtils.getKey(id)));
     }

--- a/server/libs/atlas/atlas-execution/atlas-execution-service/src/main/java/com/bytechef/atlas/execution/facade/JobFacadeImpl.java
+++ b/server/libs/atlas/atlas-execution/atlas-execution-service/src/main/java/com/bytechef/atlas/execution/facade/JobFacadeImpl.java
@@ -98,6 +98,10 @@ public class JobFacadeImpl implements JobFacade {
     @Override
     @Transactional
     public void deleteJob(long id) {
+        for (long childJobId : jobService.getChildJobIds(id)) {
+            deleteJob(childJobId);
+        }
+
         taskExecutionService.deleteJobTaskExecutions(id);
 
         jobService.deleteJob(id);

--- a/server/libs/atlas/atlas-execution/atlas-execution-service/src/main/java/com/bytechef/atlas/execution/service/JobServiceImpl.java
+++ b/server/libs/atlas/atlas-execution/atlas-execution-service/src/main/java/com/bytechef/atlas/execution/service/JobServiceImpl.java
@@ -92,6 +92,12 @@ public class JobServiceImpl implements JobService {
 
     @Override
     @Transactional(readOnly = true)
+    public List<Long> getChildJobIds(long parentJobId) {
+        return jobRepository.findAllIdsByParentJobId(parentJobId);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
     public Job getJob(long id) {
         return OptionalUtils.get(jobRepository.findById(id));
     }

--- a/server/libs/platform/platform-job-sync/src/main/java/com/bytechef/platform/job/sync/executor/JobServiceWrapper.java
+++ b/server/libs/platform/platform-job-sync/src/main/java/com/bytechef/platform/job/sync/executor/JobServiceWrapper.java
@@ -27,6 +27,11 @@ import org.springframework.data.domain.Page;
 public record JobServiceWrapper(JobSyncExecutor.JobFactoryFunction jobFactoryFunction) implements JobService {
 
     @Override
+    public List<Long> getChildJobIds(long parentJobId) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public Job getJob(long id) {
         throw new UnsupportedOperationException();
     }


### PR DESCRIPTION
Recursively delete child subflow jobs before the parent's task_executions to satisfy the fk_job_task_execution constraint.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
