### PR TITLE
4754 client - Fix fromAi tool parameter cleanup on toggle and mode switch

### DIFF
--- a/client/src/pages/platform/workflow-editor/components/properties/hooks/tests/handleFromAiToggle.test.ts
+++ b/client/src/pages/platform/workflow-editor/components/properties/hooks/tests/handleFromAiToggle.test.ts
@@ -1,0 +1,207 @@
+import {describe, expect, it} from 'vitest';
+
+/**
+ * Tests for handleFromAiToggle and handleControlledModeSwitch fromAi cleanup.
+ *
+ * When the user toggles the fromAi button off in a Tools cluster element
+ * parameter, the previous implementation only flipped local state and left the
+ * `fromAi` entry, `dynamicPropertyTypes` entry, and stale `"="` value behind in
+ * the workflow definition. The same gap existed when leaving dynamic mode while
+ * fromAi was active.
+ *
+ * The handlers must always:
+ *   - update the form field value (empty when toggling off / leaving mode)
+ *   - call saveProperty so the backend strips the path from the fromAi array
+ */
+
+interface FromAiToggleResultI {
+    fieldValue: string;
+    savePayload: {
+        fromAi: boolean;
+        includeInMetadata: boolean;
+        value: string;
+    } | null;
+}
+
+const FROM_AI_EXPRESSION = "=fromAi('fieldName')";
+
+const computeFromAiToggle = ({
+    custom = false,
+    fromAi,
+    fromAiExpression = FROM_AI_EXPRESSION,
+    hasPath = true,
+    hasWorkflowId = true,
+}: {
+    custom?: boolean;
+    fromAi: boolean;
+    fromAiExpression?: string;
+    hasPath?: boolean;
+    hasWorkflowId?: boolean;
+}): FromAiToggleResultI => {
+    const fieldValue = fromAi ? fromAiExpression : '';
+
+    if (!hasPath || !hasWorkflowId) {
+        return {fieldValue, savePayload: null};
+    }
+
+    return {
+        fieldValue,
+        savePayload: {
+            fromAi,
+            includeInMetadata: custom || fromAi,
+            value: fieldValue,
+        },
+    };
+};
+
+interface ModeSwitchResultI {
+    savePayload: {
+        fromAi: boolean;
+        includeInMetadata: boolean;
+        value: string;
+    } | null;
+}
+
+const computeControlledModeSwitch = ({
+    controlledFromAi,
+    custom = false,
+    hasPath = true,
+    hasWorkflowId = true,
+    toDynamic,
+}: {
+    controlledFromAi: boolean | undefined;
+    custom?: boolean;
+    hasPath?: boolean;
+    hasWorkflowId?: boolean;
+    toDynamic: boolean;
+}): ModeSwitchResultI => {
+    const wasFromAi = controlledFromAi === true;
+
+    if (!wasFromAi || !hasPath || !hasWorkflowId) {
+        return {savePayload: null};
+    }
+
+    return {
+        savePayload: {
+            fromAi: false,
+            includeInMetadata: custom,
+            value: toDynamic ? '=' : '',
+        },
+    };
+};
+
+describe('handleFromAiToggle', () => {
+    describe('toggling ON', () => {
+        it('sets field value to the fromAi expression', () => {
+            const result = computeFromAiToggle({fromAi: true});
+
+            expect(result.fieldValue).toBe(FROM_AI_EXPRESSION);
+        });
+
+        it('saves with fromAi true and forces includeInMetadata', () => {
+            const result = computeFromAiToggle({custom: false, fromAi: true});
+
+            expect(result.savePayload).toEqual({
+                fromAi: true,
+                includeInMetadata: true,
+                value: FROM_AI_EXPRESSION,
+            });
+        });
+    });
+
+    describe('toggling OFF', () => {
+        it('clears the field value', () => {
+            const result = computeFromAiToggle({fromAi: false});
+
+            expect(result.fieldValue).toBe('');
+        });
+
+        it('saves with fromAi false so the backend removes the entry', () => {
+            const result = computeFromAiToggle({custom: false, fromAi: false});
+
+            expect(result.savePayload).toEqual({
+                fromAi: false,
+                includeInMetadata: false,
+                value: '',
+            });
+        });
+
+        it('keeps includeInMetadata true when the property is custom', () => {
+            const result = computeFromAiToggle({custom: true, fromAi: false});
+
+            expect(result.savePayload?.includeInMetadata).toBe(true);
+        });
+    });
+
+    describe('guards', () => {
+        it('does not save when path is missing', () => {
+            const result = computeFromAiToggle({fromAi: false, hasPath: false});
+
+            expect(result.savePayload).toBeNull();
+            expect(result.fieldValue).toBe('');
+        });
+
+        it('does not save when workflow id is missing', () => {
+            const result = computeFromAiToggle({fromAi: true, hasWorkflowId: false});
+
+            expect(result.savePayload).toBeNull();
+            expect(result.fieldValue).toBe(FROM_AI_EXPRESSION);
+        });
+    });
+});
+
+describe('handleControlledModeSwitch fromAi cleanup', () => {
+    it('clears fromAi metadata when leaving dynamic mode while fromAi was active', () => {
+        const result = computeControlledModeSwitch({
+            controlledFromAi: true,
+            toDynamic: false,
+        });
+
+        expect(result.savePayload).toEqual({
+            fromAi: false,
+            includeInMetadata: false,
+            value: '',
+        });
+    });
+
+    it('clears fromAi metadata when entering dynamic mode while fromAi was active', () => {
+        const result = computeControlledModeSwitch({
+            controlledFromAi: true,
+            toDynamic: true,
+        });
+
+        expect(result.savePayload).toEqual({
+            fromAi: false,
+            includeInMetadata: false,
+            value: '=',
+        });
+    });
+
+    it('does not save when fromAi was not active', () => {
+        const result = computeControlledModeSwitch({
+            controlledFromAi: false,
+            toDynamic: false,
+        });
+
+        expect(result.savePayload).toBeNull();
+    });
+
+    it('does not save when controlledFromAi is undefined', () => {
+        const result = computeControlledModeSwitch({
+            controlledFromAi: undefined,
+            toDynamic: true,
+        });
+
+        expect(result.savePayload).toBeNull();
+    });
+
+    it('propagates custom flag into includeInMetadata', () => {
+        const result = computeControlledModeSwitch({
+            controlledFromAi: true,
+            custom: true,
+            toDynamic: false,
+        });
+
+        expect(result.savePayload?.includeInMetadata).toBe(true);
+    });
+});

--- a/client/src/pages/platform/workflow-editor/components/properties/hooks/useProperty.ts
+++ b/client/src/pages/platform/workflow-editor/components/properties/hooks/useProperty.ts
@@ -629,7 +629,12 @@ export const useProperty = ({
             setControlledDynamicMode(toDynamic);
             setControlledFromAi(undefined);
 
-            if (wasFromAi && path && workflow.id) {
+            if (
+                wasFromAi &&
+                path &&
+                workflow.id &&
+                (updateWorkflowNodeParameterMutation || updateClusterElementParameterMutation)
+            ) {
                 saveProperty({
                     fromAi: false,
                     includeInMetadata: custom,
@@ -661,7 +666,11 @@ export const useProperty = ({
 
             fieldOnChange(value);
 
-            if (!path || !workflow.id) {
+            if (
+                !path ||
+                !workflow.id ||
+                !(updateWorkflowNodeParameterMutation || updateClusterElementParameterMutation)
+            ) {
                 return;
             }
 

--- a/client/src/pages/platform/workflow-editor/components/properties/hooks/useProperty.ts
+++ b/client/src/pages/platform/workflow-editor/components/properties/hooks/useProperty.ts
@@ -620,22 +620,71 @@ export const useProperty = ({
         [validatePropertyValue]
     );
 
-    const handleControlledModeSwitch = useCallback((toDynamic: boolean) => {
-        resetOnModeChangeRef.current = true;
+    const handleControlledModeSwitch = useCallback(
+        (toDynamic: boolean) => {
+            resetOnModeChangeRef.current = true;
 
-        setControlledDynamicMode(toDynamic);
-        setControlledFromAi(undefined);
-    }, []);
+            const wasFromAi = controlledFromAi === true;
+
+            setControlledDynamicMode(toDynamic);
+            setControlledFromAi(undefined);
+
+            if (wasFromAi && path && workflow.id) {
+                saveProperty({
+                    fromAi: false,
+                    includeInMetadata: custom,
+                    path,
+                    type,
+                    updateClusterElementParameterMutation,
+                    updateWorkflowNodeParameterMutation,
+                    value: toDynamic ? '=' : '',
+                    workflowId: workflow.id,
+                });
+            }
+        },
+        [
+            controlledFromAi,
+            custom,
+            path,
+            type,
+            updateClusterElementParameterMutation,
+            updateWorkflowNodeParameterMutation,
+            workflow.id,
+        ]
+    );
 
     const handleFromAiToggle = useCallback(
         (fromAi: boolean, fieldOnChange: (value: string) => void) => {
             setControlledFromAi(fromAi);
 
-            if (fromAi) {
-                fieldOnChange(fromAiExpression);
+            const value = fromAi ? fromAiExpression : '';
+
+            fieldOnChange(value);
+
+            if (!path || !workflow.id) {
+                return;
             }
+
+            saveProperty({
+                fromAi,
+                includeInMetadata: custom || fromAi,
+                path,
+                type,
+                updateClusterElementParameterMutation,
+                updateWorkflowNodeParameterMutation,
+                value,
+                workflowId: workflow.id,
+            });
         },
-        [fromAiExpression]
+        [
+            custom,
+            fromAiExpression,
+            path,
+            type,
+            updateClusterElementParameterMutation,
+            updateWorkflowNodeParameterMutation,
+            workflow.id,
+        ]
     );
 
     const handleJsonSchemaBuilderChange = useDebouncedCallback((value?: SchemaRecordType) => {


### PR DESCRIPTION
Toggling the fromAi button off or switching out of dynamic mode now
clears the field value and persists the change so the backend removes
the path from the fromAi metadata array, dynamicPropertyTypes, and
parameters.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
