### PR TITLE
4000 Fix dataTable updateRecord stripping values on refresh

### DIFF
--- a/server/libs/modules/components/data-table/src/main/java/com/bytechef/component/datatable/util/DataTableUtils.java
+++ b/server/libs/modules/components/data-table/src/main/java/com/bytechef/component/datatable/util/DataTableUtils.java
@@ -227,21 +227,21 @@ public final class DataTableUtils {
                 columnProperties.add(mapColumn(columnSpec));
             }
 
+            if (singleRecord) {
+                return columnProperties;
+            }
+
             var valuesObject = object(VALUES)
                 .label("Values")
                 .properties(columnProperties)
                 .required(true);
 
-            if (singleRecord) {
-                return List.of(valuesObject);
-            } else {
-                var recordsArray = array(VALUES)
-                    .label("Records")
-                    .items(valuesObject)
-                    .required(true);
+            var recordsArray = array(VALUES)
+                .label("Records")
+                .items(valuesObject)
+                .required(true);
 
-                return List.of(recordsArray);
-            }
+            return List.of(recordsArray);
         };
     }
 


### PR DESCRIPTION
Remove the redundant object(VALUES) wrapper in DataTableUtils.createDynamicProperties
for the single-record case. The outer dynamicProperties(VALUES) in DataTableUpdateRecordAction
was already acting as the container, so wrapping the columns in another object named VALUES
produced colliding paths like values.values.<column> that the client form logic dropped on
reopen. Returning the columns directly yields clean values.<column> paths and also matches
what perform() reads via inputParameters.getRequired(VALUES, Map.class).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
