### PR TITLE
2896

### DIFF
--- a/client/src/components/assistant-ui/markdown-text.tsx
+++ b/client/src/components/assistant-ui/markdown-text.tsx
@@ -35,7 +35,7 @@ const CodeHeader: FC<CodeHeaderProps> = ({ language, code }) => {
   };
 
   return (
-    <div className="aui-code-header-root mt-4 flex items-center justify-between gap-4 rounded-t-lg bg-muted-foreground/15 px-4 py-2 text-sm font-semibold text-foreground dark:bg-muted-foreground/20">
+    <div className="aui-code-header-root mt-4 flex items-center justify-between gap-4 rounded-t-lg border border-b-0 border-border bg-muted-foreground/15 px-4 py-2 text-sm font-semibold text-foreground dark:bg-muted-foreground/20">
       <span className="aui-code-header-language lowercase [&>span]:text-xs">
         {language}
       </span>
@@ -205,7 +205,7 @@ const defaultComponents = memoizeMarkdownComponents({
   pre: ({ className, ...props }) => (
     <pre
       className={cn(
-        "aui-md-pre overflow-x-auto !rounded-t-none rounded-b-lg bg-black p-4 text-white",
+        "aui-md-pre overflow-x-auto !rounded-t-none rounded-b-lg border border-t-0 border-border bg-black p-4 text-white",
         className,
       )}
       {...props}

--- a/client/src/pages/automation/chats/components/ChatsSidebar.tsx
+++ b/client/src/pages/automation/chats/components/ChatsSidebar.tsx
@@ -1,3 +1,4 @@
+import {Skeleton} from '@/components/ui/skeleton';
 import {useChatsStore} from '@/pages/automation/chats/stores/useChatsStore';
 import {useWorkspaceStore} from '@/pages/automation/stores/useWorkspaceStore';
 import {LeftSidebarNav, LeftSidebarNavItem} from '@/shared/layout/LeftSidebarNav';
@@ -5,6 +6,22 @@ import {useWorkspaceChatWorkflowsQuery} from '@/shared/middleware/graphql';
 import {useEnvironmentStore} from '@/shared/stores/useEnvironmentStore';
 import {useMemo} from 'react';
 import {useParams} from 'react-router-dom';
+
+const ChatsSidebarSkeleton = () => (
+    <>
+        {Array.from({length: 2}).map((_, groupIndex) => (
+            <div className="mb-6 px-4" key={groupIndex}>
+                <Skeleton className="my-1 h-4 w-28" />
+
+                <div className="mt-2 flex flex-col gap-2">
+                    {Array.from({length: 6}).map((_, itemIndex) => (
+                        <Skeleton className="h-6 w-full" key={itemIndex} />
+                    ))}
+                </div>
+            </div>
+        ))}
+    </>
+);
 
 interface ProjectChatGroupI {
     projectName: string;
@@ -52,9 +69,13 @@ const ChatsSidebar = () => {
         return result;
     }, [isLoading, data]);
 
+    if (isLoading) {
+        return <ChatsSidebarSkeleton />;
+    }
+
     return (
         <>
-            {workflowsByProject.size === 0 && data ? (
+            {workflowsByProject.size === 0 ? (
                 <div className="mb-4 px-2">
                     <span className="px-3 text-xs">No chats found</span>
                 </div>

--- a/client/src/pages/automation/chats/components/ChatsSidebar.tsx
+++ b/client/src/pages/automation/chats/components/ChatsSidebar.tsx
@@ -73,6 +73,10 @@ const ChatsSidebar = () => {
         return <ChatsSidebarSkeleton />;
     }
 
+    if (!data?.workspaceChatWorkflows) {
+        return null;
+    }
+
     return (
         <>
             {workflowsByProject.size === 0 ? (

--- a/client/src/pages/automation/project-deployments/components/project-deployment-workflow-list/ProjectDeploymentWorkflowListItem.tsx
+++ b/client/src/pages/automation/project-deployments/components/project-deployment-workflow-list/ProjectDeploymentWorkflowListItem.tsx
@@ -65,7 +65,7 @@ const ProjectDeploymentWorkflowListItem = ({
         workflow.triggers.findIndex((trigger) => trigger.type.includes('chat/')) !== -1 &&
         (workflow.triggers?.[0]?.parameters?.mode ?? 1) === 1;
 
-    const hostedChatTriggerPageUrl = getPageUrl('chat', undefined, projectDeploymentWorkflow.staticWebhookUrl);
+    const hostedChatTriggerPageUrl = getPageUrl('chats', undefined, projectDeploymentWorkflow.staticWebhookUrl);
 
     const enableProjectDeploymentWorkflowMutation = useEnableProjectDeploymentWorkflowMutation({
         onSuccess: () => {

--- a/client/src/pages/automation/project-deployments/components/project-deployment-workflow-list/util/pageUrl-utils.ts
+++ b/client/src/pages/automation/project-deployments/components/project-deployment-workflow-list/util/pageUrl-utils.ts
@@ -1,4 +1,4 @@
-export const getPageUrl = (type: 'form' | 'chat', environmentId?: number, staticWebhookUrl?: string) => {
+export const getPageUrl = (type: 'form' | 'chats', environmentId?: number, staticWebhookUrl?: string) => {
     if (!staticWebhookUrl) {
         return '';
     }
@@ -7,5 +7,5 @@ export const getPageUrl = (type: 'form' | 'chat', environmentId?: number, static
         staticWebhookUrl.lastIndexOf('/webhooks/') + '/webhooks/'.length
     );
 
-    return `${type === 'chat' ? '/automation' : ''}/${type}${type === 'form' ? `/${environmentId}` : ''}/${workflowExecutionId}`;
+    return `${type === 'chats' ? '/automation' : ''}/${type}${type === 'form' ? `/${environmentId}` : ''}/${workflowExecutionId}`;
 };

--- a/client/src/pages/automation/project-deployments/components/project-deployment-workflow-list/util/tests/pageUrl-utils.test.ts
+++ b/client/src/pages/automation/project-deployments/components/project-deployment-workflow-list/util/tests/pageUrl-utils.test.ts
@@ -22,9 +22,9 @@ describe('getPageUrl', () => {
     });
 
     it('generates chat trigger URL', () => {
-        const result = getPageUrl('chat', undefined, 'https://example.com/webhooks/xyz789');
+        const result = getPageUrl('chats', undefined, 'https://example.com/webhooks/xyz789');
 
-        expect(result).toBe('/automation/chat/xyz789');
+        expect(result).toBe('/automation/chats/xyz789');
     });
 
     it('handles different environment IDs', () => {
@@ -34,9 +34,9 @@ describe('getPageUrl', () => {
     });
 
     it('extracts webhook ID from URL with path segments', () => {
-        const result = getPageUrl('chat', undefined, 'https://api.example.com/v1/webhooks/webhook-identifier-123');
+        const result = getPageUrl('chats', undefined, 'https://api.example.com/v1/webhooks/webhook-identifier-123');
 
-        expect(result).toBe('/automation/chat/webhook-identifier-123');
+        expect(result).toBe('/automation/chats/webhook-identifier-123');
     });
 
     it('handles webhook URL with trailing slash', () => {
@@ -46,9 +46,9 @@ describe('getPageUrl', () => {
     });
 
     it('handles webhook URL with query parameters', () => {
-        const result = getPageUrl('chat', 1, 'https://example.com/webhooks/abc123?param=value');
+        const result = getPageUrl('chats', 1, 'https://example.com/webhooks/abc123?param=value');
 
-        expect(result).toBe('/automation/chat/abc123?param=value');
+        expect(result).toBe('/automation/chats/abc123?param=value');
     });
 
     it('handles complex webhook IDs', () => {

--- a/client/src/pages/platform/workflow-editor/hooks/useLayout.tsx
+++ b/client/src/pages/platform/workflow-editor/hooks/useLayout.tsx
@@ -16,7 +16,6 @@ import {
     Workflow,
     WorkflowTask,
 } from '@/shared/middleware/platform/configuration';
-import {WIDTHS} from '@/shared/theme/constants';
 import {BranchCaseType, NodeDataType} from '@/shared/types';
 import {Edge, Node} from '@xyflow/react';
 import {ComponentIcon} from 'lucide-react';
@@ -869,23 +868,7 @@ export default function useLayout({
                 return;
             }
 
-            let targetNodes: Node[];
-
-            if (readOnlyWorkflow) {
-                const SHEET_WIDTH = WIDTHS.WORKFLOW_READ_ONLY_SHEET_WIDTH;
-
-                const centeringOffsetX = (canvasWidthRef.current - SHEET_WIDTH) / 2;
-
-                targetNodes = elements.nodes.map((node) => ({
-                    ...node,
-                    position: {
-                        x: node.position.x - centeringOffsetX,
-                        y: node.position.y,
-                    },
-                }));
-            } else {
-                targetNodes = elements.nodes;
-            }
+            const targetNodes: Node[] = elements.nodes;
 
             if (isInitialLayoutRef.current || readOnlyWorkflow) {
                 setNodes(targetNodes);
@@ -930,8 +913,8 @@ export default function useLayout({
     }, [layoutDirection, layoutResetCounter, tasks, triggers, isWorkflowLoaded]);
 
     useEffect(() => {
-        if (canvasWidth > 0 && !isWorkflowLoaded) {
+        if (canvasWidth > 0 && !isWorkflowLoaded && !readOnlyWorkflow) {
             initializeWithCanvasWidth(canvasWidth);
         }
-    }, [canvasWidth, initializeWithCanvasWidth, isWorkflowLoaded]);
+    }, [canvasWidth, initializeWithCanvasWidth, isWorkflowLoaded, readOnlyWorkflow]);
 }

--- a/client/src/pages/platform/workflow-editor/utils/handleComponentAddedSuccess.ts
+++ b/client/src/pages/platform/workflow-editor/utils/handleComponentAddedSuccess.ts
@@ -23,6 +23,7 @@ export function openNodeDetailsPanelForNewNode(nodeData: NodeDataType): void {
     const {
         currentComponent,
         currentNode,
+        setActiveTab,
         setCurrentComponent,
         setCurrentNode,
         setWorkflowNodeDetailsPanelOpen,
@@ -35,6 +36,9 @@ export function openNodeDetailsPanelForNewNode(nodeData: NodeDataType): void {
             setCurrentComponent({...currentComponent, ...nodeData});
         }
     } else {
+        // Reset to 'description' so the Properties tab's display-conditions query
+        // doesn't fire against the server before the optimistic workflow update lands.
+        setActiveTab('description');
         setCurrentNode({...nodeData, description: ''});
         setCurrentComponent({...nodeData, description: ''});
         setWorkflowNodeDetailsPanelOpen(true);

--- a/client/src/pages/platform/workflow-editor/utils/tests/handleComponentAddedSuccess.test.ts
+++ b/client/src/pages/platform/workflow-editor/utils/tests/handleComponentAddedSuccess.test.ts
@@ -20,6 +20,7 @@ const makeNodeData = (overrides: Partial<NodeDataType> = {}): NodeDataType =>
 describe('openNodeDetailsPanelForNewNode', () => {
     beforeEach(() => {
         useWorkflowNodeDetailsPanelStore.setState({
+            activeTab: 'description',
             currentComponent: undefined,
             currentNode: undefined,
             workflowNodeDetailsPanelOpen: false,
@@ -37,6 +38,14 @@ describe('openNodeDetailsPanelForNewNode', () => {
         expect(state.currentNode?.name).toBe('slack_1');
         expect(state.currentNode?.description).toBe('');
         expect(state.currentComponent?.componentName).toBe('slack');
+    });
+
+    it('should reset activeTab to description when opening the panel for a new node', () => {
+        useWorkflowNodeDetailsPanelStore.setState({activeTab: 'properties'});
+
+        openNodeDetailsPanelForNewNode(makeNodeData());
+
+        expect(useWorkflowNodeDetailsPanelStore.getState().activeTab).toBe('description');
     });
 
     it('should not open the panel for cluster element nodes', () => {

--- a/client/test/playwright/tests/properties/objectProperty.spec.ts
+++ b/client/test/playwright/tests/properties/objectProperty.spec.ts
@@ -215,6 +215,64 @@ test.describe('ObjectProperty - Object property type (ObjectProperty.tsx)', () =
             });
         });
 
+        test('should block adding a subproperty whose name matches an existing one', async () => {
+            const existingPropertyName = workflowPage.objectPropertyParameterKeys[0];
+
+            expect(existingPropertyName, 'sample workflow must expose at least one existing subproperty').toBeTruthy();
+
+            const initialSubpropertyCount = await workflowPage.subPropertyListItems.count();
+
+            const addButton = workflowPage.parentObjectProperty.getByRole('button', {
+                name: /Add value object property/i,
+            });
+
+            const popover = authenticatedPage.getByRole('dialog', {name: /value object property popover/i});
+
+            await test.step('Open Add object property popover', async () => {
+                await clickAndExpectToBeVisible({
+                    target: popover,
+                    trigger: addButton,
+                });
+            });
+
+            const nameInput = popover.getByRole('textbox', {name: /name/i});
+            const submitButton = popover.getByRole('button', {exact: true, name: 'Add'});
+            const duplicateError = popover.getByText('A property with this name already exists.');
+
+            await test.step('Typing an existing subproperty name shows an inline duplicate-name error', async () => {
+                await nameInput.fill(existingPropertyName);
+
+                await expect(duplicateError).toBeVisible();
+            });
+
+            await test.step('Add button is disabled while the name is a duplicate', async () => {
+                await expect(submitButton).toBeDisabled();
+            });
+
+            await test.step('Subproperty list stays unchanged while the duplicate name is in place', async () => {
+                await expect(workflowPage.subPropertyListItems).toHaveCount(initialSubpropertyCount);
+            });
+
+            const uniquePropertyName = `${existingPropertyName}Unique`;
+
+            await test.step('Editing the name to a unique value clears the duplicate-name error', async () => {
+                await nameInput.fill(uniquePropertyName);
+
+                await expect(duplicateError).toBeHidden();
+            });
+
+            await test.step('Submitting the unique name adds the subproperty', async () => {
+                await addObjectSubPropertyViaPopover({
+                    itemType: 'STRING',
+                    objectProperty: workflowPage.parentObjectProperty,
+                    page: authenticatedPage,
+                    propertyName: uniquePropertyName,
+                });
+
+                await expect(workflowPage.subPropertyListItems).toHaveCount(initialSubpropertyCount + 1);
+            });
+        });
+
         test('should prefix the property name with an underscore in the UI after creation if it starts with a number', async () => {
             const numericPropertyName = '123property';
             const expectedPrefixedName = '_123property';

--- a/sdks/frontend/automation/chat/library/src/components/assistant-ui/markdown-text.tsx
+++ b/sdks/frontend/automation/chat/library/src/components/assistant-ui/markdown-text.tsx
@@ -35,7 +35,7 @@ const CodeHeader: FC<CodeHeaderProps> = ({ language, code }) => {
   };
 
   return (
-    <div className="aui-code-header-root mt-4 flex items-center justify-between gap-4 rounded-t-lg bg-muted-foreground/15 px-4 py-2 font-semibold text-foreground text-sm dark:bg-muted-foreground/20">
+    <div className="aui-code-header-root mt-4 flex items-center justify-between gap-4 rounded-t-lg border border-b-0 border-border bg-muted-foreground/15 px-4 py-2 font-semibold text-foreground text-sm dark:bg-muted-foreground/20">
       <span className="aui-code-header-language lowercase [&>span]:text-xs">
         {language}
       </span>
@@ -205,7 +205,7 @@ const defaultComponents = memoizeMarkdownComponents({
   pre: ({ className, ...props }) => (
     <pre
       className={cn(
-        "aui-md-pre overflow-x-auto rounded-t-none! rounded-b-lg bg-black p-4 text-white",
+        "aui-md-pre overflow-x-auto rounded-t-none! rounded-b-lg border border-t-0 border-border bg-black p-4 text-white",
         className,
       )}
       {...props}

--- a/server/apps/server-app/src/main/resources/config/application-bytechef.yml
+++ b/server/apps/server-app/src/main/resources/config/application-bytechef.yml
@@ -140,6 +140,8 @@ bytechef:
     mode: single
   user-guiding:
     enabled: false
+  upgrade:
+    enabled: true
   webhook-url:
   # When the worker is enabled, subscribe to the default "default" queue with 10 concurrent consumers.
   # You may also route workflow tasks to other arbitrarily named task queues by specifying the "node"

--- a/server/apps/server-app/src/main/resources/config/application.yml
+++ b/server/apps/server-app/src/main/resources/config/application.yml
@@ -221,6 +221,7 @@ spring:
       enabled: ${bytechef.mail.ssl.enabled}
   liquibase:
     contexts: mono, #spring.profiles.active#
+    enabled: ${bytechef.upgrade.enabled}
   output:
     ansi:
       enabled: always

--- a/server/apps/server-app/src/main/resources/config/application.yml
+++ b/server/apps/server-app/src/main/resources/config/application.yml
@@ -221,7 +221,7 @@ spring:
       enabled: ${bytechef.mail.ssl.enabled}
   liquibase:
     contexts: mono, #spring.profiles.active#
-    enabled: ${bytechef.upgrade.enabled}
+    enabled: ${bytechef.upgrade.enabled:true}
   output:
     ansi:
       enabled: always

--- a/server/ee/libs/embedded/embedded-ai/embedded-ai-mcp-server/src/main/java/com/bytechef/ee/embedded/ai/mcp/server/config/EmbeddedMcpServerConfiguration.java
+++ b/server/ee/libs/embedded/embedded-ai/embedded-ai-mcp-server/src/main/java/com/bytechef/ee/embedded/ai/mcp/server/config/EmbeddedMcpServerConfiguration.java
@@ -144,8 +144,9 @@ public class EmbeddedMcpServerConfiguration {
         ApplicationProperties applicationProperties, ChildJobPrincipalFactory childJobPrincipalFactory,
         ClusterElementDefinitionFacade clusterElementDefinitionFacade,
         ClusterElementDefinitionService clusterElementDefinitionService, ConnectedUserService connectedUserService,
-        ContextService contextService, CounterService counterService, Environment environment,
-        Evaluator evaluator, IntegrationInstanceConfigurationService integrationInstanceConfigurationService,
+        ContextService contextService, CounterService counterService, TaskFileStorage durableTaskFileStorage,
+        Environment environment, Evaluator evaluator,
+        IntegrationInstanceConfigurationService integrationInstanceConfigurationService,
         IntegrationInstanceConfigurationWorkflowService integrationInstanceConfigurationWorkflowService,
         IntegrationInstanceService integrationInstanceService, IntegrationService integrationService,
         JobService jobService, JwtTokenService jwtTokenService, McpComponentService mcpComponentService,
@@ -160,7 +161,7 @@ public class EmbeddedMcpServerConfiguration {
 
         AsyncMessageBroker asyncMessageBroker = new AsyncMessageBroker(environment);
 
-        TaskFileStorage taskFileStorage = new InMemoryTaskFileStorage();
+        TaskFileStorage taskFileStorage = new InMemoryTaskFileStorage(durableTaskFileStorage);
 
         ApplicationEventPublisher coordinatorEventPublisher = createEventPublisher(asyncMessageBroker);
 

--- a/server/libs/automation/automation-ai/automation-ai-mcp-server/src/main/java/com/bytechef/automation/ai/mcp/server/config/AutomationMcpServerConfiguration.java
+++ b/server/libs/automation/automation-ai/automation-ai-mcp-server/src/main/java/com/bytechef/automation/ai/mcp/server/config/AutomationMcpServerConfiguration.java
@@ -125,17 +125,17 @@ public class AutomationMcpServerConfiguration {
         ChildJobPrincipalFactory childJobPrincipalFactory,
         ClusterElementDefinitionFacade clusterElementDefinitionFacade,
         ClusterElementDefinitionService clusterElementDefinitionService, ContextService contextService,
-        CounterService counterService, Environment environment, Evaluator evaluator, JobService jobService,
-        McpComponentService mcpComponentService, McpProjectWorkflowService mcpProjectWorkflowService,
-        McpServerService mcpServerService, PrincipalJobFacade principalJobFacade,
-        ProjectDeploymentWorkflowService projectDeploymentWorkflowService, SubflowResolver subflowResolver,
-        List<TaskDispatcherPreSendProcessor> taskDispatcherPreSendProcessors,
+        CounterService counterService, TaskFileStorage durableTaskFileStorage, Environment environment,
+        Evaluator evaluator, JobService jobService, McpComponentService mcpComponentService,
+        McpProjectWorkflowService mcpProjectWorkflowService, McpServerService mcpServerService,
+        PrincipalJobFacade principalJobFacade, ProjectDeploymentWorkflowService projectDeploymentWorkflowService,
+        SubflowResolver subflowResolver, List<TaskDispatcherPreSendProcessor> taskDispatcherPreSendProcessors,
         TaskExecutionService taskExecutionService, TaskExecutor taskExecutor, TaskHandlerRegistry taskHandlerRegistry,
         WorkflowService workflowService) {
 
         AsyncMessageBroker asyncMessageBroker = new AsyncMessageBroker(environment);
 
-        TaskFileStorage taskFileStorage = new InMemoryTaskFileStorage();
+        TaskFileStorage taskFileStorage = new InMemoryTaskFileStorage(durableTaskFileStorage);
 
         ApplicationEventPublisher coordinatorEventPublisher = createEventPublisher(asyncMessageBroker);
 

--- a/server/libs/config/app-config/src/main/java/com/bytechef/config/ApplicationProperties.java
+++ b/server/libs/config/app-config/src/main/java/com/bytechef/config/ApplicationProperties.java
@@ -115,6 +115,9 @@ public class ApplicationProperties {
     /** Multi-tenancy configuration */
     private Tenant tenant = new Tenant();
 
+    /** Database upgrade (Liquibase) configuration */
+    private Upgrade upgrade = new Upgrade();
+
     /** User guiding configuration */
     private UserGuiding userGuiding = new UserGuiding();
 
@@ -219,6 +222,10 @@ public class ApplicationProperties {
 
     public Tenant getTenant() {
         return tenant;
+    }
+
+    public Upgrade getUpgrade() {
+        return upgrade;
     }
 
     public UserGuiding getUserGuiding() {
@@ -331,6 +338,10 @@ public class ApplicationProperties {
 
     public void setTenant(Tenant tenant) {
         this.tenant = tenant;
+    }
+
+    public void setUpgrade(Upgrade upgrade) {
+        this.upgrade = upgrade;
     }
 
     public void setUserGuiding(UserGuiding userGuiding) {
@@ -3133,6 +3144,25 @@ public class ApplicationProperties {
 
         public void setMode(Mode mode) {
             this.mode = mode;
+        }
+    }
+
+    /**
+     * Database upgrade configuration. Controls whether Liquibase migrations run at application startup. Useful for
+     * disabling migrations on read-only replicas or when only a designated instance should apply schema changes in a
+     * multi-instance deployment.
+     */
+    public static class Upgrade {
+
+        /** Whether database upgrades (Liquibase migrations) run at startup */
+        private boolean enabled = true;
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
         }
     }
 

--- a/server/libs/core/file-storage/file-storage-base64-service/src/main/java/com/bytechef/file/storage/base64/service/Base64FileStorageService.java
+++ b/server/libs/core/file-storage/file-storage-base64-service/src/main/java/com/bytechef/file/storage/base64/service/Base64FileStorageService.java
@@ -56,9 +56,7 @@ public class Base64FileStorageService implements FileStorageService {
 
     @Override
     public long getContentLength(String directory, FileEntry fileEntry) throws FileStorageException {
-        String url = fileEntry.getUrl();
-
-        String string = EncodingUtils.base64DecodeToString(url.replace(URL_PREFIX, ""));
+        String string = EncodingUtils.base64DecodeToString(stripUrlPrefix(fileEntry.getUrl()));
 
         byte[] bytes = string.getBytes(StandardCharsets.UTF_8);
 
@@ -82,9 +80,7 @@ public class Base64FileStorageService implements FileStorageService {
 
     @Override
     public InputStream getInputStream(String directory, FileEntry fileEntry) {
-        String url = fileEntry.getUrl();
-
-        return new ByteArrayInputStream(EncodingUtils.base64Decode(url.replace(URL_PREFIX, "")));
+        return new ByteArrayInputStream(EncodingUtils.base64Decode(stripUrlPrefix(fileEntry.getUrl())));
     }
 
     @Override
@@ -94,16 +90,12 @@ public class Base64FileStorageService implements FileStorageService {
 
     @Override
     public byte[] readFileToBytes(String directory, FileEntry fileEntry) throws FileStorageException {
-        String url = fileEntry.getUrl();
-
-        return EncodingUtils.base64Decode(url.replace(URL_PREFIX, ""));
+        return EncodingUtils.base64Decode(stripUrlPrefix(fileEntry.getUrl()));
     }
 
     @Override
     public String readFileToString(String directory, FileEntry fileEntry) throws FileStorageException {
-        String url = fileEntry.getUrl();
-
-        return EncodingUtils.base64DecodeToString(url.replace(URL_PREFIX, ""));
+        return EncodingUtils.base64DecodeToString(stripUrlPrefix(fileEntry.getUrl()));
     }
 
     @Override
@@ -151,6 +143,16 @@ public class Base64FileStorageService implements FileStorageService {
         throws FileStorageException {
 
         return storeFileContent(directory, filename, inputStream);
+    }
+
+    private static String stripUrlPrefix(String url) {
+        if (url == null || !url.startsWith(URL_PREFIX)) {
+            throw new FileStorageException(
+                "FileEntry URL '%s' does not use the expected '%s' scheme; it was likely stored with a different file-storage provider (check bytechef.workflow.output-storage.provider)."
+                    .formatted(url, URL_PREFIX));
+        }
+
+        return url.substring(URL_PREFIX.length());
     }
 
     private byte[] toByteArray(InputStream inputStream) throws FileStorageException, IOException {

--- a/server/libs/modules/components/ai/agent/src/main/java/com/bytechef/component/ai/agent/action/AiAgentChatAction.java
+++ b/server/libs/modules/components/ai/agent/src/main/java/com/bytechef/component/ai/agent/action/AiAgentChatAction.java
@@ -95,6 +95,7 @@ public class AiAgentChatAction extends AbstractAiAgentChatAction {
 
             toolExecutionLogEntry.put("confidence", toolExecutionEvent.confidence());
             toolExecutionLogEntry.put("inputs", toolExecutionEvent.inputs());
+            toolExecutionLogEntry.put("output", toolExecutionEvent.output());
             toolExecutionLogEntry.put("reasoning", toolExecutionEvent.reasoning());
             toolExecutionLogEntry.put("toolName", toolExecutionEvent.toolName());
 

--- a/server/libs/modules/components/ai/agent/src/main/java/com/bytechef/component/ai/agent/action/AiAgentChatAction.java
+++ b/server/libs/modules/components/ai/agent/src/main/java/com/bytechef/component/ai/agent/action/AiAgentChatAction.java
@@ -121,7 +121,7 @@ public class AiAgentChatAction extends AbstractAiAgentChatAction {
 
             response.put("response", chatResponse);
 
-            List<Map<String, Object>> toolExecutions = toolExecutionEvents.stream()
+            List<Map<String, @Nullable Object>> toolExecutions = toolExecutionEvents.stream()
                 .map(toolExecutionEvent -> {
                     Map<String, @Nullable Object> eventData = new LinkedHashMap<>();
 

--- a/server/libs/modules/components/workflow/src/main/java/com/bytechef/component/workflow/subflow/sync/config/WorkflowSubflowSyncExecutorConfiguration.java
+++ b/server/libs/modules/components/workflow/src/main/java/com/bytechef/component/workflow/subflow/sync/config/WorkflowSubflowSyncExecutorConfiguration.java
@@ -91,8 +91,8 @@ public class WorkflowSubflowSyncExecutorConfiguration {
     @Bean
     SubflowSyncExecutor subflowSyncExecutor(
         ChildJobPrincipalFactory childJobPrincipalFactory, ContextService contextService, CounterService counterService,
-        Environment environment, Evaluator evaluator, JobService jobService, SubflowResolver subflowResolver,
-        List<TaskDispatcherPreSendProcessor> taskDispatcherPreSendProcessors,
+        TaskFileStorage durableTaskFileStorage, Environment environment, Evaluator evaluator, JobService jobService,
+        SubflowResolver subflowResolver, List<TaskDispatcherPreSendProcessor> taskDispatcherPreSendProcessors,
         TaskExecutionService taskExecutionService, TaskHandlerRegistry taskHandlerRegistry,
         WorkflowService workflowService) {
 
@@ -100,7 +100,7 @@ public class WorkflowSubflowSyncExecutorConfiguration {
 
         SimpleAsyncTaskExecutor taskExecutor = new SimpleAsyncTaskExecutor();
 
-        TaskFileStorage taskFileStorage = new InMemoryTaskFileStorage();
+        TaskFileStorage taskFileStorage = new InMemoryTaskFileStorage(durableTaskFileStorage);
 
         ApplicationEventPublisher coordinatorEventPublisher = createEventPublisher(asyncMessageBroker);
 

--- a/server/libs/platform/platform-job-sync/src/main/java/com/bytechef/platform/job/sync/file/storage/InMemoryTaskFileStorage.java
+++ b/server/libs/platform/platform-job-sync/src/main/java/com/bytechef/platform/job/sync/file/storage/InMemoryTaskFileStorage.java
@@ -19,145 +19,135 @@ package com.bytechef.platform.job.sync.file.storage;
 import com.bytechef.atlas.execution.domain.Context;
 import com.bytechef.atlas.file.storage.TaskFileStorage;
 import com.bytechef.file.storage.domain.FileEntry;
-import com.bytechef.file.storage.exception.FileStorageException;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import org.jspecify.annotations.Nullable;
 
 /**
- * In-memory TaskFileStorage implementation that stores objects directly without serialization or compression, using
- * job-scoped storage. This is useful for testing scenarios where you want to preserve the exact objects (like Publisher
- * instances) without JSON serialization, isolated per job execution.
+ * Read-through cache layered over a durable {@link TaskFileStorage}. Used by the synchronous job executors (webhook
+ * sync, subflow sync, MCP sync) and by workflow test mode.
+ * <p>
+ * Every write is forwarded to the durable delegate; the {@link FileEntry} URL returned by the delegate becomes the
+ * cache key so that any read that follows in the same sync execution skips the gzip + base64 + Jackson round-trip the
+ * durable storage would otherwise do. Reads miss → delegate → fill cache. Sync executors run against real JDBC-backed
+ * {@code JobService} / {@code TaskExecutionService} / {@code ContextService}, so these {@link FileEntry} URLs land in
+ * the {@code Job.outputs}, {@code TaskExecution.output} and {@code Context.value} columns — durable storage is
+ * mandatory here so the async read path (the UI) can later read those columns through the registry-configured
+ * {@code FileStorageService}.
+ * <p>
+ * The cache uses Caffeine's {@code expireAfterAccess(30, MINUTES)} as a bounded-memory safety net; it's in-process
+ * only. Caffeine is used directly (not via Spring {@code CacheManager}) so a Redis swap can't break this cache — the
+ * values are arbitrary deserialized {@code Map}/{@code Object} instances, some of which aren't {@code Serializable}.
  *
  * @author Ivica Cardic
  */
 @SuppressFBWarnings("EI")
 public class InMemoryTaskFileStorage implements TaskFileStorage {
 
-    private static final String CONTEXT_FILES_DIR = "outputs/workflow_contexts";
-    private static final String JOB_FILES_DIR = "outputs/workflow_jobs";
-    private static final String TASK_EXECUTION_FILES_DIR = "outputs/workflow_task_executions";
-    private static final String URL_PREFIX = "inmemory://";
+    private final Cache<String, Object> jobDataStorage = Caffeine.newBuilder()
+        .expireAfterAccess(30, TimeUnit.MINUTES)
+        .build();
 
-    private final Map<Long, Map<String, Object>> jobDataStorage = new ConcurrentHashMap<>();
+    private final TaskFileStorage durableTaskFileStorage;
 
-    public void initializeJobStorage(long jobId) {
-        jobDataStorage.putIfAbsent(jobId, new ConcurrentHashMap<>());
-    }
-
-    public void cleanupJobStorage(long jobId) {
-        jobDataStorage.remove(jobId);
+    public InMemoryTaskFileStorage(TaskFileStorage durableTaskFileStorage) {
+        this.durableTaskFileStorage = Objects.requireNonNull(durableTaskFileStorage, "durableTaskFileStorage");
     }
 
     @Override
     @SuppressWarnings("unchecked")
     public Map<String, ?> readContextValue(FileEntry fileEntry) {
-        Object data = readObject(fileEntry);
+        Object cached = jobDataStorage.getIfPresent(fileEntry.getUrl());
 
-        if (!(data instanceof Map)) {
-            throw new FileStorageException("Expected Map but found: " + data.getClass());
+        if (cached instanceof Map<?, ?> map) {
+            return (Map<String, ?>) map;
         }
 
-        return (Map<String, ?>) data;
+        Map<String, ?> value = durableTaskFileStorage.readContextValue(fileEntry);
+
+        cache(fileEntry, value);
+
+        return value;
     }
 
     @Override
     @SuppressWarnings("unchecked")
     public Map<String, ?> readJobOutputs(FileEntry fileEntry) {
-        Object data = readObject(fileEntry);
+        Object cached = jobDataStorage.getIfPresent(fileEntry.getUrl());
 
-        if (!(data instanceof Map)) {
-            throw new FileStorageException("Expected Map but found: " + data.getClass());
+        if (cached instanceof Map<?, ?> map) {
+            return (Map<String, ?>) map;
         }
 
-        return (Map<String, ?>) data;
+        Map<String, ?> value = durableTaskFileStorage.readJobOutputs(fileEntry);
+
+        cache(fileEntry, value);
+
+        return value;
     }
 
     @Override
     public Object readTaskExecutionOutput(FileEntry fileEntry) {
-        return readObject(fileEntry);
+        Object cached = jobDataStorage.getIfPresent(fileEntry.getUrl());
+
+        if (cached != null) {
+            return cached;
+        }
+
+        Object value = durableTaskFileStorage.readTaskExecutionOutput(fileEntry);
+
+        cache(fileEntry, value);
+
+        return value;
     }
 
     @Override
-    public FileEntry storeContextValue(
-        long stackId, Context.Classname classname, Map<String, ?> value) {
+    public FileEntry storeContextValue(long stackId, Context.Classname classname, Map<String, ?> value) {
+        FileEntry fileEntry = durableTaskFileStorage.storeContextValue(stackId, classname, value);
 
-        String filename = stackId + "_" + classname.name() + ".dat";
+        cache(fileEntry, value);
 
-        return storeObject(CONTEXT_FILES_DIR, filename, value, stackId);
+        return fileEntry;
     }
 
     @Override
     public FileEntry storeContextValue(
         long stackId, int subStackId, Context.Classname classname, Map<String, ?> value) {
 
-        String filename = stackId + "_" + subStackId + "_" + classname.name() + ".dat";
+        FileEntry fileEntry = durableTaskFileStorage.storeContextValue(stackId, subStackId, classname, value);
 
-        return storeObject(CONTEXT_FILES_DIR, filename, value, stackId);
+        cache(fileEntry, value);
+
+        return fileEntry;
     }
 
     @Override
     public FileEntry storeJobOutputs(long jobId, Map<String, ?> outputs) {
-        String filename = jobId + ".dat";
+        FileEntry fileEntry = durableTaskFileStorage.storeJobOutputs(jobId, outputs);
 
-        return storeObject(JOB_FILES_DIR, filename, outputs, jobId);
+        cache(fileEntry, outputs);
+
+        return fileEntry;
     }
 
     @Override
     public FileEntry storeTaskExecutionOutput(long jobId, long taskExecutionId, Object output) {
-        String filename = taskExecutionId + ".dat";
+        FileEntry fileEntry = durableTaskFileStorage.storeTaskExecutionOutput(jobId, taskExecutionId, output);
 
-        return storeObject(TASK_EXECUTION_FILES_DIR, filename, output, jobId);
+        cache(fileEntry, output);
+
+        return fileEntry;
     }
 
-    private Object readObject(FileEntry fileEntry) {
-        UrlParts urlParts = extractJobIdAndKeyFromUrl(fileEntry.getUrl());
-        Map<String, Object> storage = jobDataStorage.get(urlParts.jobId());
-
-        if (storage == null || !storage.containsKey(urlParts.key())) {
-            throw new FileStorageException("Data not found: " + fileEntry.getName());
+    private void cache(FileEntry fileEntry, @Nullable Object value) {
+        if (value == null) {
+            return;
         }
 
-        return storage.get(urlParts.key());
-    }
-
-    private FileEntry storeObject(String directory, String filename, Object data, long jobId) {
-        Map<String, Object> storage = jobDataStorage.computeIfAbsent(jobId, k -> new ConcurrentHashMap<>());
-        String key = getKey(directory, filename);
-
-        // ConcurrentHashMap doesn't allow null values, so wrap it
-        storage.put(key, data);
-
-        // Encode job ID in URL so we can retrieve it later
-        return new FileEntry(filename, URL_PREFIX + jobId + "/" + key);
-    }
-
-    private static String getKey(String directory, String filename) {
-        return directory + "/" + filename;
-    }
-
-    private static UrlParts extractJobIdAndKeyFromUrl(String url) {
-        if (!url.startsWith(URL_PREFIX)) {
-            throw new FileStorageException("Invalid URL format: " + url);
-        }
-
-        String remainder = url.substring(URL_PREFIX.length());
-        int slashIndex = remainder.indexOf('/');
-
-        if (slashIndex == -1) {
-            throw new FileStorageException("Invalid URL format - missing job ID: " + url);
-        }
-
-        try {
-            long jobId = Long.parseLong(remainder.substring(0, slashIndex));
-            String key = remainder.substring(slashIndex + 1);
-
-            return new UrlParts(jobId, key);
-        } catch (NumberFormatException e) {
-            throw new FileStorageException("Invalid job ID in URL: " + url, e);
-        }
-    }
-
-    private record UrlParts(long jobId, String key) {
+        jobDataStorage.put(fileEntry.getUrl(), value);
     }
 }

--- a/server/libs/platform/platform-job-sync/src/main/java/com/bytechef/platform/job/sync/file/storage/InMemoryTaskFileStorage.java
+++ b/server/libs/platform/platform-job-sync/src/main/java/com/bytechef/platform/job/sync/file/storage/InMemoryTaskFileStorage.java
@@ -39,9 +39,10 @@ import org.jspecify.annotations.Nullable;
  * mandatory here so the async read path (the UI) can later read those columns through the registry-configured
  * {@code FileStorageService}.
  * <p>
- * The cache uses Caffeine's {@code expireAfterAccess(30, MINUTES)} as a bounded-memory safety net; it's in-process
- * only. Caffeine is used directly (not via Spring {@code CacheManager}) so a Redis swap can't break this cache — the
- * values are arbitrary deserialized {@code Map}/{@code Object} instances, some of which aren't {@code Serializable}.
+ * The cache uses Caffeine's {@code expireAfterAccess(30, MINUTES)} paired with {@code maximumSize(10_000)} as a
+ * bounded-memory safety net; it's in-process only. Caffeine is used directly (not via Spring {@code CacheManager}) so a
+ * Redis swap can't break this cache — the values are arbitrary deserialized {@code Map}/{@code Object} instances, some
+ * of which aren't {@code Serializable}.
  *
  * @author Ivica Cardic
  */
@@ -50,6 +51,7 @@ public class InMemoryTaskFileStorage implements TaskFileStorage {
 
     private final Cache<String, Object> jobDataStorage = Caffeine.newBuilder()
         .expireAfterAccess(30, TimeUnit.MINUTES)
+        .maximumSize(10_000)
         .build();
 
     private final TaskFileStorage durableTaskFileStorage;

--- a/server/libs/platform/platform-job-sync/src/test/java/com/bytechef/platform/job/sync/file/storage/InMemoryTaskFileStorageTest.java
+++ b/server/libs/platform/platform-job-sync/src/test/java/com/bytechef/platform/job/sync/file/storage/InMemoryTaskFileStorageTest.java
@@ -17,13 +17,13 @@
 package com.bytechef.platform.job.sync.file.storage;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import com.bytechef.atlas.execution.domain.Context;
+import com.bytechef.atlas.file.storage.TaskFileStorage;
 import com.bytechef.file.storage.domain.FileEntry;
 import java.util.Map;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -33,33 +33,166 @@ class InMemoryTaskFileStorageTest {
 
     private static final long jobId = 123L;
 
-    private InMemoryTaskFileStorage storage;
+    @Test
+    void testStoreJobOutputsDelegatesToDurableStorage() {
+        FileEntry durableFileEntry = new FileEntry("456.json", "base64://AAA=");
+        Map<String, Object> outputs = Map.of("result", "ok");
 
-    @BeforeEach
-    void setUp() {
-        storage = new InMemoryTaskFileStorage();
-        storage.initializeJobStorage(jobId);
-    }
+        RecordingTaskFileStorage durable = new RecordingTaskFileStorage(durableFileEntry);
 
-    @AfterEach
-    void tearDown() {
-        storage.cleanupJobStorage(jobId);
+        InMemoryTaskFileStorage storage = new InMemoryTaskFileStorage(durable);
+
+        FileEntry result = storage.storeJobOutputs(456L, outputs);
+
+        assertSame(durableFileEntry, result);
+        assertEquals(1, durable.storeJobOutputsCalls.get());
     }
 
     @Test
-    void testStoreContextValueWithJobIdParameter() {
-        // This test verifies that when storeContextValue is called with a stackId,
-        // it uses that stackId (which is the jobId for Context.Classname.JOB) to store data
-        // even when ThreadLocal is set to a different value initially
+    void testReadJobOutputsCachesWriteSoDurableReadIsSkipped() {
+        FileEntry durableFileEntry = new FileEntry("789.json", "base64://QkJC");
+        Map<String, Object> outputs = Map.of("status", "done");
 
+        RecordingTaskFileStorage durable = new RecordingTaskFileStorage(durableFileEntry);
+
+        InMemoryTaskFileStorage storage = new InMemoryTaskFileStorage(durable);
+
+        storage.storeJobOutputs(789L, outputs);
+
+        Map<String, ?> readOnce = storage.readJobOutputs(durableFileEntry);
+        Map<String, ?> readTwice = storage.readJobOutputs(durableFileEntry);
+
+        assertSame(outputs, readOnce);
+        assertSame(outputs, readTwice);
+        assertEquals(0, durable.readJobOutputsCalls.get());
+    }
+
+    @Test
+    void testReadJobOutputsMissFetchesFromDurableAndFillsCache() {
+        FileEntry durableFileEntry = new FileEntry("999.json", "base64://Q0NE");
+        Map<String, Object> outputs = Map.of("x", 1);
+
+        RecordingTaskFileStorage durable = new RecordingTaskFileStorage(durableFileEntry, outputs);
+
+        InMemoryTaskFileStorage storage = new InMemoryTaskFileStorage(durable);
+
+        Map<String, ?> firstRead = storage.readJobOutputs(durableFileEntry);
+        Map<String, ?> secondRead = storage.readJobOutputs(durableFileEntry);
+
+        assertEquals(outputs, firstRead);
+        assertSame(firstRead, secondRead);
+        assertEquals(1, durable.readJobOutputsCalls.get());
+    }
+
+    @Test
+    void testStoreContextValueDelegatesAndCaches() {
+        FileEntry durableFileEntry = new FileEntry("ctx.json", "base64://Q1RY");
         Map<String, Object> contextValue = Map.of("key", "value");
 
-        FileEntry fileEntry = storage.storeContextValue(jobId, Context.Classname.JOB, contextValue);
+        RecordingTaskFileStorage durable = new RecordingTaskFileStorage(durableFileEntry);
 
-        assertNotNull(fileEntry);
+        InMemoryTaskFileStorage storage = new InMemoryTaskFileStorage(durable);
 
-        Map<String, ?> readValue = storage.readContextValue(fileEntry);
+        FileEntry stored = storage.storeContextValue(jobId, Context.Classname.JOB, contextValue);
 
-        assertEquals(contextValue, readValue);
+        assertSame(durableFileEntry, stored);
+
+        Map<String, ?> read = storage.readContextValue(durableFileEntry);
+
+        assertSame(contextValue, read);
+        assertEquals(1, durable.storeContextCalls.get());
+        assertEquals(0, durable.readContextCalls.get());
+    }
+
+    @Test
+    void testStoreTaskExecutionOutputDelegatesAndCaches() {
+        FileEntry durableFileEntry = new FileEntry("42.json", "base64://VEVY");
+        String output = "payload";
+
+        RecordingTaskFileStorage durable = new RecordingTaskFileStorage(durableFileEntry);
+
+        InMemoryTaskFileStorage storage = new InMemoryTaskFileStorage(durable);
+
+        storage.storeTaskExecutionOutput(jobId, 42L, output);
+
+        Object read = storage.readTaskExecutionOutput(durableFileEntry);
+
+        assertSame(output, read);
+        assertEquals(1, durable.storeTaskExecutionCalls.get());
+        assertEquals(0, durable.readTaskExecutionCalls.get());
+    }
+
+    private static final class RecordingTaskFileStorage implements TaskFileStorage {
+
+        private final FileEntry storeResult;
+        private final Object readResult;
+        private final AtomicInteger storeJobOutputsCalls = new AtomicInteger();
+        private final AtomicInteger readJobOutputsCalls = new AtomicInteger();
+        private final AtomicInteger storeContextCalls = new AtomicInteger();
+        private final AtomicInteger readContextCalls = new AtomicInteger();
+        private final AtomicInteger storeTaskExecutionCalls = new AtomicInteger();
+        private final AtomicInteger readTaskExecutionCalls = new AtomicInteger();
+
+        RecordingTaskFileStorage(FileEntry storeResult) {
+            this(storeResult, Map.of());
+        }
+
+        RecordingTaskFileStorage(FileEntry storeResult, Object readResult) {
+            this.storeResult = storeResult;
+            this.readResult = readResult;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public Map<String, ?> readContextValue(FileEntry fileEntry) {
+            readContextCalls.incrementAndGet();
+
+            return (Map<String, ?>) readResult;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public Map<String, ?> readJobOutputs(FileEntry fileEntry) {
+            readJobOutputsCalls.incrementAndGet();
+
+            return (Map<String, ?>) readResult;
+        }
+
+        @Override
+        public Object readTaskExecutionOutput(FileEntry fileEntry) {
+            readTaskExecutionCalls.incrementAndGet();
+
+            return readResult;
+        }
+
+        @Override
+        public FileEntry storeContextValue(long stackId, Context.Classname classname, Map<String, ?> value) {
+            storeContextCalls.incrementAndGet();
+
+            return storeResult;
+        }
+
+        @Override
+        public FileEntry storeContextValue(
+            long stackId, int subStackId, Context.Classname classname, Map<String, ?> value) {
+
+            storeContextCalls.incrementAndGet();
+
+            return storeResult;
+        }
+
+        @Override
+        public FileEntry storeJobOutputs(long jobId, Map<String, ?> outputs) {
+            storeJobOutputsCalls.incrementAndGet();
+
+            return storeResult;
+        }
+
+        @Override
+        public FileEntry storeTaskExecutionOutput(long jobId, long taskExecutionId, Object output) {
+            storeTaskExecutionCalls.incrementAndGet();
+
+            return storeResult;
+        }
     }
 }

--- a/server/libs/platform/platform-webhook/platform-webhook-impl/src/main/java/com/bytechef/platform/webhook/executor/config/WebhookConfiguration.java
+++ b/server/libs/platform/platform-webhook/platform-webhook-impl/src/main/java/com/bytechef/platform/webhook/executor/config/WebhookConfiguration.java
@@ -88,16 +88,16 @@ public class WebhookConfiguration {
     @Bean
     WebhookWorkflowExecutor webhookExecutor(
         ChildJobPrincipalFactory childJobPrincipalFactory, ContextService contextService,
-        CounterService counterService, Environment environment, Evaluator evaluator,
-        ApplicationEventPublisher eventPublisher, JobPrincipalAccessorRegistry jobPrincipalAccessorRegistry,
-        PrincipalJobFacade principalJobFacade, JobService jobService,
-        List<TaskDispatcherPreSendProcessor> taskDispatcherPreSendProcessors,
+        CounterService counterService, TaskFileStorage durableTaskFileStorage, Environment environment,
+        Evaluator evaluator, ApplicationEventPublisher eventPublisher,
+        JobPrincipalAccessorRegistry jobPrincipalAccessorRegistry, PrincipalJobFacade principalJobFacade,
+        JobService jobService, List<TaskDispatcherPreSendProcessor> taskDispatcherPreSendProcessors,
         SseStreamBridgeRegistry sseStreamBridgeRegistry, SubflowResolver subflowResolver,
         TaskExecutionService taskExecutionService, TaskExecutor taskExecutor, TaskHandlerRegistry taskHandlerRegistry,
         WebhookWorkflowSyncExecutor triggerSyncExecutor, WorkflowService workflowService) {
 
         AsyncMessageBroker asyncMessageBroker = new AsyncMessageBroker(environment);
-        TaskFileStorage taskFileStorage = new InMemoryTaskFileStorage();
+        TaskFileStorage taskFileStorage = new InMemoryTaskFileStorage(durableTaskFileStorage);
 
         ApplicationEventPublisher coordinatorEventPublisher = createEventPublisher(asyncMessageBroker);
 

--- a/server/libs/platform/platform-workflow/platform-workflow-test/platform-workflow-test-service/build.gradle.kts
+++ b/server/libs/platform/platform-workflow/platform-workflow-test/platform-workflow-test-service/build.gradle.kts
@@ -10,6 +10,7 @@ dependencies {
     implementation(project(":server:libs:atlas:atlas-worker:atlas-worker-api"))
     implementation(project(":server:libs:core:commons:commons-util"))
     implementation(project(":server:libs:core:commons:commons-data"))
+    implementation(project(":server:libs:core:file-storage:file-storage-base64-service"))
     implementation(project(":server:libs:core:message:message-broker:message-broker-memory"))
     implementation(project(":server:libs:core:tenant:tenant-api"))
     implementation(project(":server:libs:platform:platform-component:platform-component-api"))

--- a/server/libs/platform/platform-workflow/platform-workflow-test/platform-workflow-test-service/src/main/java/com/bytechef/platform/workflow/test/config/WorkflowTestConfiguration.java
+++ b/server/libs/platform/platform-workflow/platform-workflow-test/platform-workflow-test-service/src/main/java/com/bytechef/platform/workflow/test/config/WorkflowTestConfiguration.java
@@ -38,6 +38,7 @@ import com.bytechef.atlas.execution.service.JobServiceImpl;
 import com.bytechef.atlas.execution.service.TaskExecutionService;
 import com.bytechef.atlas.execution.service.TaskExecutionServiceImpl;
 import com.bytechef.atlas.file.storage.TaskFileStorage;
+import com.bytechef.atlas.file.storage.TaskFileStorageImpl;
 import com.bytechef.atlas.worker.task.handler.TaskDispatcherAdapterFactory;
 import com.bytechef.atlas.worker.task.handler.TaskHandler;
 import com.bytechef.atlas.worker.task.handler.TaskHandlerRegistry;
@@ -45,6 +46,7 @@ import com.bytechef.atlas.worker.task.handler.TaskHandlerResolver;
 import com.bytechef.component.map.MapTaskDispatcherAdapterTaskHandler;
 import com.bytechef.component.map.constant.MapConstants;
 import com.bytechef.evaluator.Evaluator;
+import com.bytechef.file.storage.base64.service.Base64FileStorageService;
 import com.bytechef.message.broker.MessageBroker;
 import com.bytechef.message.broker.memory.AsyncMessageBroker;
 import com.bytechef.message.event.MessageEvent;
@@ -126,7 +128,8 @@ public class WorkflowTestConfiguration {
         JobService jobService = new JobServiceImpl(new InMemoryJobRepository(taskExecutionRepository, objectMapper));
         TaskExecutionService taskExecutionService = new TaskExecutionServiceImpl(taskExecutionRepository);
 
-        TaskFileStorage taskFileStorage = new InMemoryTaskFileStorage();
+        TaskFileStorage taskFileStorage = new InMemoryTaskFileStorage(
+            new TaskFileStorageImpl(new Base64FileStorageService()));
 
         ApplicationEventPublisher coordinatorEventPublisher = createEventPublisher(asyncMessageBroker);
 


### PR DESCRIPTION
- **2896 Include tool output in AiAgentChat tool execution log**
- **2896 SF**
- **4807 Turn InMemoryTaskFileStorage into a URL-keyed caching decorator**
- **2311 client - Rename hosted chat trigger page URL from /chat to /chats**
- **1652 client - Add continuous border around chat markdown code blocks**
- **4213 client - Fix read-only workflow graph centering and disappearance on panel resize**
- **4213 client - Reset activeTab to description when opening details panel for a new node**
- **2311 client - Show skeleton placeholder in chats sidebar while loading**
- **4804 Add bytechef.upgrade.enabled property to toggle Liquibase migrations**
- **4719 client - Add test for duplicate subproperty name guard in ObjectProperty popover**
