### PR TITLE
4719 client - Block duplicate subproperty names in ObjectProperty popover

### DIFF
--- a/client/src/pages/platform/workflow-editor/components/properties/ObjectProperty.tsx
+++ b/client/src/pages/platform/workflow-editor/components/properties/ObjectProperty.tsx
@@ -27,6 +27,7 @@ const ObjectProperty = ({arrayIndex, arrayName, onDeleteClick, operationName, pa
         handleAddItemClick,
         handleDeleteClick,
         isContainerObject,
+        isDuplicateName,
         label,
         name,
         newPropertyName,
@@ -87,6 +88,7 @@ const ObjectProperty = ({arrayIndex, arrayName, onDeleteClick, operationName, pa
                     availablePropertyTypes={availablePropertyTypes}
                     buttonLabel={placeholder}
                     handleClick={handleAddItemClick}
+                    isDuplicateName={isDuplicateName}
                     newPropertyName={newPropertyName}
                     newPropertyType={newPropertyType}
                     propertyName={name}

--- a/client/src/pages/platform/workflow-editor/components/properties/components/SubPropertyPopover.tsx
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/SubPropertyPopover.tsx
@@ -16,6 +16,7 @@ interface SubPropertyPopoverProps {
     disabledTooltip?: string;
     handleClick: () => void;
     insideConditionTaskDispatcher?: boolean;
+    isDuplicateName?: boolean;
     newPropertyName?: string;
     newPropertyType: keyof typeof VALUE_PROPERTY_CONTROL_TYPES | string;
     propertyName?: string;
@@ -31,6 +32,7 @@ const SubPropertyPopover = ({
     disabledTooltip,
     handleClick,
     insideConditionTaskDispatcher,
+    isDuplicateName = false,
     newPropertyName,
     newPropertyType,
     propertyName,
@@ -103,6 +105,8 @@ const SubPropertyPopover = ({
                     {!array && (
                         <PropertyInput
                             className="mb-2"
+                            error={isDuplicateName}
+                            errorMessage="A property with this name already exists."
                             label="Name"
                             name="additionalPropertyName"
                             onChange={handleNewPropertyNameChange}
@@ -154,7 +158,12 @@ const SubPropertyPopover = ({
 
                 <footer className="flex items-center justify-end space-x-2">
                     <PopoverClose asChild>
-                        <Button disabled={!array && !newPropertyName} label="Add" onClick={handleClick} size="sm" />
+                        <Button
+                            disabled={isDuplicateName || (!array && !newPropertyName)}
+                            label="Add"
+                            onClick={handleClick}
+                            size="sm"
+                        />
                     </PopoverClose>
                 </footer>
             </PopoverContent>

--- a/client/src/pages/platform/workflow-editor/components/properties/hooks/tests/useObjectProperty.test.ts
+++ b/client/src/pages/platform/workflow-editor/components/properties/hooks/tests/useObjectProperty.test.ts
@@ -154,6 +154,45 @@ describe('useObjectProperty — default value save guard', () => {
         expect(hoisted.mockSaveProperty).not.toHaveBeenCalled();
     });
 
+    it('should not add a duplicate subproperty when the typed name matches an existing one', async () => {
+        hoisted.storeState.currentComponent = {
+            parameters: {response: {outputSchema: {testField: {}}}},
+        };
+
+        const {useObjectProperty} = await import('../useObjectProperty');
+
+        const {result} = renderHook(() =>
+            useObjectProperty({
+                path: 'response.outputSchema',
+                property: {
+                    controlType: 'OBJECT_BUILDER',
+                    name: 'outputSchema',
+                    properties: subPropertyDefinitions,
+                    type: 'OBJECT',
+                } as unknown as Parameters<typeof useObjectProperty>[0]['property'],
+            })
+        );
+
+        await act(async () => {
+            vi.advanceTimersByTime(700);
+        });
+
+        expect(result.current.subProperties).toHaveLength(1);
+
+        act(() => {
+            result.current.setNewPropertyName('testField');
+        });
+
+        expect(result.current.isDuplicateName).toBe(true);
+
+        act(() => {
+            result.current.handleAddItemClick();
+        });
+
+        expect(result.current.subProperties).toHaveLength(1);
+        expect(hoisted.mockSaveProperty).not.toHaveBeenCalled();
+    });
+
     it('should reset save guard when path changes', async () => {
         const {useObjectProperty} = await import('../useObjectProperty');
 

--- a/client/src/pages/platform/workflow-editor/components/properties/hooks/useObjectProperty.ts
+++ b/client/src/pages/platform/workflow-editor/components/properties/hooks/useObjectProperty.ts
@@ -95,8 +95,23 @@ export const useObjectProperty = ({onDeleteClick, path, property}: UseObjectProp
         path = path.replace('.__item', '');
     }
 
+    const encodedNewPropertyName = useMemo(
+        () => (newPropertyName ? encodePath(newPropertyName) : ''),
+        [newPropertyName]
+    );
+
+    const isDuplicateName = useMemo(() => {
+        if (!encodedNewPropertyName) {
+            return false;
+        }
+
+        return !!subProperties?.some((subProperty) => subProperty.name === encodedNewPropertyName);
+    }, [encodedNewPropertyName, subProperties]);
+
     const handleAddItemClick = useCallback(() => {
-        const encodedPropertyName = encodePath(newPropertyName);
+        if (!newPropertyName || isDuplicateName) {
+            return;
+        }
 
         const newItem: SubPropertyType = {
             additionalProperties,
@@ -104,7 +119,7 @@ export const useObjectProperty = ({onDeleteClick, path, property}: UseObjectProp
             custom: true,
             expressionEnabled: true,
             label: newPropertyName,
-            name: encodedPropertyName,
+            name: encodedNewPropertyName,
             type: (newPropertyType ||
                 additionalProperties?.[0].type ||
                 'STRING') as keyof typeof VALUE_PROPERTY_CONTROL_TYPES,
@@ -117,7 +132,7 @@ export const useObjectProperty = ({onDeleteClick, path, property}: UseObjectProp
         if (updateWorkflowNodeParameterMutation || updateClusterElementParameterMutation) {
             saveProperty({
                 includeInMetadata: true,
-                path: `${path}.${encodedPropertyName}`,
+                path: `${path}.${encodedNewPropertyName}`,
                 type: newPropertyType,
                 updateClusterElementParameterMutation,
                 updateWorkflowNodeParameterMutation,
@@ -126,6 +141,8 @@ export const useObjectProperty = ({onDeleteClick, path, property}: UseObjectProp
         }
     }, [
         additionalProperties,
+        encodedNewPropertyName,
+        isDuplicateName,
         newPropertyName,
         newPropertyType,
         path,
@@ -486,6 +503,7 @@ export const useObjectProperty = ({onDeleteClick, path, property}: UseObjectProp
         handleAddItemClick,
         handleDeleteClick,
         isContainerObject,
+        isDuplicateName,
         label,
         name,
         newPropertyName,

--- a/client/src/pages/platform/workflow-editor/components/properties/hooks/useObjectProperty.ts
+++ b/client/src/pages/platform/workflow-editor/components/properties/hooks/useObjectProperty.ts
@@ -105,7 +105,9 @@ export const useObjectProperty = ({onDeleteClick, path, property}: UseObjectProp
             return false;
         }
 
-        return !!subProperties?.some((subProperty) => subProperty.name === encodedNewPropertyName);
+        return !!subProperties?.some(
+            (subProperty) => !!subProperty.name && encodePath(subProperty.name) === encodedNewPropertyName
+        );
     }, [encodedNewPropertyName, subProperties]);
 
     const handleAddItemClick = useCallback(() => {


### PR DESCRIPTION
Prevents React duplicate-key errors when a user adds a subproperty whose
name already exists. The hook now exposes an isDuplicateName flag; the
popover surfaces an inline error and disables Add until the name is unique.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
