### PR TITLE
4213 client - Fix race condition opening workflow node details panel for new node

### DIFF
--- a/client/src/pages/platform/workflow-editor/components/hooks/useWorkflowNodeDetailsPanel.ts
+++ b/client/src/pages/platform/workflow-editor/components/hooks/useWorkflowNodeDetailsPanel.ts
@@ -1225,19 +1225,15 @@ export default function useWorkflowNodeDetailsPanel({
 
     // Set currentOperationName depending on the currentWorkflowNode.operationName
     useEffect(() => {
-        if (!workflowNodes?.length) {
-            return;
-        }
-
         let currentWorkflowNode;
 
-        if (workflowNodes.length && !clusterElementsCanvasOpen && !isClusterElement) {
+        if (workflowNodes?.length && !clusterElementsCanvasOpen && !isClusterElement) {
             currentWorkflowNode = workflowNodes.find(
                 (workflowNode) => workflowNode.workflowNodeName === currentNode?.workflowNodeName
             );
         } else if (clusterElementsCanvasOpen) {
             if (currentNode?.clusterRoot && !currentNode.isNestedClusterRoot) {
-                currentWorkflowNode = workflowNodes.find(
+                currentWorkflowNode = workflowNodes?.find(
                     (workflowNodeType) => workflowNodeType.workflowNodeName === currentNode?.workflowNodeName
                 );
             } else if (clusterElementComponentOperations) {
@@ -1247,12 +1243,23 @@ export default function useWorkflowNodeDetailsPanel({
             }
         }
 
-        if (currentWorkflowNode?.operationName && currentWorkflowNode.operationName !== currentOperationName) {
-            setCurrentOperationName(currentWorkflowNode.operationName);
+        // Prefer the server-synced operationName once available; otherwise fall back to the
+        // optimistically-set currentNode.operationName so a newly added node can resolve its
+        // operation before the workflow mutation settles.
+        const resolvedOperationName = currentWorkflowNode?.operationName ?? currentNode?.operationName;
+
+        if (resolvedOperationName && resolvedOperationName !== currentOperationName) {
+            setCurrentOperationName(resolvedOperationName);
         }
 
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [clusterElementComponentOperations, currentNode?.workflowNodeName, currentOperationName, workflowNodes]);
+    }, [
+        clusterElementComponentOperations,
+        currentNode?.workflowNodeName,
+        currentNode?.operationName,
+        currentOperationName,
+        workflowNodes,
+    ]);
 
     // Update display conditions when currentNode changes
     useEffect(() => {


### PR DESCRIPTION
Prefer optimistically-set currentNode.operationName as fallback when the
server-backed workflowNodes lookup misses, avoiding a spurious "operation
not found" error right after adding a node and before the workflow
mutation settles.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
