### PR TITLE
4854 client - Sync React Flow node data with workflow.tasks on parameter save

### DIFF
--- a/client/src/pages/platform/workflow-editor/components/properties/hooks/tests/useArrayPropertyHydration.test.ts
+++ b/client/src/pages/platform/workflow-editor/components/properties/hooks/tests/useArrayPropertyHydration.test.ts
@@ -1,0 +1,205 @@
+import {act, renderHook} from '@testing-library/react';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+
+const hoisted = vi.hoisted(() => {
+    const mockSaveProperty = vi.fn();
+
+    type StoreShapeType = {
+        currentComponent: {
+            componentName?: string;
+            metadata?: {ui?: {dynamicPropertyTypes?: Record<string, string>}};
+            parameters?: Record<string, unknown>;
+            workflowNodeName?: string;
+        } | null;
+    };
+
+    const storeState: StoreShapeType = {
+        currentComponent: null,
+    };
+
+    return {
+        mockSaveProperty,
+        storeState,
+    };
+});
+
+vi.mock('../../../../utils/saveProperty', () => ({
+    default: hoisted.mockSaveProperty,
+}));
+
+vi.mock('../../../../stores/useWorkflowNodeDetailsPanelStore', () => ({
+    default: Object.assign((selector: (state: typeof hoisted.storeState) => unknown) => selector(hoisted.storeState), {
+        getState: () => hoisted.storeState,
+    }),
+}));
+
+vi.mock('../../../../stores/useWorkflowDataStore', () => ({
+    default: (selector: (state: {workflow: {id: string}}) => unknown) => selector({workflow: {id: 'workflow-1'}}),
+}));
+
+vi.mock('../../../../providers/workflowEditorProvider', () => ({
+    useWorkflowEditor: () => ({
+        updateClusterElementParameterMutation: undefined,
+        updateWorkflowNodeParameterMutation: {mutateAsync: vi.fn()},
+    }),
+}));
+
+describe('useArrayProperty — hydration from currentComponent.parameters', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    afterEach(() => {
+        hoisted.storeState.currentComponent = null;
+    });
+
+    it('hydrates items on REMOUNT with items:null (exact var_v1 shape)', async () => {
+        hoisted.storeState.currentComponent = {
+            componentName: 'var',
+            metadata: {
+                ui: {
+                    dynamicPropertyTypes: {
+                        'value[0]': 'STRING',
+                        'value[1]': 'STRING',
+                        'value[2]': 'STRING',
+                    },
+                },
+            },
+            parameters: {
+                type: 'ARRAY',
+                value: ['www', 'wqewqe', 'rrrr'],
+            },
+            workflowNodeName: 'var_1',
+        };
+
+        const {useArrayProperty} = await import('../useArrayProperty');
+
+        // First mount (user originally added 3 items).
+        const first = renderHook(() =>
+            useArrayProperty({
+                onDeleteClick: vi.fn(),
+                path: 'value',
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                property: {controlType: 'ARRAY_BUILDER', items: null, name: 'value', type: 'ARRAY'} as any,
+            })
+        );
+
+        await act(async () => {
+            await Promise.resolve();
+        });
+
+        expect(first.result.current.arrayItems).toHaveLength(3);
+
+        // Simulate "switch to Description tab" — unmount Properties.
+        first.unmount();
+
+        // Simulate "switch back to Properties" — fresh mount.
+        // currentComponent in the store is unchanged from before (Zustand store persists).
+        const second = renderHook(() =>
+            useArrayProperty({
+                onDeleteClick: vi.fn(),
+                path: 'value',
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                property: {controlType: 'ARRAY_BUILDER', items: null, name: 'value', type: 'ARRAY'} as any,
+            })
+        );
+
+        await act(async () => {
+            await Promise.resolve();
+        });
+
+        expect(second.result.current.arrayItems).toHaveLength(3);
+    });
+
+    it('hydrates items when parameterValue contains a null slot (reproduces add-then-tab-switch)', async () => {
+        // Server's setParameter may leave a null in the array when the user clicks
+        // "Add" for a new item but hasn't typed a value yet. On tab return we hit
+        // hydration with a null value. This checks the third branch handles it.
+        hoisted.storeState.currentComponent = {
+            componentName: 'var',
+            metadata: {
+                ui: {
+                    dynamicPropertyTypes: {
+                        'value[0]': 'STRING',
+                        'value[1]': 'STRING',
+                    },
+                },
+            },
+            parameters: {
+                type: 'ARRAY',
+                value: ['www', null],
+            },
+            workflowNodeName: 'var_1',
+        };
+
+        const {useArrayProperty} = await import('../useArrayProperty');
+
+        const {result} = renderHook(() =>
+            useArrayProperty({
+                onDeleteClick: vi.fn(),
+                path: 'value',
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                property: {controlType: 'ARRAY_BUILDER', items: null, name: 'value', type: 'ARRAY'} as any,
+            })
+        );
+
+        await act(async () => {
+            await Promise.resolve();
+        });
+
+        expect(result.current.arrayItems).toHaveLength(2);
+    });
+
+    it('hydrates three STRING items from parameters.value on mount (var component scenario)', async () => {
+        // This mirrors the workflow JSON from the bug report:
+        //   parameters: {type: 'ARRAY', value: ['www', 'wqewqe', 'rrrr']}
+        //   metadata.ui.dynamicPropertyTypes: {value[0]: 'STRING', value[1]: 'STRING', value[2]: 'STRING'}
+        hoisted.storeState.currentComponent = {
+            componentName: 'var',
+            metadata: {
+                ui: {
+                    dynamicPropertyTypes: {
+                        'value[0]': 'STRING',
+                        'value[1]': 'STRING',
+                        'value[2]': 'STRING',
+                    },
+                },
+            },
+            parameters: {
+                type: 'ARRAY',
+                value: ['www', 'wqewqe', 'rrrr'],
+            },
+            workflowNodeName: 'var_1',
+        };
+
+        const {useArrayProperty} = await import('../useArrayProperty');
+
+        const {result} = renderHook(() =>
+            useArrayProperty({
+                onDeleteClick: vi.fn(),
+                path: 'value',
+                property: {
+                    controlType: 'ARRAY_BUILDER',
+                    name: 'value',
+                    type: 'ARRAY',
+                    // Var component's array(VALUE) has no items() specified.
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                } as any,
+            })
+        );
+
+        // Allow the mount-time hydration effect to run.
+        await act(async () => {
+            await Promise.resolve();
+        });
+
+        expect(result.current.arrayItems).toHaveLength(3);
+
+        const items = result.current.arrayItems as Array<{defaultValue: unknown; type: string}>;
+
+        expect(items[0].defaultValue).toBe('www');
+        expect(items[0].type).toBe('STRING');
+        expect(items[1].defaultValue).toBe('wqewqe');
+        expect(items[2].defaultValue).toBe('rrrr');
+    });
+});

--- a/client/src/pages/platform/workflow-editor/stores/useWorkflowDataStore.ts
+++ b/client/src/pages/platform/workflow-editor/stores/useWorkflowDataStore.ts
@@ -57,7 +57,8 @@ interface WorkflowDataStateI {
     updateWorkflowNodeParameters: (
         workflowNodeName: string,
         parameters: Record<string, object>,
-        version?: number
+        version?: number,
+        metadata?: Record<string, unknown>
     ) => void;
 }
 
@@ -65,7 +66,8 @@ function updateClusterElementParameters(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     clusterElements: Record<string, any>,
     workflowNodeName: string,
-    parameters: Record<string, object>
+    parameters: Record<string, object>,
+    metadata?: Record<string, unknown>
 ): boolean {
     for (const elementValue of Object.values(clusterElements)) {
         if (!elementValue) {
@@ -78,11 +80,15 @@ function updateClusterElementParameters(
             if (element.name === workflowNodeName) {
                 element.parameters = parameters;
 
+                if (metadata !== undefined) {
+                    element.metadata = metadata;
+                }
+
                 return true;
             }
 
             if (element.clusterElements) {
-                if (updateClusterElementParameters(element.clusterElements, workflowNodeName, parameters)) {
+                if (updateClusterElementParameters(element.clusterElements, workflowNodeName, parameters, metadata)) {
                     return true;
                 }
             }
@@ -96,17 +102,22 @@ function updateTaskParametersInTasks(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     tasks: any[],
     workflowNodeName: string,
-    parameters: Record<string, object>
+    parameters: Record<string, object>,
+    metadata?: Record<string, unknown>
 ): boolean {
     for (const task of tasks) {
         if (task.name === workflowNodeName) {
             task.parameters = parameters;
 
+            if (metadata !== undefined) {
+                task.metadata = metadata;
+            }
+
             return true;
         }
 
         if (task.clusterElements) {
-            if (updateClusterElementParameters(task.clusterElements, workflowNodeName, parameters)) {
+            if (updateClusterElementParameters(task.clusterElements, workflowNodeName, parameters, metadata)) {
                 return true;
             }
         }
@@ -115,7 +126,7 @@ function updateTaskParametersInTasks(
             let found = false;
 
             forEachNestedTaskGroup(task.parameters as Record<string, unknown>, (subtasks) => {
-                if (!found && updateTaskParametersInTasks(subtasks, workflowNodeName, parameters)) {
+                if (!found && updateTaskParametersInTasks(subtasks, workflowNodeName, parameters, metadata)) {
                     found = true;
                 }
             });
@@ -201,7 +212,7 @@ const useWorkflowDataStore = create<WorkflowDataStateI>()(
             workflow: {
                 nodeNames: ['trigger_1'],
             },
-            updateWorkflowNodeParameters: (workflowNodeName, parameters, version) =>
+            updateWorkflowNodeParameters: (workflowNodeName, parameters, version, metadata) =>
                 set((state) => {
                     const workflow = state.workflow;
 
@@ -224,25 +235,51 @@ const useWorkflowDataStore = create<WorkflowDataStateI>()(
                             if (trigger.name === workflowNodeName) {
                                 trigger.parameters = parameters;
 
+                                if (metadata !== undefined) {
+                                    trigger.metadata = metadata;
+                                }
+
                                 break;
                             }
                         }
                     }
 
                     if (definition.tasks) {
-                        updateTaskParametersInTasks(definition.tasks, workflowNodeName, parameters);
+                        updateTaskParametersInTasks(definition.tasks, workflowNodeName, parameters, metadata);
                     }
 
                     const updatedTriggers = workflow.triggers?.map((trigger) =>
-                        trigger.name === workflowNodeName ? {...trigger, parameters} : trigger
+                        trigger.name === workflowNodeName
+                            ? {...trigger, parameters, ...(metadata !== undefined ? {metadata} : {})}
+                            : trigger
                     );
 
                     const updatedTasks = workflow.tasks?.map((task) =>
-                        task.name === workflowNodeName ? {...task, parameters} : task
+                        task.name === workflowNodeName
+                            ? {...task, parameters, ...(metadata !== undefined ? {metadata} : {})}
+                            : task
+                    );
+
+                    // Keep React Flow node data in sync. useLayout skips re-runs on parameter-only
+                    // changes (structural fingerprint), so without this patch nodes[i].data.parameters
+                    // stays frozen at the first layout. Clicking a node later then seeds the details
+                    // panel from stale data and the user loses recent edits until the next refresh.
+                    const updatedNodes = state.nodes.map((node) =>
+                        node.id === workflowNodeName
+                            ? {
+                                  ...node,
+                                  data: {
+                                      ...node.data,
+                                      parameters,
+                                      ...(metadata !== undefined ? {metadata} : {}),
+                                  },
+                              }
+                            : node
                     );
 
                     return {
                         ...state,
+                        nodes: updatedNodes,
                         workflow: {
                             ...workflow,
                             definition: JSON.stringify(definition, null, SPACE),

--- a/client/src/pages/platform/workflow-editor/utils/deleteProperty.ts
+++ b/client/src/pages/platform/workflow-editor/utils/deleteProperty.ts
@@ -87,7 +87,8 @@ export default function deleteProperty(
                                 .updateWorkflowNodeParameters(
                                     clusterElementWorkflowNodeName,
                                     response.parameters,
-                                    response.version
+                                    response.version,
+                                    response.metadata as Record<string, unknown> | undefined
                                 );
                         }
                     },
@@ -136,7 +137,12 @@ export default function deleteProperty(
                     if (response.parameters) {
                         useWorkflowDataStore
                             .getState()
-                            .updateWorkflowNodeParameters(nodeWorkflowNodeName, response.parameters, response.version);
+                            .updateWorkflowNodeParameters(
+                                nodeWorkflowNodeName,
+                                response.parameters,
+                                response.version,
+                                response.metadata as Record<string, unknown> | undefined
+                            );
                     }
                 },
             }

--- a/client/src/pages/platform/workflow-editor/utils/saveProperty.ts
+++ b/client/src/pages/platform/workflow-editor/utils/saveProperty.ts
@@ -86,7 +86,12 @@ export default function saveProperty({
         if (response.parameters && updatedWorkflowNodeName) {
             useWorkflowDataStore
                 .getState()
-                .updateWorkflowNodeParameters(updatedWorkflowNodeName, response.parameters, response.version);
+                .updateWorkflowNodeParameters(
+                    updatedWorkflowNodeName,
+                    response.parameters,
+                    response.version,
+                    response.metadata as Record<string, unknown> | undefined
+                );
         }
     }
 

--- a/client/test/playwright/tests/properties/arrayProperty.spec.ts
+++ b/client/test/playwright/tests/properties/arrayProperty.spec.ts
@@ -504,5 +504,61 @@ test.describe('ArrayProperty - Array property type (ArrayProperty.tsx)', () => {
                 await expect(firstArrayItemTextbox).toContainText(newValue);
             });
         });
+
+        // Regression for the stale-node-data bug: useLayout skips re-runs on
+        // parameter-only changes, so nodes[i].data.parameters stayed frozen at
+        // the first layout. Clicking another node and coming back seeded the
+        // details panel from stale data and the just-added item disappeared
+        // until the next full page reload.
+        test('should keep edits visible after opening another node and returning to var_1', async () => {
+            const newValue = 'still here after node switch';
+
+            await test.step('Add a new array item and fill it', async () => {
+                await addArrayItemViaPopover({
+                    arrayProperty: workflowPage.arrayProperty,
+                    page: authenticatedPage,
+                });
+
+                const initialCount = SAMPLE_VAR_ARRAY?.length ?? 0;
+
+                const newItemTextbox = workflowPage.arrayPropertyItemTextboxAt(initialCount);
+
+                await replaceMentionsInputValue({
+                    input: newItemTextbox,
+                    page: authenticatedPage,
+                    value: newValue,
+                });
+
+                await authenticatedPage.waitForTimeout(WorkflowPage.LONG_DEBOUNCE_MS);
+            });
+
+            await test.step('Open another node (propertyTesting_1), then return to var_1', async () => {
+                const otherNode = authenticatedPage.getByLabel('propertyTesting_1 node');
+
+                await clickAndExpectToBeVisible({
+                    target: authenticatedPage.getByLabel('propertyTesting_1 component configuration panel'),
+                    trigger: otherNode,
+                });
+
+                await clickAndExpectToBeVisible({
+                    target: workflowPage.firstTaskComponentConfigurationPanel,
+                    trigger: workflowPage.firstNode,
+                });
+
+                await openPropertiesTab(workflowPage.firstTaskComponentConfigurationPanel);
+            });
+
+            await test.step('Newly added item value must still be rendered (no stale node data)', async () => {
+                const initialCount = SAMPLE_VAR_ARRAY?.length ?? 0;
+
+                const arrayItems = workflowPage.arrayPropertyItems;
+
+                await expect(arrayItems).toHaveCount(initialCount + 1);
+
+                const newItemTextbox = workflowPage.arrayPropertyItemTextboxAt(initialCount);
+
+                await expect(newItemTextbox).toContainText(newValue);
+            });
+        });
     });
 });


### PR DESCRIPTION
updateWorkflowNodeParameters now also patches state.nodes[i].data.parameters
and .metadata for the matching node. Without this, useLayout's structural
fingerprint optimization kept nodes[].data frozen at the first layout, so
useNodeClick seeded currentComponent from stale parameters after a user
clicked away and back. The effect was most visible on array properties
(var value[], postgres values.rows) where recent adds/edits disappeared
until a page reload.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
