### PR TITLE
4756 Fix principal_job FK violation when deleting project deployment

### DIFF
--- a/server/ee/libs/embedded/embedded-configuration/embedded-configuration-service/src/main/java/com/bytechef/ee/embedded/configuration/facade/IntegrationInstanceConfigurationFacadeImpl.java
+++ b/server/ee/libs/embedded/embedded-configuration/embedded-configuration-service/src/main/java/com/bytechef/ee/embedded/configuration/facade/IntegrationInstanceConfigurationFacadeImpl.java
@@ -62,6 +62,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -239,7 +240,12 @@ public class IntegrationInstanceConfigurationFacadeImpl implements IntegrationIn
             principalJobService.deletePrincipalJobs(jobId, PlatformType.EMBEDDED);
         }
 
-        for (long jobId : jobIds) {
+        List<Long> orderedJobIds = jobIds.stream()
+            .distinct()
+            .sorted(Comparator.reverseOrder())
+            .toList();
+
+        for (long jobId : orderedJobIds) {
             jobFacade.deleteJob(jobId);
         }
 

--- a/server/ee/libs/embedded/embedded-configuration/embedded-configuration-service/src/main/java/com/bytechef/ee/embedded/configuration/facade/IntegrationInstanceConfigurationFacadeImpl.java
+++ b/server/ee/libs/embedded/embedded-configuration/embedded-configuration-service/src/main/java/com/bytechef/ee/embedded/configuration/facade/IntegrationInstanceConfigurationFacadeImpl.java
@@ -237,7 +237,9 @@ public class IntegrationInstanceConfigurationFacadeImpl implements IntegrationIn
             triggerExecutionService.deleteJobTriggerExecution(jobId);
 
             principalJobService.deletePrincipalJobs(jobId, PlatformType.EMBEDDED);
+        }
 
+        for (long jobId : jobIds) {
             jobFacade.deleteJob(jobId);
         }
 

--- a/server/libs/atlas/atlas-execution/atlas-execution-service/build.gradle.kts
+++ b/server/libs/atlas/atlas-execution/atlas-execution-service/build.gradle.kts
@@ -11,8 +11,11 @@ dependencies {
     implementation(project(":server:libs:core:commons:commons-util"))
 
     testImplementation("org.springframework.data:spring-data-jdbc")
+    testImplementation("tools.jackson.core:jackson-databind")
+    testImplementation(project(":server:libs:atlas:atlas-configuration:atlas-configuration-converter"))
     testImplementation(project(":server:libs:atlas:atlas-configuration:atlas-configuration-repository:atlas-configuration-repository-jdbc"))
     testImplementation(project(":server:libs:atlas:atlas-execution:atlas-execution-repository:atlas-execution-repository-jdbc"))
     testImplementation(project(":server:libs:config:liquibase-config"))
+    testImplementation(project(":server:libs:core:commons:commons-data"))
     testImplementation(project(":server:libs:test:test-int-support"))
 }

--- a/server/libs/atlas/atlas-execution/atlas-execution-service/src/test/java/com/bytechef/atlas/execution/facade/JobFacadeIntTest.java
+++ b/server/libs/atlas/atlas-execution/atlas-execution-service/src/test/java/com/bytechef/atlas/execution/facade/JobFacadeIntTest.java
@@ -16,19 +16,41 @@
 
 package com.bytechef.atlas.execution.facade;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.bytechef.atlas.configuration.converter.StringToWorkflowTaskConverter;
+import com.bytechef.atlas.configuration.converter.WorkflowTaskToStringConverter;
+import com.bytechef.atlas.configuration.domain.WorkflowTask;
 import com.bytechef.atlas.configuration.service.WorkflowService;
+import com.bytechef.atlas.execution.domain.Job;
+import com.bytechef.atlas.execution.domain.TaskExecution;
 import com.bytechef.atlas.execution.dto.JobParametersDTO;
 import com.bytechef.atlas.execution.repository.JobRepository;
+import com.bytechef.atlas.execution.repository.TaskExecutionRepository;
+import com.bytechef.atlas.execution.repository.jdbc.converter.StringToWebhooksConverter;
+import com.bytechef.atlas.execution.repository.jdbc.converter.WebhooksToStringConverter;
 import com.bytechef.atlas.execution.service.ContextService;
 import com.bytechef.atlas.execution.service.JobService;
 import com.bytechef.atlas.execution.service.JobServiceImpl;
 import com.bytechef.atlas.execution.service.TaskExecutionService;
+import com.bytechef.atlas.execution.service.TaskExecutionServiceImpl;
 import com.bytechef.atlas.file.storage.TaskFileStorage;
+import com.bytechef.commons.data.jdbc.converter.ExecutionErrorToStringConverter;
+import com.bytechef.commons.data.jdbc.converter.FileEntryToStringConverter;
+import com.bytechef.commons.data.jdbc.converter.MapWrapperToStringConverter;
+import com.bytechef.commons.data.jdbc.converter.StringToFileEntryConverter;
+import com.bytechef.commons.data.jdbc.converter.StringToMapWrapperConverter;
 import com.bytechef.jackson.config.JacksonConfiguration;
 import com.bytechef.liquibase.config.LiquibaseConfiguration;
 import com.bytechef.test.config.jdbc.AbstractIntTestJdbcConfiguration;
 import com.bytechef.test.config.testcontainers.PostgreSQLContainerConfiguration;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.lang3.Validate;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -41,6 +63,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.jdbc.repository.config.EnableJdbcAuditing;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * Ivica Cardic
@@ -57,6 +80,12 @@ public class JobFacadeIntTest {
     @Autowired
     private JobFacade jobFacade;
 
+    @Autowired
+    private JobRepository jobRepository;
+
+    @Autowired
+    private TaskExecutionRepository taskExecutionRepository;
+
     @Test
     public void testRequiredParameters() {
         Assertions.assertThrows(
@@ -64,7 +93,67 @@ public class JobFacadeIntTest {
             () -> jobFacade.createJob(new JobParametersDTO("aGVsbG8x", Collections.emptyMap())));
     }
 
-    @ComponentScan(basePackages = "com.bytechef.atlas.execution.facade")
+    @Test
+    public void testDeleteJobRecursivelyDeletesChildJobsAndTaskExecutions() {
+        Job parentJob = jobRepository.save(newJob());
+        long parentJobId = Validate.notNull(parentJob.getId(), "id");
+
+        TaskExecution parentTaskExecution = taskExecutionRepository.save(newTaskExecution(parentJobId, null));
+
+        long parentTaskExecutionId = Validate.notNull(parentTaskExecution.getId(), "id");
+
+        Job childJob = jobRepository.save(newJob());
+
+        childJob.setParentTaskExecutionId(parentTaskExecutionId);
+
+        jobRepository.save(childJob);
+
+        long childJobId = Validate.notNull(childJob.getId(), "id");
+
+        TaskExecution childTaskExecution = taskExecutionRepository.save(newTaskExecution(childJobId, null));
+
+        long childTaskExecutionId = Validate.notNull(childTaskExecution.getId(), "id");
+
+        jobFacade.deleteJob(parentJobId);
+
+        assertThat(jobRepository.findById(parentJobId)).isEmpty();
+        assertThat(jobRepository.findById(childJobId)).isEmpty();
+        assertThat(taskExecutionRepository.findById(parentTaskExecutionId)).isEmpty();
+        assertThat(taskExecutionRepository.findById(childTaskExecutionId)).isEmpty();
+    }
+
+    private static Job newJob() {
+        Job job = new Job();
+
+        job.setStatus(Job.Status.COMPLETED);
+        job.setWorkflowId("demo:1234");
+
+        return job;
+    }
+
+    private static TaskExecution newTaskExecution(long jobId, Long parentId) {
+        Map<String, Object> taskMap = new HashMap<>();
+
+        taskMap.put("name", "task1");
+        taskMap.put("type", "test/v1/noop");
+
+        TaskExecution taskExecution = TaskExecution.builder()
+            .workflowTask(new WorkflowTask(taskMap))
+            .build();
+
+        taskExecution.setJobId(jobId);
+        taskExecution.setTaskNumber(1);
+
+        if (parentId != null) {
+            taskExecution.setParentId(parentId);
+        }
+
+        return taskExecution;
+    }
+
+    @ComponentScan(basePackages = {
+        "com.bytechef.atlas.execution.facade", "com.bytechef.atlas.configuration.converter"
+    })
     @EnableAutoConfiguration
     @Configuration
     public static class WorkflowExecutionIntTestConfiguration {
@@ -76,13 +165,13 @@ public class JobFacadeIntTest {
         private WorkflowService workflowService;
 
         @MockitoBean
-        private TaskExecutionService taskExecutionService;
-
-        @MockitoBean
         private TaskFileStorage taskFileStorage;
 
         @Bean
-        JobFacade jobFacade(ApplicationEventPublisher eventPublisher, JobService jobService) {
+        JobFacade jobFacade(
+            ApplicationEventPublisher eventPublisher, JobService jobService,
+            TaskExecutionService taskExecutionService) {
+
             return new JobFacadeImpl(
                 eventPublisher, contextService, jobService, taskExecutionService, taskFileStorage, workflowService);
         }
@@ -92,8 +181,34 @@ public class JobFacadeIntTest {
             return new JobServiceImpl(jobRepository);
         }
 
+        @Bean
+        TaskExecutionService taskExecutionService(TaskExecutionRepository taskExecutionRepository) {
+            return new TaskExecutionServiceImpl(taskExecutionRepository);
+        }
+
         @EnableJdbcAuditing(auditorAwareRef = "auditorProvider", dateTimeProviderRef = "auditingDateTimeProvider")
         public static class WorkflowIntTestJdbcConfiguration extends AbstractIntTestJdbcConfiguration {
+
+            private final ObjectMapper objectMapper;
+
+            @SuppressFBWarnings("EI")
+            public WorkflowIntTestJdbcConfiguration(ObjectMapper objectMapper) {
+                this.objectMapper = objectMapper;
+            }
+
+            @Override
+            protected List<?> userConverters() {
+                return Arrays.asList(
+                    new ExecutionErrorToStringConverter(objectMapper),
+                    new FileEntryToStringConverter(objectMapper),
+                    new MapWrapperToStringConverter(objectMapper),
+                    new StringToFileEntryConverter(objectMapper),
+                    new StringToMapWrapperConverter(objectMapper),
+                    new StringToWebhooksConverter(objectMapper),
+                    new StringToWorkflowTaskConverter(objectMapper),
+                    new WebhooksToStringConverter(objectMapper),
+                    new WorkflowTaskToStringConverter(objectMapper));
+            }
         }
     }
 }

--- a/server/libs/automation/automation-configuration/automation-configuration-service/src/main/java/com/bytechef/automation/configuration/facade/ProjectDeploymentFacadeImpl.java
+++ b/server/libs/automation/automation-configuration/automation-configuration-service/src/main/java/com/bytechef/automation/configuration/facade/ProjectDeploymentFacadeImpl.java
@@ -222,7 +222,9 @@ public class ProjectDeploymentFacadeImpl implements ProjectDeploymentFacade {
             triggerExecutionService.deleteJobTriggerExecution(jobId);
 
             principalJobService.deletePrincipalJobs(jobId, PlatformType.AUTOMATION);
+        }
 
+        for (long jobId : jobIds) {
             jobFacade.deleteJob(jobId);
         }
 

--- a/server/libs/automation/automation-configuration/automation-configuration-service/src/main/java/com/bytechef/automation/configuration/facade/ProjectDeploymentFacadeImpl.java
+++ b/server/libs/automation/automation-configuration/automation-configuration-service/src/main/java/com/bytechef/automation/configuration/facade/ProjectDeploymentFacadeImpl.java
@@ -62,6 +62,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -224,7 +225,12 @@ public class ProjectDeploymentFacadeImpl implements ProjectDeploymentFacade {
             principalJobService.deletePrincipalJobs(jobId, PlatformType.AUTOMATION);
         }
 
-        for (long jobId : jobIds) {
+        List<Long> orderedJobIds = jobIds.stream()
+            .distinct()
+            .sorted(Comparator.reverseOrder())
+            .toList();
+
+        for (long jobId : orderedJobIds) {
             jobFacade.deleteJob(jobId);
         }
 

--- a/server/libs/automation/automation-configuration/automation-configuration-service/src/test/java/com/bytechef/automation/configuration/facade/ProjectDeploymentFacadeIntTest.java
+++ b/server/libs/automation/automation-configuration/automation-configuration-service/src/test/java/com/bytechef/automation/configuration/facade/ProjectDeploymentFacadeIntTest.java
@@ -24,6 +24,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -60,6 +61,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
@@ -186,6 +188,33 @@ public class ProjectDeploymentFacadeIntTest {
             true);
 
         assertThat(workspaceProjectDeployments).hasSize(0);
+    }
+
+    @Test
+    public void testDeleteProjectDeploymentRemovesAllPrincipalJobsBeforeAnyJob() {
+        ProjectDTO projectDTO = projectDeploymentFacadeHelper.createProject(workspace.getId());
+        ProjectDeploymentDTO projectDeploymentDTO =
+            projectDeploymentFacadeHelper.createProjectDeployment(workspace.getId(), projectDTO);
+
+        long deploymentId = projectDeploymentDTO.id();
+        long parentJobId = 501L;
+        long childJobId = 502L;
+
+        when(principalJobService.getJobIds(deploymentId, PlatformType.AUTOMATION))
+            .thenReturn(List.of(parentJobId, childJobId));
+
+        projectDeploymentFacade.deleteProjectDeployment(deploymentId);
+
+        InOrder inOrder = inOrder(principalJobService, jobFacade);
+
+        inOrder.verify(principalJobService)
+            .deletePrincipalJobs(parentJobId, PlatformType.AUTOMATION);
+        inOrder.verify(principalJobService)
+            .deletePrincipalJobs(childJobId, PlatformType.AUTOMATION);
+        inOrder.verify(jobFacade)
+            .deleteJob(parentJobId);
+        inOrder.verify(jobFacade)
+            .deleteJob(childJobId);
     }
 
     @Disabled

--- a/server/libs/automation/automation-configuration/automation-configuration-service/src/test/java/com/bytechef/automation/configuration/facade/ProjectDeploymentFacadeIntTest.java
+++ b/server/libs/automation/automation-configuration/automation-configuration-service/src/test/java/com/bytechef/automation/configuration/facade/ProjectDeploymentFacadeIntTest.java
@@ -24,6 +24,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.calls;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
@@ -211,10 +212,13 @@ public class ProjectDeploymentFacadeIntTest {
             .deletePrincipalJobs(parentJobId, PlatformType.AUTOMATION);
         inOrder.verify(principalJobService)
             .deletePrincipalJobs(childJobId, PlatformType.AUTOMATION);
-        inOrder.verify(jobFacade)
-            .deleteJob(parentJobId);
-        inOrder.verify(jobFacade)
-            .deleteJob(childJobId);
+        inOrder.verify(jobFacade, calls(1))
+            .deleteJob(anyLong());
+        inOrder.verify(jobFacade, calls(1))
+            .deleteJob(anyLong());
+
+        verify(jobFacade).deleteJob(parentJobId);
+        verify(jobFacade).deleteJob(childJobId);
     }
 
     @Disabled


### PR DESCRIPTION
Split the delete loop into two passes — delete all principal_job rows first, then delete all jobs. The previous single-pass loop deleted parent's principal_job and then called jobFacade.deleteJob(parent), which recursively deletes child jobs whose principal_job rows still existed, causing fk_principal_job_job violations.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
