### PR TITLE
4761 Fix nested AI agent tool connection resolution

### DIFF
--- a/server/ee/libs/platform/platform-component/platform-component-remote-client/src/main/java/com/bytechef/ee/platform/component/remote/client/service/RemoteClusterElementDefinitionServiceClient.java
+++ b/server/ee/libs/platform/platform-component/platform-component-remote-client/src/main/java/com/bytechef/ee/platform/component/remote/client/service/RemoteClusterElementDefinitionServiceClient.java
@@ -82,6 +82,14 @@ public class RemoteClusterElementDefinitionServiceClient implements ClusterEleme
     }
 
     @Override
+    public Object executeTool(
+        String componentName, int componentVersion, String clusterElementName, Map<String, ?> inputParameters,
+        Map<String, ?> extensions, Map<String, ComponentConnection> componentConnections, boolean editorEnvironment) {
+
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public String executeWorkflowNodeDescription(
         String componentName, int componentVersion, String clusterElementName, Map<String, ?> inputParameters) {
 

--- a/server/libs/modules/components/ai/agent/src/main/java/com/bytechef/component/ai/agent/action/AbstractAiAgentChatAction.java
+++ b/server/libs/modules/components/ai/agent/src/main/java/com/bytechef/component/ai/agent/action/AbstractAiAgentChatAction.java
@@ -39,6 +39,7 @@ import com.bytechef.platform.component.definition.ParametersFactory;
 import com.bytechef.platform.component.definition.ai.agent.ChatMemoryFunction;
 import com.bytechef.platform.component.definition.ai.agent.GuardrailsFunction;
 import com.bytechef.platform.component.definition.ai.agent.ModelFunction;
+import com.bytechef.platform.component.definition.ai.agent.MultipleConnectionsToolFunction;
 import com.bytechef.platform.component.definition.ai.agent.RagFunction;
 import com.bytechef.platform.component.definition.ai.agent.ToolCallbackProviderFunction;
 import com.bytechef.platform.component.service.ClusterElementDefinitionService;
@@ -249,6 +250,9 @@ public abstract class AbstractAiAgentChatAction {
                 } catch (Exception exception) {
                     throw new RuntimeException(exception);
                 }
+            } else if (clusterElementFunction instanceof MultipleConnectionsToolFunction) {
+                toolCallbacks.add(
+                    aiAgentToolFacade.getFunctionToolCallback(clusterElement, connectionParameters, editorEnvironment));
             } else {
                 ComponentConnection componentConnection = connectionParameters.get(
                     clusterElement.getWorkflowNodeName());

--- a/server/libs/modules/components/ai/agent/src/main/java/com/bytechef/component/ai/agent/facade/AiAgentToolFacade.java
+++ b/server/libs/modules/components/ai/agent/src/main/java/com/bytechef/component/ai/agent/facade/AiAgentToolFacade.java
@@ -86,6 +86,42 @@ public class AiAgentToolFacade extends AbstractToolFacade {
         return builder.build();
     }
 
+    public ToolCallback getFunctionToolCallback(
+        ClusterElement clusterElement, Map<String, ComponentConnection> componentConnections,
+        boolean editorEnvironment) {
+
+        ClusterElementDefinition clusterElementDefinition =
+            clusterElementDefinitionService.getClusterElementDefinition(
+                clusterElement.getComponentName(), clusterElement.getComponentVersion(),
+                clusterElement.getClusterElementName());
+
+        Map<String, ?> toolParameters = clusterElement.getParameters();
+
+        List<FromAiResult> fromAiResults = extractFromAiResults(toolParameters);
+
+        FunctionToolCallback.Builder<Map<String, Object>, Object> builder = FunctionToolCallback.builder(
+            getToolName(clusterElementDefinition.getComponentName(), clusterElementDefinition.getName(),
+                toolParameters),
+            getMultipleConnectionsToolCallbackFunction(
+                clusterElement.getComponentName(), clusterElement.getComponentVersion(),
+                clusterElementDefinition.getName(), toolParameters, clusterElement.getExtensions(),
+                componentConnections, editorEnvironment))
+            .inputType(Map.class)
+            .inputSchema(FromAiInputSchemaUtils.generateInputSchema(fromAiResults));
+
+        String toolDescription = getToolDescription(toolParameters, clusterElement.getExtensions());
+
+        if (toolDescription == null) {
+            toolDescription = clusterElementDefinition.getDescription();
+        }
+
+        if (toolDescription != null) {
+            builder.description(toolDescription);
+        }
+
+        return builder.build();
+    }
+
     private Function<Map<String, Object>, Object> getFromAiToolCallbackFunction(
         String componentName, int componentVersion, String clusterElementName, Map<String, ?> parameters,
         @Nullable ComponentConnection componentConnection, boolean editorEnvironment) {
@@ -100,6 +136,23 @@ public class AiAgentToolFacade extends AbstractToolFacade {
             return clusterElementDefinitionService.executeTool(
                 componentName, componentVersion, clusterElementName, MapUtils.concat(request, resolvedParameters),
                 componentConnection, editorEnvironment);
+        };
+    }
+
+    private Function<Map<String, Object>, Object> getMultipleConnectionsToolCallbackFunction(
+        String componentName, int componentVersion, String clusterElementName, Map<String, ?> parameters,
+        Map<String, ?> extensions, Map<String, ComponentConnection> componentConnections, boolean editorEnvironment) {
+
+        return request -> {
+            Map<String, Object> resolvedParameters = new HashMap<>();
+
+            for (Map.Entry<String, ?> entry : parameters.entrySet()) {
+                resolvedParameters.put(entry.getKey(), resolveParameterValue(entry.getValue(), request));
+            }
+
+            return clusterElementDefinitionService.executeTool(
+                componentName, componentVersion, clusterElementName, MapUtils.concat(request, resolvedParameters),
+                extensions, componentConnections, editorEnvironment);
         };
     }
 

--- a/server/libs/platform/platform-component/platform-component-api/src/main/java/com/bytechef/platform/component/service/ClusterElementDefinitionService.java
+++ b/server/libs/platform/platform-component/platform-component-api/src/main/java/com/bytechef/platform/component/service/ClusterElementDefinitionService.java
@@ -61,6 +61,10 @@ public interface ClusterElementDefinitionService extends OperationDefinitionServ
         String componentName, int componentVersion, String clusterElementName, Map<String, ?> inputParameters,
         @Nullable ComponentConnection componentConnection, boolean editorEnvironment);
 
+    Object executeTool(
+        String componentName, int componentVersion, String clusterElementName, Map<String, ?> inputParameters,
+        Map<String, ?> extensions, Map<String, ComponentConnection> componentConnections, boolean editorEnvironment);
+
     String executeWorkflowNodeDescription(
         String componentName, int componentVersion, String clusterElementName, Map<String, ?> inputParameters);
 

--- a/server/libs/platform/platform-component/platform-component-service/src/main/java/com/bytechef/platform/component/service/ClusterElementDefinitionServiceImpl.java
+++ b/server/libs/platform/platform-component/platform-component-service/src/main/java/com/bytechef/platform/component/service/ClusterElementDefinitionServiceImpl.java
@@ -46,6 +46,7 @@ import com.bytechef.platform.component.definition.ActionContextAdapater;
 import com.bytechef.platform.component.definition.ClusterRootComponentDefinition;
 import com.bytechef.platform.component.definition.ParametersFactory;
 import com.bytechef.platform.component.definition.PropertyFactory;
+import com.bytechef.platform.component.definition.ai.agent.MultipleConnectionsToolFunction;
 import com.bytechef.platform.component.definition.ai.agent.ToolCallbackProviderFunction;
 import com.bytechef.platform.component.definition.datastream.ClusterElementResolverFunction;
 import com.bytechef.platform.component.domain.ClusterElementDefinition;
@@ -203,6 +204,24 @@ public class ClusterElementDefinitionServiceImpl implements ClusterElementDefini
 
         return doExecuteTool(
             componentName, componentVersion, clusterElementName, inputParameters, componentConnection,
+            clusterElementContext);
+    }
+
+    @Override
+    public Object executeTool(
+        String componentName, int componentVersion, String clusterElementName, Map<String, ?> inputParameters,
+        Map<String, ?> extensions, Map<String, ComponentConnection> componentConnections, boolean editorEnvironment) {
+
+        ComponentConnection firstConnection = componentConnections.isEmpty()
+            ? null : componentConnections.values()
+                .iterator()
+                .next();
+
+        ClusterElementContext clusterElementContext = contextFactory.createClusterElementContext(
+            componentName, componentVersion, clusterElementName, firstConnection, editorEnvironment);
+
+        return doExecuteTool(
+            componentName, componentVersion, clusterElementName, inputParameters, extensions, componentConnections,
             clusterElementContext);
     }
 
@@ -442,6 +461,45 @@ public class ClusterElementDefinitionServiceImpl implements ClusterElementDefini
         Parameters connectionParameters = ParametersFactory.create(componentConnection);
 
         try {
+            if (clusterElement instanceof ToolCallbackProviderFunction toolCallbackProviderFunction) {
+                return toolCallbackProviderFunction.apply(inputParameters, connectionParameters, context);
+            }
+
+            if (clusterElement instanceof ToolFunction toolFunction) {
+                return toolFunction.apply(inputParameters, connectionParameters, context);
+            }
+
+            throw new ExecutionException(
+                "Unsupported cluster element type: " + clusterElement.getClass()
+                    .getName(),
+                inputParameters, ClusterElementDefinitionErrorType.EXECUTE_PERFORM);
+        } catch (Exception exception) {
+            if (exception instanceof ProviderException) {
+                throw (ProviderException) exception;
+            }
+
+            throw new ExecutionException(
+                exception, inputParameterMap, ClusterElementDefinitionErrorType.EXECUTE_PERFORM);
+        }
+    }
+
+    private Object doExecuteTool(
+        String componentName, Integer componentVersion, String clusterElementName, Map<String, ?> inputParameterMap,
+        Map<String, ?> extensionMap, Map<String, ComponentConnection> componentConnections,
+        ClusterElementContext context) {
+
+        Object clusterElement = getClusterElement(componentName, componentVersion, clusterElementName);
+
+        Parameters inputParameters = ParametersFactory.create(inputParameterMap);
+        Parameters connectionParameters = ParametersFactory.create(Map.of());
+        Parameters extensions = ParametersFactory.create(extensionMap);
+
+        try {
+            if (clusterElement instanceof MultipleConnectionsToolFunction multipleConnectionsToolFunction) {
+                return multipleConnectionsToolFunction.apply(
+                    inputParameters, connectionParameters, extensions, componentConnections, context);
+            }
+
             if (clusterElement instanceof ToolCallbackProviderFunction toolCallbackProviderFunction) {
                 return toolCallbackProviderFunction.apply(inputParameters, connectionParameters, context);
             }

--- a/server/libs/platform/platform-configuration/platform-configuration-api/build.gradle.kts
+++ b/server/libs/platform/platform-configuration/platform-configuration-api/build.gradle.kts
@@ -12,4 +12,6 @@ dependencies {
     implementation(project(":server:libs:core:commons:commons-util"))
     implementation(project(":server:libs:platform:platform-connection:platform-connection-api"))
     implementation(project(":server:libs:platform:platform-user:platform-user-api"))
+
+    testImplementation(project(":server:libs:test:test-support"))
 }

--- a/server/libs/platform/platform-configuration/platform-configuration-api/src/main/java/com/bytechef/platform/configuration/domain/ClusterElementMap.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-api/src/main/java/com/bytechef/platform/configuration/domain/ClusterElementMap.java
@@ -124,17 +124,86 @@ public class ClusterElementMap extends AbstractMap<String, Object> {
                 .filter(curClusterElement -> Objects.equals(
                     curClusterElement.getWorkflowNodeName(), clusterElementWorkflowNodeName))
                 .findFirst()
+                .or(() -> findNestedClusterElement(clusterElementType, clusterElementWorkflowNodeName))
                 .orElseThrow(() -> new IllegalArgumentException(
                     "Cluster element %s not found".formatted(clusterElementWorkflowNodeName)));
         } else {
-            ClusterElement clusterElement = getClusterElement(clusterElementType);
+            ClusterElement clusterElement = super.get(clusterElementType.key()) instanceof ClusterElement ce
+                ? ce : null;
 
-            if (!Objects.equals(clusterElement.getWorkflowNodeName(), clusterElementWorkflowNodeName)) {
-                throw new IllegalArgumentException("Cluster element type %s not found".formatted(clusterElementType));
+            if (clusterElement == null ||
+                !Objects.equals(clusterElement.getWorkflowNodeName(), clusterElementWorkflowNodeName)) {
+
+                return findNestedClusterElement(clusterElementType, clusterElementWorkflowNodeName)
+                    .orElseThrow(() -> new IllegalArgumentException(
+                        "Cluster element type %s not found".formatted(clusterElementType)));
             }
 
             return clusterElement;
         }
+    }
+
+    private Optional<ClusterElement> findNestedClusterElement(
+        ClusterElementType clusterElementType, String clusterElementWorkflowNodeName) {
+
+        for (Entry<String, Object> entry : entrySet) {
+            Object value = entry.getValue();
+
+            if (value instanceof ClusterElement clusterElement) {
+                Optional<ClusterElement> clusterElementOptional = searchClusterElementInside(
+                    clusterElement, clusterElementType, clusterElementWorkflowNodeName);
+
+                if (clusterElementOptional.isPresent()) {
+                    return clusterElementOptional;
+                }
+            } else if (value instanceof List<?> list) {
+                for (Object item : list) {
+                    if (item instanceof ClusterElement clusterElement) {
+                        Optional<ClusterElement> clusterElementOptional = searchClusterElementInside(
+                            clusterElement, clusterElementType, clusterElementWorkflowNodeName);
+
+                        if (clusterElementOptional.isPresent()) {
+                            return clusterElementOptional;
+                        }
+                    }
+                }
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    private static Optional<ClusterElement> searchClusterElementInside(
+        ClusterElement clusterElement, ClusterElementType clusterElementType, String clusterElementWorkflowNodeName) {
+
+        Map<String, ?> extensions = clusterElement.getExtensions();
+
+        if (extensions == null || !extensions.containsKey(WorkflowExtConstants.CLUSTER_ELEMENTS)) {
+            return Optional.empty();
+        }
+
+        ClusterElementMap clusterElementMap = of(extensions);
+
+        if (clusterElementType.multipleElements()) {
+            Optional<ClusterElement> direct = clusterElementMap.getClusterElements(clusterElementType)
+                .stream()
+                .filter(curClusterElement -> Objects.equals(
+                    curClusterElement.getWorkflowNodeName(), clusterElementWorkflowNodeName))
+                .findFirst();
+
+            if (direct.isPresent()) {
+                return direct;
+            }
+        } else {
+            Optional<ClusterElement> clusterElementOptional = clusterElementMap.fetchClusterElement(clusterElementType)
+                .filter(ce -> Objects.equals(ce.getWorkflowNodeName(), clusterElementWorkflowNodeName));
+
+            if (clusterElementOptional.isPresent()) {
+                return clusterElementOptional;
+            }
+        }
+
+        return clusterElementMap.findNestedClusterElement(clusterElementType, clusterElementWorkflowNodeName);
     }
 
     @SuppressWarnings("unchecked")

--- a/server/libs/platform/platform-configuration/platform-configuration-api/src/test/java/com/bytechef/platform/configuration/domain/ClusterElementMapTest.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-api/src/test/java/com/bytechef/platform/configuration/domain/ClusterElementMapTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2025 ByteChef
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.bytechef.platform.configuration.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.bytechef.atlas.configuration.constant.WorkflowConstants;
+import com.bytechef.component.definition.ClusterElementDefinition.ClusterElementType;
+import com.bytechef.platform.configuration.constant.WorkflowExtConstants;
+import com.bytechef.test.extension.ObjectMapperSetupExtension;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * @author Ivica Cardic
+ */
+@ExtendWith(ObjectMapperSetupExtension.class)
+class ClusterElementMapTest {
+
+    private static final ClusterElementType TOOLS = new ClusterElementType("TOOLS", "tools", "Tools", true, false);
+
+    @Test
+    void testGetClusterElementResolvesDirectChild() {
+        Map<String, Object> extensions = Map.of(
+            WorkflowExtConstants.CLUSTER_ELEMENTS,
+            Map.of("tools", List.of(
+                Map.of(
+                    WorkflowConstants.NAME, "hubspot_1",
+                    WorkflowConstants.TYPE, "hubspot/v1/createContact",
+                    WorkflowConstants.PARAMETERS, Map.of()))));
+
+        ClusterElementMap clusterElementMap = ClusterElementMap.of(extensions);
+
+        ClusterElement clusterElement = clusterElementMap.getClusterElement(TOOLS, "hubspot_1");
+
+        assertThat(clusterElement.getWorkflowNodeName()).isEqualTo("hubspot_1");
+        assertThat(clusterElement.getComponentName()).isEqualTo("hubspot");
+    }
+
+    @Test
+    void testGetClusterElementResolvesNestedChild() {
+        Map<String, Object> hubspotTool = Map.of(
+            WorkflowConstants.NAME, "hubspot_1",
+            WorkflowConstants.TYPE, "hubspot/v1/createContact",
+            WorkflowConstants.PARAMETERS, Map.of());
+
+        Map<String, Object> aiAgentTool = Map.of(
+            WorkflowConstants.NAME, "aiAgent_tool_1",
+            WorkflowConstants.TYPE, "aiAgent/v1/aiAgentTool",
+            WorkflowConstants.PARAMETERS, Map.of(),
+            WorkflowExtConstants.CLUSTER_ELEMENTS, Map.of("tools", List.of(hubspotTool)));
+
+        Map<String, Object> extensions = Map.of(
+            WorkflowExtConstants.CLUSTER_ELEMENTS, Map.of("tools", List.of(aiAgentTool)));
+
+        ClusterElementMap clusterElementMap = ClusterElementMap.of(extensions);
+
+        ClusterElement clusterElement = clusterElementMap.getClusterElement(TOOLS, "hubspot_1");
+
+        assertThat(clusterElement.getWorkflowNodeName()).isEqualTo("hubspot_1");
+        assertThat(clusterElement.getComponentName()).isEqualTo("hubspot");
+    }
+
+    @Test
+    void testGetClusterElementThrowsWhenMissing() {
+        Map<String, Object> extensions = Map.of(
+            WorkflowExtConstants.CLUSTER_ELEMENTS,
+            Map.of("tools", List.of(
+                Map.of(
+                    WorkflowConstants.NAME, "hubspot_1",
+                    WorkflowConstants.TYPE, "hubspot/v1/createContact",
+                    WorkflowConstants.PARAMETERS, Map.of()))));
+
+        ClusterElementMap clusterElementMap = ClusterElementMap.of(extensions);
+
+        assertThatThrownBy(() -> clusterElementMap.getClusterElement(TOOLS, "missing_1"))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/server/libs/platform/platform-configuration/platform-configuration-service/src/main/java/com/bytechef/platform/configuration/facade/WorkflowNodeOptionFacadeImpl.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-service/src/main/java/com/bytechef/platform/configuration/facade/WorkflowNodeOptionFacadeImpl.java
@@ -143,26 +143,46 @@ public class WorkflowNodeOptionFacadeImpl implements WorkflowNodeOptionFacade {
     private Map<String, Map<String, ?>> evaluateClusterElementInputParameters(
         ClusterElementMap clusterElementMap, Map<String, Object> context) {
 
-        Map<String, Map<String, ?>> result = new java.util.HashMap<>();
+        Map<String, Map<String, ?>> parameterMap = new java.util.HashMap<>();
 
         for (Map.Entry<String, Object> entry : clusterElementMap.entrySet()) {
             Object value = entry.getValue();
 
             if (value instanceof ClusterElement clusterElement) {
-                result.put(
+                parameterMap.put(
                     clusterElement.getWorkflowNodeName(), evaluator.evaluate(clusterElement.getParameters(), context));
+
+                addNestedClusterElementParameters(clusterElement, context, parameterMap);
             } else if (value instanceof List<?> list) {
                 for (Object item : list) {
                     if (item instanceof ClusterElement clusterElement) {
-                        result.put(
+                        parameterMap.put(
                             clusterElement.getWorkflowNodeName(),
                             evaluator.evaluate(clusterElement.getParameters(), context));
+
+                        addNestedClusterElementParameters(clusterElement, context, parameterMap);
                     }
                 }
             }
         }
 
-        return result;
+        return parameterMap;
+    }
+
+    private void addNestedClusterElementParameters(
+        ClusterElement clusterElement, Map<String, Object> context, Map<String, Map<String, ?>> parameterMap) {
+
+        Map<String, ?> extensions = clusterElement.getExtensions();
+
+        if (extensions == null || !extensions.containsKey(
+            com.bytechef.platform.configuration.constant.WorkflowExtConstants.CLUSTER_ELEMENTS)) {
+
+            return;
+        }
+
+        ClusterElementMap clusterElementMap = ClusterElementMap.of(extensions);
+
+        parameterMap.putAll(evaluateClusterElementInputParameters(clusterElementMap, context));
     }
 
     @Override

--- a/server/libs/platform/platform-configuration/platform-configuration-service/src/main/java/com/bytechef/platform/configuration/facade/WorkflowNodeOptionFacadeImpl.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-service/src/main/java/com/bytechef/platform/configuration/facade/WorkflowNodeOptionFacadeImpl.java
@@ -28,6 +28,7 @@ import com.bytechef.platform.component.facade.ActionDefinitionFacade;
 import com.bytechef.platform.component.facade.ClusterElementDefinitionFacade;
 import com.bytechef.platform.component.facade.TriggerDefinitionFacade;
 import com.bytechef.platform.component.service.ClusterElementDefinitionService;
+import com.bytechef.platform.configuration.constant.WorkflowExtConstants;
 import com.bytechef.platform.configuration.domain.ClusterElement;
 import com.bytechef.platform.configuration.domain.ClusterElementMap;
 import com.bytechef.platform.configuration.domain.WorkflowTestConfigurationConnection;
@@ -174,9 +175,7 @@ public class WorkflowNodeOptionFacadeImpl implements WorkflowNodeOptionFacade {
 
         Map<String, ?> extensions = clusterElement.getExtensions();
 
-        if (extensions == null || !extensions.containsKey(
-            com.bytechef.platform.configuration.constant.WorkflowExtConstants.CLUSTER_ELEMENTS)) {
-
+        if (extensions == null || !extensions.containsKey(WorkflowExtConstants.CLUSTER_ELEMENTS)) {
             return;
         }
 

--- a/server/libs/platform/platform-configuration/platform-configuration-service/src/main/java/com/bytechef/platform/configuration/facade/WorkflowNodeParameterFacadeImpl.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-service/src/main/java/com/bytechef/platform/configuration/facade/WorkflowNodeParameterFacadeImpl.java
@@ -810,26 +810,27 @@ public class WorkflowNodeParameterFacadeImpl implements WorkflowNodeParameterFac
                         }
                     }
                 }
-            } else {
-                if (entry.getValue() instanceof Map<?, ?> map) {
-                    if (map.containsKey(WorkflowExtConstants.CLUSTER_ELEMENTS)) {
+            }
+
+            if (clusterElementMap != null) {
+                break;
+            }
+
+            if (entry.getValue() instanceof Map<?, ?> map) {
+                if (map.containsKey(WorkflowExtConstants.CLUSTER_ELEMENTS)) {
+                    clusterElementMap = getClusterElementMap(
+                        clusterElementTypeName, clusterElementWorkflowNodeName, (Map<String, ?>) map, false);
+                }
+            } else if (entry.getValue() instanceof List<?> list) {
+                for (Object item : list) {
+                    if ((item instanceof Map<?, ?> map) && map.containsKey(WorkflowExtConstants.CLUSTER_ELEMENTS)) {
                         clusterElementMap = getClusterElementMap(
                             clusterElementTypeName, clusterElementWorkflowNodeName, (Map<String, ?>) map, false);
-                    }
-                } else if (entry.getValue() instanceof List<?> list) {
-                    for (Object item : list) {
-                        if ((item instanceof Map<?, ?> map) && map.containsKey(WorkflowExtConstants.CLUSTER_ELEMENTS)) {
-                            clusterElementMap = getClusterElementMap(
-                                clusterElementTypeName, clusterElementWorkflowNodeName, (Map<String, ?>) map, false);
 
-                            if (clusterElementMap != null && Objects.equals(
-                                clusterElementMap.get(WorkflowConstants.NAME), clusterElementWorkflowNodeName)) {
-
-                                break;
-                            }
+                        if (clusterElementMap != null) {
+                            break;
                         }
                     }
-
                 }
             }
 

--- a/server/libs/platform/platform-configuration/platform-configuration-service/src/test/java/com/bytechef/platform/configuration/facade/WorkflowNodeOptionFacadeTest.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-service/src/test/java/com/bytechef/platform/configuration/facade/WorkflowNodeOptionFacadeTest.java
@@ -31,21 +31,25 @@ import static org.mockito.Mockito.when;
 import com.bytechef.atlas.configuration.domain.Workflow;
 import com.bytechef.atlas.configuration.domain.WorkflowTask;
 import com.bytechef.atlas.configuration.service.WorkflowService;
+import com.bytechef.component.definition.ClusterElementDefinition.ClusterElementType;
 import com.bytechef.evaluator.Evaluator;
 import com.bytechef.platform.component.domain.Option;
 import com.bytechef.platform.component.facade.ActionDefinitionFacade;
 import com.bytechef.platform.component.facade.ClusterElementDefinitionFacade;
 import com.bytechef.platform.component.facade.TriggerDefinitionFacade;
 import com.bytechef.platform.component.service.ClusterElementDefinitionService;
+import com.bytechef.platform.configuration.constant.WorkflowExtConstants;
 import com.bytechef.platform.configuration.domain.WorkflowTrigger;
 import com.bytechef.platform.configuration.service.WorkflowTestConfigurationService;
 import com.bytechef.platform.workflow.task.dispatcher.service.TaskDispatcherDefinitionService;
+import com.bytechef.test.extension.ObjectMapperSetupExtension;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -53,7 +57,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 /**
  * @author Ivica Cardic
  */
-@ExtendWith(MockitoExtension.class)
+@ExtendWith({
+    MockitoExtension.class, ObjectMapperSetupExtension.class
+})
 class WorkflowNodeOptionFacadeTest {
 
     @Mock
@@ -225,5 +231,85 @@ class WorkflowNodeOptionFacadeTest {
             verify(triggerDefinitionFacade).executeOptions(
                 eq("github"), eq(1), eq("newIssue"), eq(propertyName), anyMap(), anyList(), isNull(), eq(connectionId));
         }
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void testGetClusterElementNodeOptionsAggregatesNestedClusterElementParameters() {
+        String workflowId = "workflow1";
+        String workflowNodeName = "aiAgent_1";
+        String clusterElementTypeName = "tools";
+        String clusterElementWorkflowNodeName = "aiAgent_tool_1";
+        String propertyName = "objectType";
+        long environmentId = 1L;
+
+        Map<String, ?> nestedToolMap = Map.of(
+            "name", "hubspot_1",
+            "type", "hubspot/v1/createContact",
+            "label", "Hubspot",
+            "parameters", Map.of("apiKey", "secret"));
+
+        Map<String, ?> outerToolMap = Map.of(
+            "name", clusterElementWorkflowNodeName,
+            "type", "aiAgent/v1/tool",
+            "label", "AI Agent Tool",
+            "parameters", Map.of("prompt", "do something"),
+            WorkflowExtConstants.CLUSTER_ELEMENTS, Map.of("tools", List.of(nestedToolMap)));
+
+        Map<String, ?> taskExtensions = Map.of(
+            WorkflowExtConstants.CLUSTER_ELEMENTS, Map.of("tools", List.of(outerToolMap)));
+
+        when(workflowTestConfigurationService.fetchWorkflowTestConfiguration(workflowId, environmentId))
+            .thenReturn(Optional.empty());
+        doReturn(Map.of()).when(workflowTestConfigurationService)
+            .getWorkflowTestConfigurationInputs(workflowId, environmentId);
+
+        Workflow workflow = mock(Workflow.class);
+        WorkflowTask workflowTask = mock(WorkflowTask.class);
+
+        when(workflowService.getWorkflow(workflowId)).thenReturn(workflow);
+        when(workflow.getTask(workflowNodeName)).thenReturn(workflowTask);
+        when(workflowTask.getType()).thenReturn("aiAgent/v1");
+        when(workflowTask.getName()).thenReturn(workflowNodeName);
+        doReturn(taskExtensions).when(workflowTask)
+            .getExtensions();
+
+        doReturn(Map.of()).when(workflowNodeOutputFacade)
+            .getPreviousWorkflowNodeSampleOutputs(eq(workflowId), eq(workflowNodeName), eq(environmentId));
+
+        ClusterElementType clusterElementType = new ClusterElementType(
+            clusterElementTypeName, "tools", "Tools", true, false);
+
+        when(clusterElementDefinitionService.getClusterElementType("aiAgent", 1, clusterElementTypeName))
+            .thenReturn(clusterElementType);
+
+        when(evaluator.evaluate(anyMap(), anyMap()))
+            .thenAnswer(invocation -> invocation.getArgument(0));
+
+        List<Option> expectedOptions = List.of(mock(Option.class));
+
+        when(clusterElementDefinitionFacade.executeOptions(
+            eq("aiAgent"), eq(1), eq("tool"), eq(propertyName), anyMap(), anyMap(), anyList(), isNull(), isNull(),
+            anyMap(), anyMap()))
+                .thenReturn(expectedOptions);
+
+        List<Option> result = workflowNodeOptionFacade.getClusterElementNodeOptions(
+            workflowId, workflowNodeName, clusterElementTypeName, clusterElementWorkflowNodeName, propertyName,
+            List.of(), null, environmentId);
+
+        assertEquals(expectedOptions, result);
+
+        ArgumentCaptor<Map<String, Map<String, ?>>> captor = ArgumentCaptor.forClass(Map.class);
+
+        verify(clusterElementDefinitionFacade).executeOptions(
+            eq("aiAgent"), eq(1), eq("tool"), eq(propertyName), anyMap(), anyMap(), anyList(), isNull(), isNull(),
+            anyMap(), captor.capture());
+
+        Map<String, Map<String, ?>> capturedInputParameters = captor.getValue();
+
+        assertEquals(true, capturedInputParameters.containsKey("aiAgent_tool_1"));
+        assertEquals(true, capturedInputParameters.containsKey("hubspot_1"));
+        assertEquals("secret", capturedInputParameters.get("hubspot_1")
+            .get("apiKey"));
     }
 }


### PR DESCRIPTION
Resolve cluster elements recursively so tools nested inside an AI agent
tool (e.g. hubspot_1 inside aiAgent_tool_1) are found by both option and
display-condition facades.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
