### PR TITLE
4822 - use node label instead of component name

### DIFF
--- a/client/src/pages/platform/workflow-editor/components/WorkflowTestConfigurationDialog.tsx
+++ b/client/src/pages/platform/workflow-editor/components/WorkflowTestConfigurationDialog.tsx
@@ -249,19 +249,20 @@ const WorkflowTestConfigurationDialog = ({
         },
     });
 
-    const workflowNodeLabelMap = new Map<string, string>();
+    const workflowNodeLabelMap = useMemo(() => {
+        if (connectionsGrouped) return new Map<string, string>();
 
-    for (const task of workflow?.tasks ?? []) {
-        if (task.label) {
-            workflowNodeLabelMap.set(task.name, task.label);
-        }
-    }
+        const map = new Map<string, string>();
 
-    for (const trigger of workflow?.triggers ?? []) {
-        if (trigger.label) {
-            workflowNodeLabelMap.set(trigger.name, trigger.label);
+        for (const task of workflow?.tasks ?? []) {
+            if (task.label) map.set(task.name, task.label);
         }
-    }
+        for (const trigger of workflow?.triggers ?? []) {
+            if (trigger.label) map.set(trigger.name, trigger.label);
+        }
+
+        return map;
+    }, [connectionsGrouped, workflow?.tasks, workflow?.triggers]);
 
     function saveWorkflowTestConfiguration(workflowTestConfiguration: WorkflowTestConfiguration) {
         workflowTestConfiguration = {

--- a/client/src/pages/platform/workflow-editor/components/WorkflowTestConfigurationDialog.tsx
+++ b/client/src/pages/platform/workflow-editor/components/WorkflowTestConfigurationDialog.tsx
@@ -52,6 +52,7 @@ interface WorkflowTestConfigurationFormFieldProps {
     index: number;
     setComponentConnection: Dispatch<SetStateAction<ComponentConnection | undefined>>;
     setShowNewConnectionDialog: Dispatch<SetStateAction<boolean>>;
+    workflowNodeLabel?: string;
 }
 
 const WorkflowTestConfigurationFormField = ({
@@ -63,6 +64,7 @@ const WorkflowTestConfigurationFormField = ({
     index,
     setComponentConnection,
     setShowNewConnectionDialog,
+    workflowNodeLabel,
 }: WorkflowTestConfigurationFormFieldProps) => {
     const {data: componentDefinition} = useGetComponentDefinitionQuery({
         componentName: componentConnection.componentName,
@@ -97,7 +99,9 @@ const WorkflowTestConfigurationFormField = ({
                                     <InlineSVG className="size-4 flex-none" src={componentDefinition.icon} />
                                 )}
 
-                                <span className="ml-1">{componentDefinition?.title} Connection</span>
+                                <span className="ml-1">
+                                    {workflowNodeLabel || `${componentDefinition?.title} Connection`}
+                                </span>
 
                                 {groupedIndices ? (
                                     <span className="ml-0.5 text-xs text-content-neutral-secondary">
@@ -245,6 +249,20 @@ const WorkflowTestConfigurationDialog = ({
         },
     });
 
+    const workflowNodeLabelMap = new Map<string, string>();
+
+    for (const task of workflow?.tasks ?? []) {
+        if (task.label) {
+            workflowNodeLabelMap.set(task.name, task.label);
+        }
+    }
+
+    for (const trigger of workflow?.triggers ?? []) {
+        if (trigger.label) {
+            workflowNodeLabelMap.set(trigger.name, trigger.label);
+        }
+    }
+
     function saveWorkflowTestConfiguration(workflowTestConfiguration: WorkflowTestConfiguration) {
         workflowTestConfiguration = {
             ...workflowTestConfiguration,
@@ -362,6 +380,13 @@ const WorkflowTestConfigurationDialog = ({
                                                             key={`${connection.workflowNodeName}_${connection.key}`}
                                                             setComponentConnection={setComponentConnection}
                                                             setShowNewConnectionDialog={setShowNewConnectionDialog}
+                                                            workflowNodeLabel={
+                                                                groupedIndices
+                                                                    ? undefined
+                                                                    : workflowNodeLabelMap.get(
+                                                                          connection.workflowNodeName
+                                                                      )
+                                                            }
                                                         />
                                                     )
                                             )}

--- a/client/src/pages/platform/workflow-editor/components/datapills/DataPillPanelBodyPropertiesItem.tsx
+++ b/client/src/pages/platform/workflow-editor/components/datapills/DataPillPanelBodyPropertiesItem.tsx
@@ -42,9 +42,10 @@ const DataPillPanelBodyPropertiesItem = ({
     operation,
     sampleOutput,
 }: DataPillPanelBodyPropertiesItemProps) => {
-    const {componentDefinitions, workflowNodes} = useWorkflowDataStore(
+    const {componentDefinitions, workflow, workflowNodes} = useWorkflowDataStore(
         useShallow((state) => ({
             componentDefinitions: state.componentDefinitions,
+            workflow: state.workflow,
             workflowNodes: state.workflowNodes,
         }))
     );
@@ -77,6 +78,10 @@ const DataPillPanelBodyPropertiesItem = ({
         title = operation.taskDispatcherDefinition.title;
     }
 
+    const workflowNodeLabel =
+        workflow?.tasks?.find((task) => task.name === workflowNodeName)?.label ||
+        workflow?.triggers?.find((trigger) => trigger.name === workflowNodeName)?.label;
+
     const currentWorkflowNode = workflowNodes.find(
         (workflowNode) => workflowNode.workflowNodeName === workflowNodeName
     );
@@ -107,7 +112,7 @@ const DataPillPanelBodyPropertiesItem = ({
                     )}
 
                     <h3 className="flex flex-col items-start text-sm">
-                        {title}
+                        {workflowNodeLabel || title}
 
                         <span className="truncate text-xs text-gray-400">({workflowNodeName})</span>
                     </h3>

--- a/client/src/pages/platform/workflow-editor/components/datapills/DataPillPanelBodyPropertiesItem.tsx
+++ b/client/src/pages/platform/workflow-editor/components/datapills/DataPillPanelBodyPropertiesItem.tsx
@@ -78,9 +78,9 @@ const DataPillPanelBodyPropertiesItem = ({
         title = operation.taskDispatcherDefinition.title;
     }
 
-    const workflowNodeLabel =
-        workflow?.tasks?.find((task) => task.name === workflowNodeName)?.label ||
-        workflow?.triggers?.find((trigger) => trigger.name === workflowNodeName)?.label;
+    const workflowNodeLabel = [...(workflow?.tasks ?? []), ...(workflow?.triggers ?? [])].find(
+        (operation) => operation.name === workflowNodeName
+    )?.label;
 
     const currentWorkflowNode = workflowNodes.find(
         (workflowNode) => workflowNode.workflowNodeName === workflowNodeName


### PR DESCRIPTION
fixes #4822 

use node label instead of component name

1. data pill panel - using renamed component labels 
<img width="1172" height="916" alt="image" src="https://github.com/user-attachments/assets/58b0c2a8-7371-48a4-a93f-2c298b7f637d" />

2. workflow test configuration - using renamed component labels until grouped
<img width="1172" height="970" alt="image" src="https://github.com/user-attachments/assets/4f47c0ac-04f2-43c3-bba8-835da0adc420" />
<img width="1172" height="970" alt="image" src="https://github.com/user-attachments/assets/cfb4139d-067b-4263-9d2c-6deec6b54200" />
