### PR TITLE
2311 Preserve FIFO delivery for ordered in-memory broker routes

### DIFF
--- a/server/libs/core/message/message-api/src/main/java/com/bytechef/message/route/MessageRoute.java
+++ b/server/libs/core/message/message-api/src/main/java/com/bytechef/message/route/MessageRoute.java
@@ -46,6 +46,15 @@ public interface MessageRoute {
         return Exchange.MESSAGE == getExchange();
     }
 
+    /**
+     * Whether messages on this route must be delivered in strict FIFO order to receivers. In-memory broker
+     * implementations may dispatch unordered routes on a shared thread pool for throughput; ordered routes require
+     * per-route serial dispatch so tokens (e.g., SSE stream events) reach the receiver in the sequence they were sent.
+     */
+    default boolean isOrdered() {
+        return false;
+    }
+
     Exchange getExchange();
 
     String getName();

--- a/server/libs/core/message/message-broker/message-broker-memory/src/main/java/com/bytechef/message/broker/memory/AsyncMessageBroker.java
+++ b/server/libs/core/message/message-broker/message-broker-memory/src/main/java/com/bytechef/message/broker/memory/AsyncMessageBroker.java
@@ -21,9 +21,13 @@ import com.bytechef.message.route.MessageRoute;
 import io.micrometer.context.ContextSnapshot;
 import io.micrometer.context.ContextSnapshotFactory;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.commons.lang3.Validate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,9 +48,13 @@ public class AsyncMessageBroker extends AbstractMessageBroker {
     private static final Logger logger = LoggerFactory.getLogger(AsyncMessageBroker.class);
 
     private final Executor executor;
+    private final boolean virtualThreads;
+    private final Map<MessageRoute, Executor> orderedRouteExecutors = new ConcurrentHashMap<>();
 
     public AsyncMessageBroker(Environment environment) {
-        if (Threading.VIRTUAL.isActive(environment)) {
+        this.virtualThreads = Threading.VIRTUAL.isActive(environment);
+
+        if (virtualThreads) {
             executor = Executors.newVirtualThreadPerTaskExecutor();
         } else {
             executor = Executors.newCachedThreadPool();
@@ -76,14 +84,43 @@ public class AsyncMessageBroker extends AbstractMessageBroker {
             .build()
             .captureAll();
 
+        Executor dispatchExecutor = messageRoute.isOrdered()
+            ? orderedRouteExecutors.computeIfAbsent(messageRoute, this::createOrderedExecutor)
+            : executor;
+
         for (Receiver receiver : Validate.notNull(receivers, "receivers")) {
-            executor.execute(
+            dispatchExecutor.execute(
                 () -> {
                     try (ContextSnapshot.Scope scope = contextSnapshot.setThreadLocals()) {
                         receiver.receive(message);
                     }
                 });
         }
+    }
+
+    private Executor createOrderedExecutor(MessageRoute messageRoute) {
+        ThreadFactory threadFactory = buildOrderedThreadFactory(messageRoute);
+
+        return Executors.newSingleThreadExecutor(threadFactory);
+    }
+
+    private ThreadFactory buildOrderedThreadFactory(MessageRoute messageRoute) {
+        AtomicInteger counter = new AtomicInteger();
+        String prefix = "async-mb-ordered-" + messageRoute.getName() + "-";
+
+        if (virtualThreads) {
+            return runnable -> Thread.ofVirtual()
+                .name(prefix + counter.incrementAndGet())
+                .unstarted(runnable);
+        }
+
+        return runnable -> {
+            Thread thread = new Thread(runnable, prefix + counter.incrementAndGet());
+
+            thread.setDaemon(true);
+
+            return thread;
+        };
     }
 
     private void delay(long value) {

--- a/server/libs/core/message/message-broker/message-broker-memory/src/main/java/com/bytechef/message/broker/memory/AsyncMessageBroker.java
+++ b/server/libs/core/message/message-broker/message-broker-memory/src/main/java/com/bytechef/message/broker/memory/AsyncMessageBroker.java
@@ -24,13 +24,18 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.commons.lang3.Validate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.DisposableBean;
 import org.springframework.boot.thread.Threading;
 import org.springframework.core.env.Environment;
 import org.springframework.util.Assert;
@@ -43,13 +48,23 @@ import org.springframework.util.Assert;
  *
  * @author Ivica Cardic
  */
-public class AsyncMessageBroker extends AbstractMessageBroker {
+public class AsyncMessageBroker extends AbstractMessageBroker implements DisposableBean {
 
     private static final Logger logger = LoggerFactory.getLogger(AsyncMessageBroker.class);
 
-    private final Executor executor;
+    /**
+     * Backpressure threshold for ordered per-route executors. Large enough to absorb typical SSE streaming bursts (LLM
+     * tokens arrive at 50-200/sec, HTTP writer drains within the same cadence) without pinning much memory per route;
+     * small enough that a truly stuck receiver blocks the producer quickly instead of silently accumulating unbounded
+     * backlog.
+     */
+    private static final int ORDERED_QUEUE_CAPACITY = 1024;
+
+    private static final long SHUTDOWN_AWAIT_SECONDS = 5;
+
+    private final ExecutorService executor;
     private final boolean virtualThreads;
-    private final Map<MessageRoute, Executor> orderedRouteExecutors = new ConcurrentHashMap<>();
+    private final Map<MessageRoute, ExecutorService> orderedRouteExecutors = new ConcurrentHashMap<>();
 
     public AsyncMessageBroker(Environment environment) {
         this.virtualThreads = Threading.VIRTUAL.isActive(environment);
@@ -98,10 +113,68 @@ public class AsyncMessageBroker extends AbstractMessageBroker {
         }
     }
 
-    private Executor createOrderedExecutor(MessageRoute messageRoute) {
+    private ExecutorService createOrderedExecutor(MessageRoute messageRoute) {
         ThreadFactory threadFactory = buildOrderedThreadFactory(messageRoute);
 
-        return Executors.newSingleThreadExecutor(threadFactory);
+        // Single worker thread preserves FIFO; bounded queue caps memory; the blocking rejection
+        // handler applies backpressure to the producer when the receiver can't keep up, instead of
+        // dropping messages (which would break ordering semantics for SSE tokens).
+        return new ThreadPoolExecutor(
+            1, 1,
+            0L, TimeUnit.MILLISECONDS,
+            new LinkedBlockingQueue<>(ORDERED_QUEUE_CAPACITY),
+            threadFactory,
+            (task, runningExecutor) -> {
+                if (runningExecutor.isShutdown()) {
+                    throw new RejectedExecutionException(
+                        "Ordered executor is shut down; cannot enqueue message");
+                }
+
+                try {
+                    runningExecutor.getQueue()
+                        .put(task);
+                } catch (InterruptedException interruptedException) {
+                    Thread.currentThread()
+                        .interrupt();
+
+                    throw new RejectedExecutionException(
+                        "Interrupted while waiting for ordered queue capacity", interruptedException);
+                }
+            });
+    }
+
+    @Override
+    public void destroy() {
+        shutdown();
+    }
+
+    public void shutdown() {
+        executor.shutdown();
+
+        for (ExecutorService routeExecutor : orderedRouteExecutors.values()) {
+            routeExecutor.shutdown();
+        }
+
+        awaitTermination(executor);
+
+        for (ExecutorService routeExecutor : orderedRouteExecutors.values()) {
+            awaitTermination(routeExecutor);
+        }
+
+        orderedRouteExecutors.clear();
+    }
+
+    private void awaitTermination(ExecutorService executorService) {
+        try {
+            if (!executorService.awaitTermination(SHUTDOWN_AWAIT_SECONDS, TimeUnit.SECONDS)) {
+                executorService.shutdownNow();
+            }
+        } catch (InterruptedException interruptedException) {
+            executorService.shutdownNow();
+
+            Thread.currentThread()
+                .interrupt();
+        }
     }
 
     private ThreadFactory buildOrderedThreadFactory(MessageRoute messageRoute) {

--- a/server/libs/core/message/message-broker/message-broker-memory/src/test/java/com/bytechef/message/broker/memory/AsyncMessageBrokerTest.java
+++ b/server/libs/core/message/message-broker/message-broker-memory/src/test/java/com/bytechef/message/broker/memory/AsyncMessageBrokerTest.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2025 ByteChef
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.bytechef.message.broker.memory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.bytechef.message.route.MessageRoute;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.env.MockEnvironment;
+
+/**
+ * @author Ivica Cardic
+ */
+class AsyncMessageBrokerTest {
+
+    @Test
+    void orderedRoutePreservesFifoUnderConcurrentSends() throws InterruptedException {
+        AsyncMessageBroker broker = new AsyncMessageBroker(new MockEnvironment());
+        List<Integer> received = java.util.Collections.synchronizedList(new java.util.ArrayList<>());
+        int messageCount = 500;
+        CountDownLatch latch = new CountDownLatch(messageCount);
+
+        broker.receive(TestRoute.ORDERED, message -> {
+            received.add((Integer) message);
+
+            latch.countDown();
+        });
+
+        // Producer is single-threaded to establish a send-order ground truth; the broker's internal
+        // dispatch is what we're stressing. The earlier cached-thread-pool path would reorder these
+        // because each send() spawned a new executor task.
+        for (int i = 0; i < messageCount; i++) {
+            broker.send(TestRoute.ORDERED, i);
+        }
+
+        assertThat(latch.await(10, TimeUnit.SECONDS))
+            .as("all messages should be delivered within timeout")
+            .isTrue();
+        assertThat(received)
+            .as("ordered route must preserve send order")
+            .containsExactlyElementsOf(IntStream.range(0, messageCount)
+                .boxed()
+                .collect(Collectors.toList()));
+    }
+
+    @Test
+    void unorderedRouteStillDispatchesAcrossMultipleThreads() throws InterruptedException {
+        AsyncMessageBroker broker = new AsyncMessageBroker(new MockEnvironment());
+        java.util.Set<String> dispatchThreads = java.util.Collections.synchronizedSet(new java.util.HashSet<>());
+        int messageCount = 50;
+        CountDownLatch allRunning = new CountDownLatch(messageCount);
+        CountDownLatch releaseAll = new CountDownLatch(1);
+
+        broker.receive(TestRoute.UNORDERED, message -> {
+            Thread currentThread = Thread.currentThread();
+
+            dispatchThreads.add(currentThread.getName());
+
+            allRunning.countDown();
+
+            try {
+                releaseAll.await();
+            } catch (InterruptedException e) {
+                currentThread.interrupt();
+            }
+        });
+
+        for (int i = 0; i < messageCount; i++) {
+            broker.send(TestRoute.UNORDERED, i);
+        }
+
+        assertThat(allRunning.await(10, TimeUnit.SECONDS))
+            .as("unordered dispatch must let all receivers run concurrently")
+            .isTrue();
+
+        releaseAll.countDown();
+
+        assertThat(dispatchThreads)
+            .as("unordered route should fan out across the cached thread pool")
+            .hasSizeGreaterThan(1);
+    }
+
+    @Test
+    void differentOrderedRoutesRunOnIndependentThreads() throws InterruptedException {
+        AsyncMessageBroker broker = new AsyncMessageBroker(new MockEnvironment());
+        AtomicInteger routeAThread = new AtomicInteger();
+        AtomicInteger routeBThread = new AtomicInteger();
+        CountDownLatch latch = new CountDownLatch(2);
+        List<String> routeAThreadNames = java.util.Collections.synchronizedList(new java.util.ArrayList<>());
+        List<String> routeBThreadNames = java.util.Collections.synchronizedList(new java.util.ArrayList<>());
+
+        broker.receive(TestRoute.ORDERED, message -> {
+            Thread currentThread = Thread.currentThread();
+
+            routeAThreadNames.add(currentThread.getName());
+            routeAThread.incrementAndGet();
+
+            latch.countDown();
+        });
+
+        broker.receive(TestRoute.ORDERED_OTHER, message -> {
+            Thread currentThread = Thread.currentThread();
+
+            routeBThreadNames.add(currentThread.getName());
+            routeBThread.incrementAndGet();
+
+            latch.countDown();
+        });
+
+        broker.send(TestRoute.ORDERED, 1);
+        broker.send(TestRoute.ORDERED_OTHER, 2);
+
+        assertThat(latch.await(5, TimeUnit.SECONDS))
+            .as("both receivers should be invoked")
+            .isTrue();
+        assertThat(routeAThreadNames)
+            .as("route A thread name should not overlap with route B")
+            .doesNotContainAnyElementsOf(routeBThreadNames);
+    }
+
+    @Test
+    void orderedRoutePreservesFifoAcrossConcurrentProducers() throws InterruptedException {
+        AsyncMessageBroker broker = new AsyncMessageBroker(new MockEnvironment());
+        List<Integer> received = java.util.Collections.synchronizedList(new java.util.ArrayList<>());
+        int messagesPerProducer = 200;
+        int producerCount = 4;
+        int total = messagesPerProducer * producerCount;
+        CountDownLatch latch = new CountDownLatch(total);
+
+        broker.receive(TestRoute.ORDERED, message -> {
+            received.add((Integer) message);
+
+            latch.countDown();
+        });
+
+        ExecutorService producers = Executors.newFixedThreadPool(producerCount);
+
+        try {
+            for (int p = 0; p < producerCount; p++) {
+                int producerId = p;
+
+                producers.submit(() -> {
+                    for (int i = 0; i < messagesPerProducer; i++) {
+                        broker.send(TestRoute.ORDERED, producerId * messagesPerProducer + i);
+                    }
+                });
+            }
+
+            assertThat(latch.await(15, TimeUnit.SECONDS))
+                .as("all messages should be delivered")
+                .isTrue();
+        } finally {
+            producers.shutdownNow();
+        }
+
+        // Per-producer sequences must remain in send-order once interleaved at the receiver. A broker
+        // without the per-route serial executor would drop this guarantee because each send() would
+        // dispatch on its own pool thread.
+        for (int p = 0; p < producerCount; p++) {
+            int base = p * messagesPerProducer;
+            List<Integer> producerReceived = received.stream()
+                .filter(value -> value >= base && value < base + messagesPerProducer)
+                .toList();
+
+            assertThat(producerReceived)
+                .as("messages from producer %d must be received in send order", p)
+                .containsExactlyElementsOf(IntStream.range(base, base + messagesPerProducer)
+                    .boxed()
+                    .collect(Collectors.toList()));
+        }
+    }
+
+    private enum TestRoute implements MessageRoute {
+
+        ORDERED(true, "test.ordered"),
+        ORDERED_OTHER(true, "test.ordered.other"),
+        UNORDERED(false, "test.unordered");
+
+        private final boolean ordered;
+        private final String routeName;
+
+        TestRoute(boolean ordered, String routeName) {
+            this.ordered = ordered;
+            this.routeName = routeName;
+        }
+
+        @Override
+        public Exchange getExchange() {
+            return Exchange.MESSAGE;
+        }
+
+        @Override
+        public String getName() {
+            return routeName;
+        }
+
+        @Override
+        public boolean isOrdered() {
+            return ordered;
+        }
+    }
+}

--- a/server/libs/core/message/message-broker/message-broker-memory/src/test/java/com/bytechef/message/broker/memory/AsyncMessageBrokerTest.java
+++ b/server/libs/core/message/message-broker/message-broker-memory/src/test/java/com/bytechef/message/broker/memory/AsyncMessageBrokerTest.java
@@ -19,14 +19,19 @@ package com.bytechef.message.broker.memory;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.bytechef.message.route.MessageRoute;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.env.MockEnvironment;
 
@@ -35,10 +40,23 @@ import org.springframework.mock.env.MockEnvironment;
  */
 class AsyncMessageBrokerTest {
 
+    private AsyncMessageBroker broker;
+
+    @BeforeEach
+    void setUp() {
+        broker = new AsyncMessageBroker(new MockEnvironment());
+    }
+
+    @AfterEach
+    void tearDown() {
+        // Shut down all executors so test threads don't leak between cases and the JVM can exit
+        // cleanly after the suite (the cached thread pool's workers are non-daemon).
+        broker.shutdown();
+    }
+
     @Test
     void orderedRoutePreservesFifoUnderConcurrentSends() throws InterruptedException {
-        AsyncMessageBroker broker = new AsyncMessageBroker(new MockEnvironment());
-        List<Integer> received = java.util.Collections.synchronizedList(new java.util.ArrayList<>());
+        List<Integer> received = Collections.synchronizedList(new ArrayList<>());
         int messageCount = 500;
         CountDownLatch latch = new CountDownLatch(messageCount);
 
@@ -67,8 +85,7 @@ class AsyncMessageBrokerTest {
 
     @Test
     void unorderedRouteStillDispatchesAcrossMultipleThreads() throws InterruptedException {
-        AsyncMessageBroker broker = new AsyncMessageBroker(new MockEnvironment());
-        java.util.Set<String> dispatchThreads = java.util.Collections.synchronizedSet(new java.util.HashSet<>());
+        Set<String> dispatchThreads = Collections.synchronizedSet(new HashSet<>());
         int messageCount = 50;
         CountDownLatch allRunning = new CountDownLatch(messageCount);
         CountDownLatch releaseAll = new CountDownLatch(1);
@@ -104,27 +121,22 @@ class AsyncMessageBrokerTest {
 
     @Test
     void differentOrderedRoutesRunOnIndependentThreads() throws InterruptedException {
-        AsyncMessageBroker broker = new AsyncMessageBroker(new MockEnvironment());
-        AtomicInteger routeAThread = new AtomicInteger();
-        AtomicInteger routeBThread = new AtomicInteger();
         CountDownLatch latch = new CountDownLatch(2);
-        List<String> routeAThreadNames = java.util.Collections.synchronizedList(new java.util.ArrayList<>());
-        List<String> routeBThreadNames = java.util.Collections.synchronizedList(new java.util.ArrayList<>());
+        List<String> routeAThreadNames = Collections.synchronizedList(new ArrayList<>());
+        List<String> routeBThreadNames = Collections.synchronizedList(new ArrayList<>());
 
         broker.receive(TestRoute.ORDERED, message -> {
-            Thread currentThread = Thread.currentThread();
-
-            routeAThreadNames.add(currentThread.getName());
-            routeAThread.incrementAndGet();
+            routeAThreadNames.add(
+                Thread.currentThread()
+                    .getName());
 
             latch.countDown();
         });
 
         broker.receive(TestRoute.ORDERED_OTHER, message -> {
-            Thread currentThread = Thread.currentThread();
-
-            routeBThreadNames.add(currentThread.getName());
-            routeBThread.incrementAndGet();
+            routeBThreadNames.add(
+                Thread.currentThread()
+                    .getName());
 
             latch.countDown();
         });
@@ -142,8 +154,7 @@ class AsyncMessageBrokerTest {
 
     @Test
     void orderedRoutePreservesFifoAcrossConcurrentProducers() throws InterruptedException {
-        AsyncMessageBroker broker = new AsyncMessageBroker(new MockEnvironment());
-        List<Integer> received = java.util.Collections.synchronizedList(new java.util.ArrayList<>());
+        List<Integer> received = Collections.synchronizedList(new ArrayList<>());
         int messagesPerProducer = 200;
         int producerCount = 4;
         int total = messagesPerProducer * producerCount;
@@ -190,6 +201,68 @@ class AsyncMessageBrokerTest {
                     .boxed()
                     .collect(Collectors.toList()));
         }
+    }
+
+    @Test
+    void orderedRouteBackpressuresProducerWithoutDroppingMessages() throws InterruptedException {
+        // Stalled receiver + producer burst larger than the bounded queue proves the blocking
+        // rejection handler applies backpressure instead of silently losing tokens — this is the
+        // property SSE streaming relies on to avoid mid-stream gaps.
+        List<Integer> received = Collections.synchronizedList(new ArrayList<>());
+        CountDownLatch firstReceived = new CountDownLatch(1);
+        CountDownLatch release = new CountDownLatch(1);
+
+        broker.receive(TestRoute.ORDERED, message -> {
+            firstReceived.countDown();
+
+            try {
+                release.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread()
+                    .interrupt();
+            }
+
+            received.add((Integer) message);
+        });
+
+        int burst = 1100;
+        CountDownLatch producerDone = new CountDownLatch(1);
+        Thread producer = new Thread(() -> {
+            for (int i = 0; i < burst; i++) {
+                broker.send(TestRoute.ORDERED, i);
+            }
+
+            producerDone.countDown();
+        });
+
+        producer.start();
+
+        assertThat(firstReceived.await(5, TimeUnit.SECONDS))
+            .as("first message should start being consumed")
+            .isTrue();
+        assertThat(producerDone.await(1, TimeUnit.SECONDS))
+            .as("producer should block on bounded queue once capacity is reached")
+            .isFalse();
+
+        release.countDown();
+
+        assertThat(producerDone.await(10, TimeUnit.SECONDS))
+            .as("producer should complete once receiver drains the queue")
+            .isTrue();
+
+        // Wait for receiver to drain fully.
+        long deadline = System.currentTimeMillis() + 10_000;
+
+        while (received.size() < burst && System.currentTimeMillis() < deadline) {
+            Thread.sleep(20);
+        }
+
+        assertThat(received)
+            .as("bounded queue must backpressure rather than drop messages")
+            .hasSize(burst)
+            .containsExactlyElementsOf(IntStream.range(0, burst)
+                .boxed()
+                .collect(Collectors.toList()));
     }
 
     private enum TestRoute implements MessageRoute {

--- a/server/libs/modules/components/chat/src/main/java/com/bytechef/component/chat/trigger/ChatNewRequestTrigger.java
+++ b/server/libs/modules/components/chat/src/main/java/com/bytechef/component/chat/trigger/ChatNewRequestTrigger.java
@@ -92,14 +92,18 @@ public class ChatNewRequestTrigger {
             .stream()
             .collect(Collectors.toMap(entry -> (String) entry.getKey(), entry -> {
                 if (entry.getValue() instanceof List<?> list) {
+                    if (list.isEmpty()) {
+                        return list;
+                    }
+
                     if (list.getFirst() instanceof FileEntry) {
                         return list;
-                    } else {
-                        return list.getFirst();
                     }
-                } else {
-                    return entry.getValue();
+
+                    return list.getFirst();
                 }
+
+                return entry.getValue();
             }));
     }
 }

--- a/server/libs/modules/components/chat/src/test/java/com/bytechef/component/chat/trigger/ChatNewRequestTriggerTest.java
+++ b/server/libs/modules/components/chat/src/test/java/com/bytechef/component/chat/trigger/ChatNewRequestTriggerTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2025 ByteChef
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.bytechef.component.chat.trigger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.bytechef.component.definition.TriggerDefinition.WebhookBody;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Ivica Cardic
+ */
+class ChatNewRequestTriggerTest {
+
+    @Test
+    void getWebhookResultPreservesEmptyAttachmentsFromJsonPayload() {
+        // A JSON client sending `attachments: []` must not crash the trigger. Java 21's
+        // List.getFirst() throws on empty lists, so checkMap has to short-circuit first.
+        Map<String, Object> content = new LinkedHashMap<>();
+
+        content.put("conversationId", "abc123");
+        content.put("message", "Hi");
+        content.put("attachments", List.of());
+
+        WebhookBody body = mock(WebhookBody.class);
+
+        when(body.getContent()).thenReturn(content);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> result =
+            (Map<String, Object>) ChatNewRequestTrigger.getWebhookResult(null, null, null, null, body, null, null,
+                null);
+
+        assertThat(result)
+            .containsEntry("message", "Hi")
+            .containsEntry("conversationId", "abc123")
+            .containsEntry("attachments", List.of());
+    }
+
+    @Test
+    void getWebhookResultUnwrapsSingletonNonFileEntryList() {
+        // Form-data clients submit each field as a singleton list; checkMap unwraps those
+        // back to scalars so downstream ${trigger.field} resolves to the value directly.
+        Map<String, Object> content = new LinkedHashMap<>();
+
+        content.put("conversationId", List.of("abc123"));
+        content.put("message", List.of("Hi"));
+
+        WebhookBody body = mock(WebhookBody.class);
+
+        when(body.getContent()).thenReturn(content);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> result =
+            (Map<String, Object>) ChatNewRequestTrigger.getWebhookResult(null, null, null, null, body, null, null,
+                null);
+
+        assertThat(result)
+            .containsEntry("conversationId", "abc123")
+            .containsEntry("message", "Hi")
+            .containsEntry("attachments", List.of());
+    }
+
+    @Test
+    void getWebhookResultDefaultsAttachmentsWhenAbsent() {
+        Map<String, Object> content = new LinkedHashMap<>();
+
+        content.put("conversationId", "abc123");
+        content.put("message", "Hi");
+
+        WebhookBody body = mock(WebhookBody.class);
+
+        when(body.getContent()).thenReturn(content);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> result =
+            (Map<String, Object>) ChatNewRequestTrigger.getWebhookResult(null, null, null, null, body, null, null,
+                null);
+
+        assertThat(result)
+            .containsEntry("attachments", List.of());
+    }
+}

--- a/server/libs/platform/platform-webhook/platform-webhook-api/src/main/java/com/bytechef/platform/webhook/message/route/SseStreamMessageRoute.java
+++ b/server/libs/platform/platform-webhook/platform-webhook-api/src/main/java/com/bytechef/platform/webhook/message/route/SseStreamMessageRoute.java
@@ -47,6 +47,11 @@ public enum SseStreamMessageRoute implements MessageRoute {
     }
 
     @Override
+    public boolean isOrdered() {
+        return true;
+    }
+
+    @Override
     public String toString() {
         return "SseStreamMessageRoute{" +
             "exchange=" + exchange +

--- a/server/libs/platform/platform-webhook/platform-webhook-api/src/test/java/com/bytechef/platform/webhook/message/route/SseStreamMessageRouteTest.java
+++ b/server/libs/platform/platform-webhook/platform-webhook-api/src/test/java/com/bytechef/platform/webhook/message/route/SseStreamMessageRouteTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2025 ByteChef
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.bytechef.platform.webhook.message.route;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Ivica Cardic
+ */
+class SseStreamMessageRouteTest {
+
+    @Test
+    void sseStreamEventsRouteMustBeOrdered() {
+        // In-memory broker dispatches unordered routes on a shared thread pool; SSE tokens would
+        // reach the emitter out of order without this flag. Do not relax it without replacing the
+        // ordering guarantee elsewhere in the pipeline.
+        assertThat(SseStreamMessageRoute.SSE_STREAM_EVENTS.isOrdered())
+            .isTrue();
+    }
+}


### PR DESCRIPTION
Adds an opt-in MessageRoute.isOrdered() flag and makes AsyncMessageBroker
dispatch ordered routes through a per-route single-thread executor so SSE
stream tokens reach the bridge in emission order instead of racing across
the shared cached thread pool.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
