### PR TITLE
4897 - Revert context-menu shadcn component

### DIFF
--- a/client/src/components/ui/context-menu.tsx
+++ b/client/src/components/ui/context-menu.tsx
@@ -1,187 +1,261 @@
-'use client';
+"use client"
 
-import * as ContextMenuPrimitive from '@radix-ui/react-context-menu';
-import {Check, ChevronRight, Circle} from 'lucide-react';
-import * as React from 'react';
+import * as React from "react"
+import { CheckIcon, ChevronRightIcon } from "lucide-react"
+import { ContextMenu as ContextMenuPrimitive } from "radix-ui"
 
-import {twMerge} from 'tailwind-merge';
+import { cn } from "@/shared/util/cn-utils"
 
-const ContextMenu = ContextMenuPrimitive.Root;
-const ContextMenuTrigger = ContextMenuPrimitive.Trigger;
-const ContextMenuGroup = ContextMenuPrimitive.Group;
-const ContextMenuPortal = ContextMenuPrimitive.Portal;
-const ContextMenuSub = ContextMenuPrimitive.Sub;
-const ContextMenuRadioGroup = ContextMenuPrimitive.RadioGroup;
+function ContextMenu({
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Root>) {
+  return <ContextMenuPrimitive.Root data-slot="context-menu" {...props} />
+}
 
-const ContextMenuSubTrigger = React.forwardRef<
-    React.ElementRef<typeof ContextMenuPrimitive.SubTrigger>,
-    React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.SubTrigger> & {
-        inset?: boolean;
-    }
->(({children, className, inset, ...props}, ref) => (
-    <ContextMenuPrimitive.SubTrigger
-        className={twMerge(
-            'dropdown-menu-item flex select-none items-center text-sm outline-none data-[state=open]:bg-surface-neutral-primary-hover',
-            inset && 'pl-8',
-            className
-        )}
-        ref={ref}
-        {...props}
-    >
-        {children}
-        <ChevronRight className="ml-auto size-4" />
-    </ContextMenuPrimitive.SubTrigger>
-));
-ContextMenuSubTrigger.displayName = ContextMenuPrimitive.SubTrigger.displayName;
-
-const ContextMenuSubContent = React.forwardRef<
-    React.ElementRef<typeof ContextMenuPrimitive.SubContent>,
-    React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.SubContent>
->(({className, ...props}, ref) => (
-    <ContextMenuPrimitive.SubContent
-        className={twMerge(
-            'z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
-            className
-        )}
-        ref={ref}
-        {...props}
+function ContextMenuTrigger({
+  className,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Trigger>) {
+  return (
+    <ContextMenuPrimitive.Trigger
+      data-slot="context-menu-trigger"
+      className={cn("select-none", className)}
+      {...props}
     />
-));
-ContextMenuSubContent.displayName = ContextMenuPrimitive.SubContent.displayName;
+  )
+}
 
-type ContextMenuContentProps = React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Content> & {
-    portal?: boolean;
-};
+function ContextMenuGroup({
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Group>) {
+  return (
+    <ContextMenuPrimitive.Group data-slot="context-menu-group" {...props} />
+  )
+}
 
-const ContextMenuContent = React.forwardRef<React.ElementRef<typeof ContextMenuPrimitive.Content>, ContextMenuContentProps>(
-    ({className, portal = true, ...props}, ref) => {
-        const content = (
-            <ContextMenuPrimitive.Content
-                className={twMerge(
-                    'z-[9999] min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md',
-                    'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
-                    className
-                )}
-                ref={ref}
-                {...props}
-            />
-        );
+function ContextMenuPortal({
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Portal>) {
+  return (
+    <ContextMenuPrimitive.Portal data-slot="context-menu-portal" {...props} />
+  )
+}
 
-        if (!portal) {
-            return content;
-        }
+function ContextMenuSub({
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Sub>) {
+  return <ContextMenuPrimitive.Sub data-slot="context-menu-sub" {...props} />
+}
 
-        return <ContextMenuPrimitive.Portal>{content}</ContextMenuPrimitive.Portal>;
-    }
-);
-ContextMenuContent.displayName = ContextMenuPrimitive.Content.displayName;
+function ContextMenuRadioGroup({
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.RadioGroup>) {
+  return (
+    <ContextMenuPrimitive.RadioGroup
+      data-slot="context-menu-radio-group"
+      {...props}
+    />
+  )
+}
 
-const ContextMenuItem = React.forwardRef<
-    React.ElementRef<typeof ContextMenuPrimitive.Item>,
-    React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Item> & {
-        inset?: boolean;
-        destructive?: boolean;
-    }
->(({className, inset, destructive, ...props}, ref) => (
+function ContextMenuContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Content> & {
+  side?: "top" | "right" | "bottom" | "left"
+}) {
+  return (
+    <ContextMenuPrimitive.Portal>
+      <ContextMenuPrimitive.Content
+        data-slot="context-menu-content"
+        className={cn("z-50 max-h-(--radix-context-menu-content-available-height) min-w-36 origin-(--radix-context-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+        {...props}
+      />
+    </ContextMenuPrimitive.Portal>
+  )
+}
+
+function ContextMenuItem({
+  className,
+  inset,
+  variant = "default",
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Item> & {
+  inset?: boolean
+  variant?: "default" | "destructive"
+}) {
+  return (
     <ContextMenuPrimitive.Item
-        className={twMerge(
-            'relative flex select-none items-center gap-2 text-sm outline-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&>svg]:size-4 [&>svg]:shrink-0',
-            destructive ? 'dropdown-menu-item-destructive' : 'dropdown-menu-item',
-            inset && 'pl-8',
-            className
-        )}
-        ref={ref}
-        {...props}
+      data-slot="context-menu-item"
+      data-inset={inset}
+      data-variant={variant}
+      className={cn(
+        "group/context-menu-item relative flex cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-inset:pl-7 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 focus:*:[svg]:text-accent-foreground data-[variant=destructive]:*:[svg]:text-destructive",
+        className
+      )}
+      {...props}
     />
-));
-ContextMenuItem.displayName = ContextMenuPrimitive.Item.displayName;
+  )
+}
 
-const ContextMenuCheckboxItem = React.forwardRef<
-    React.ElementRef<typeof ContextMenuPrimitive.CheckboxItem>,
-    React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.CheckboxItem>
->(({checked, children, className, ...props}, ref) => (
+function ContextMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.SubTrigger> & {
+  inset?: boolean
+}) {
+  return (
+    <ContextMenuPrimitive.SubTrigger
+      data-slot="context-menu-sub-trigger"
+      data-inset={inset}
+      className={cn(
+        "flex cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-inset:pl-7 data-open:bg-accent data-open:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRightIcon className="cn-rtl-flip ml-auto" />
+    </ContextMenuPrimitive.SubTrigger>
+  )
+}
+
+function ContextMenuSubContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.SubContent>) {
+  return (
+    <ContextMenuPrimitive.SubContent
+      data-slot="context-menu-sub-content"
+      className={cn("z-50 min-w-32 origin-(--radix-context-menu-content-transform-origin) overflow-hidden rounded-lg border bg-popover p-1 text-popover-foreground shadow-lg duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+      {...props}
+    />
+  )
+}
+
+function ContextMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  inset,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.CheckboxItem> & {
+  inset?: boolean
+}) {
+  return (
     <ContextMenuPrimitive.CheckboxItem
-        checked={checked}
-        className={twMerge(
-            'dropdown-menu-item relative flex select-none items-center text-sm outline-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 pl-8',
-            className
-        )}
-        ref={ref}
-        {...props}
+      data-slot="context-menu-checkbox-item"
+      data-inset={inset}
+      className={cn(
+        "relative flex cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      checked={checked}
+      {...props}
     >
-        <span className="absolute left-2 flex size-3.5 items-center justify-center">
-            <ContextMenuPrimitive.ItemIndicator>
-                <Check className="size-4" />
-            </ContextMenuPrimitive.ItemIndicator>
-        </span>
-        {children}
+      <span className="pointer-events-none absolute right-2">
+        <ContextMenuPrimitive.ItemIndicator>
+          <CheckIcon />
+        </ContextMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
     </ContextMenuPrimitive.CheckboxItem>
-));
-ContextMenuCheckboxItem.displayName = ContextMenuPrimitive.CheckboxItem.displayName;
+  )
+}
 
-const ContextMenuRadioItem = React.forwardRef<
-    React.ElementRef<typeof ContextMenuPrimitive.RadioItem>,
-    React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.RadioItem>
->(({children, className, ...props}, ref) => (
+function ContextMenuRadioItem({
+  className,
+  children,
+  inset,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.RadioItem> & {
+  inset?: boolean
+}) {
+  return (
     <ContextMenuPrimitive.RadioItem
-        className={twMerge(
-            'dropdown-menu-item relative flex select-none items-center text-sm outline-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 pl-8',
-            className
-        )}
-        ref={ref}
-        {...props}
+      data-slot="context-menu-radio-item"
+      data-inset={inset}
+      className={cn(
+        "relative flex cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
     >
-        <span className="absolute left-2 flex size-3.5 items-center justify-center">
-            <ContextMenuPrimitive.ItemIndicator>
-                <Circle className="size-2 fill-current" />
-            </ContextMenuPrimitive.ItemIndicator>
-        </span>
-        {children}
+      <span className="pointer-events-none absolute right-2">
+        <ContextMenuPrimitive.ItemIndicator>
+          <CheckIcon />
+        </ContextMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
     </ContextMenuPrimitive.RadioItem>
-));
-ContextMenuRadioItem.displayName = ContextMenuPrimitive.RadioItem.displayName;
+  )
+}
 
-const ContextMenuLabel = React.forwardRef<
-    React.ElementRef<typeof ContextMenuPrimitive.Label>,
-    React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Label> & {
-        inset?: boolean;
-    }
->(({className, inset, ...props}, ref) => (
+function ContextMenuLabel({
+  className,
+  inset,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Label> & {
+  inset?: boolean
+}) {
+  return (
     <ContextMenuPrimitive.Label
-        className={twMerge('px-4 py-2 text-sm font-semibold text-foreground', inset && 'pl-8', className)}
-        ref={ref}
-        {...props}
+      data-slot="context-menu-label"
+      data-inset={inset}
+      className={cn(
+        "px-1.5 py-1 text-xs font-medium text-muted-foreground data-inset:pl-7",
+        className
+      )}
+      {...props}
     />
-));
-ContextMenuLabel.displayName = ContextMenuPrimitive.Label.displayName;
+  )
+}
 
-const ContextMenuSeparator = React.forwardRef<
-    React.ElementRef<typeof ContextMenuPrimitive.Separator>,
-    React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Separator>
->(({className, ...props}, ref) => (
-    <ContextMenuPrimitive.Separator className={twMerge('h-px bg-border', className)} ref={ref} {...props} />
-));
-ContextMenuSeparator.displayName = ContextMenuPrimitive.Separator.displayName;
+function ContextMenuSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof ContextMenuPrimitive.Separator>) {
+  return (
+    <ContextMenuPrimitive.Separator
+      data-slot="context-menu-separator"
+      className={cn("-mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
 
-const ContextMenuShortcut = ({className, ...props}: React.HTMLAttributes<HTMLSpanElement>) => {
-    return <span className={twMerge('ml-auto text-xs tracking-widest text-muted-foreground', className)} {...props} />;
-};
-ContextMenuShortcut.displayName = 'ContextMenuShortcut';
+function ContextMenuShortcut({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="context-menu-shortcut"
+      className={cn(
+        "ml-auto text-xs tracking-widest text-muted-foreground group-focus/context-menu-item:text-accent-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
 
 export {
-    ContextMenu,
-    ContextMenuCheckboxItem,
-    ContextMenuContent,
-    ContextMenuGroup,
-    ContextMenuItem,
-    ContextMenuLabel,
-    ContextMenuPortal,
-    ContextMenuRadioGroup,
-    ContextMenuRadioItem,
-    ContextMenuSeparator,
-    ContextMenuShortcut,
-    ContextMenuSub,
-    ContextMenuSubContent,
-    ContextMenuSubTrigger,
-    ContextMenuTrigger,
-};
+  ContextMenu,
+  ContextMenuTrigger,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuCheckboxItem,
+  ContextMenuRadioItem,
+  ContextMenuLabel,
+  ContextMenuSeparator,
+  ContextMenuShortcut,
+  ContextMenuGroup,
+  ContextMenuPortal,
+  ContextMenuSub,
+  ContextMenuSubContent,
+  ContextMenuSubTrigger,
+  ContextMenuRadioGroup,
+}

--- a/client/src/pages/platform/workflow-editor/components/WorkflowNodeContextMenu.tsx
+++ b/client/src/pages/platform/workflow-editor/components/WorkflowNodeContextMenu.tsx
@@ -91,7 +91,7 @@ const WorkflowNodeContextMenu = ({
             <ContextMenu>
                 <ContextMenuTrigger asChild>{children}</ContextMenuTrigger>
 
-                <ContextMenuContent className="w-[280px] [padding:0px]">
+                <ContextMenuContent className="w-workflow-node-context-menu-width p-0">
                     {data.trigger ? (
                         <>
                             <ContextMenuItem className="dropdown-menu-item gap-2" onClick={onSwitch}>

--- a/client/src/pages/platform/workflow-editor/components/WorkflowNodeContextMenu.tsx
+++ b/client/src/pages/platform/workflow-editor/components/WorkflowNodeContextMenu.tsx
@@ -1,3 +1,4 @@
+import '@/shared/styles/dropdownMenu.css';
 import DeleteAlertDialog from '@/components/DeleteAlertDialog';
 import {
     ContextMenu,
@@ -24,7 +25,6 @@ interface WorkflowNodeContextMenuProps {
     children: ReactNode;
     data: NodeDataType;
     hasSavedPosition: boolean;
-    onContextMenuOpenChange?: (open: boolean) => void;
     onCopy: () => void;
     onDelete: () => void;
     onPaste: () => void;
@@ -38,7 +38,6 @@ const WorkflowNodeContextMenu = ({
     children,
     data,
     hasSavedPosition,
-    onContextMenuOpenChange,
     onCopy,
     onDelete,
     onPaste,
@@ -48,20 +47,7 @@ const WorkflowNodeContextMenu = ({
 }: WorkflowNodeContextMenuProps) => {
     const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
 
-    const {copiedNode, setContextMenuOpen} = useWorkflowEditorStore(
-        useShallow((state) => ({
-            copiedNode: state.copiedNode,
-            setContextMenuOpen: state.setContextMenuOpen,
-        }))
-    );
-
-    const handleOpenChange = useCallback(
-        (open: boolean) => {
-            setContextMenuOpen(open);
-            onContextMenuOpenChange?.(open);
-        },
-        [onContextMenuOpenChange, setContextMenuOpen]
-    );
+    const copiedNode = useWorkflowEditorStore(useShallow((state) => state.copiedNode));
 
     const handleDeleteClick = useCallback(() => setDeleteDialogOpen(true), []);
 
@@ -75,7 +61,7 @@ const WorkflowNodeContextMenu = ({
         const copiedNodeLabel = copiedNode.label ?? copiedNode.componentName ?? 'Node';
 
         return (
-            <ContextMenuItem className="flex w-full flex-col items-start gap-1" onClick={onPaste}>
+            <ContextMenuItem className="dropdown-menu-item flex w-full flex-col items-start gap-1" onClick={onPaste}>
                 <div className="flex w-full items-center gap-2 self-stretch text-content-neutral-primary">
                     <ClipboardPlusIcon className="size-4 shrink-0" />
 
@@ -83,7 +69,9 @@ const WorkflowNodeContextMenu = ({
                 </div>
 
                 <div className="flex w-full items-center gap-2 text-content-neutral-secondary">
-                    <span className="flex size-4 shrink-0 items-center justify-center">{copiedNode.icon ?? null}</span>
+                    <span className="flex size-4 shrink-0 items-center justify-center overflow-hidden [&>svg]:size-4">
+                        {copiedNode.icon ?? null}
+                    </span>
 
                     <span
                         className="line-clamp-1 flex-1 text-xs font-normal"
@@ -100,49 +88,52 @@ const WorkflowNodeContextMenu = ({
 
     return (
         <>
-            <ContextMenu onOpenChange={handleOpenChange}>
+            <ContextMenu>
                 <ContextMenuTrigger asChild>{children}</ContextMenuTrigger>
 
-                <ContextMenuContent className="w-[280px]">
+                <ContextMenuContent className="w-[280px] [padding:0px]">
                     {data.trigger ? (
                         <>
-                            <ContextMenuItem onClick={onSwitch}>
-                                <ArrowLeftRightIcon />
+                            <ContextMenuItem className="dropdown-menu-item gap-2" onClick={onSwitch}>
+                                <ArrowLeftRightIcon className="size-4 shrink-0" />
                                 Replace
                             </ContextMenuItem>
 
-                            <ContextMenuItem onClick={onRename}>
-                                <TextCursorInputIcon />
+                            <ContextMenuItem className="dropdown-menu-item gap-2" onClick={onRename}>
+                                <TextCursorInputIcon className="size-4 shrink-0" />
                                 Rename
                             </ContextMenuItem>
                         </>
                     ) : (
                         <>
-                            <ContextMenuItem onClick={onCopy}>
-                                <CopyIcon />
+                            <ContextMenuItem className="dropdown-menu-item gap-2" onClick={onCopy}>
+                                <CopyIcon className="size-4 shrink-0" />
                                 Copy
                             </ContextMenuItem>
 
                             {pasteMenuItem}
 
-                            <ContextMenuSeparator />
+                            <ContextMenuSeparator className="m-0" />
 
-                            <ContextMenuItem onClick={onRename}>
-                                <TextCursorInputIcon />
+                            <ContextMenuItem className="dropdown-menu-item gap-2" onClick={onRename}>
+                                <TextCursorInputIcon className="size-4 shrink-0" />
                                 Rename
                             </ContextMenuItem>
 
                             {hasSavedPosition && (
-                                <ContextMenuItem onClick={onResetPosition}>
-                                    <RefreshCcwIcon />
+                                <ContextMenuItem className="dropdown-menu-item gap-2" onClick={onResetPosition}>
+                                    <RefreshCcwIcon className="size-4 shrink-0" />
                                     Reset position
                                 </ContextMenuItem>
                             )}
 
-                            <ContextMenuSeparator />
+                            <ContextMenuSeparator className="m-0" />
 
-                            <ContextMenuItem destructive onClick={handleDeleteClick}>
-                                <Trash2Icon />
+                            <ContextMenuItem
+                                className="dropdown-menu-item-destructive gap-2"
+                                onClick={handleDeleteClick}
+                            >
+                                <Trash2Icon className="size-4 shrink-0" />
                                 Delete
                             </ContextMenuItem>
                         </>

--- a/client/src/pages/platform/workflow-editor/components/WorkflowNodesPopoverMenu.tsx
+++ b/client/src/pages/platform/workflow-editor/components/WorkflowNodesPopoverMenu.tsx
@@ -26,6 +26,7 @@ interface WorkflowNodesPopoverMenuProps extends PropsWithChildren {
     nodeIndex?: number;
     onOpenChange?: (open: boolean) => void;
     open?: boolean;
+    showPaste?: boolean;
     sourceNodeId: string;
     sourceNodeName?: string;
 }
@@ -42,6 +43,7 @@ const WorkflowNodesPopoverMenu = ({
     nodeIndex,
     onOpenChange: externalOnOpenChange,
     open: externalOpen,
+    showPaste = true,
     sourceNodeId,
     sourceNodeName,
 }: WorkflowNodesPopoverMenuProps) => {
@@ -187,7 +189,7 @@ const WorkflowNodesPopoverMenu = ({
                         hideTriggerComponents={hideTriggerComponents}
                         onPasteClose={handlePasteClose}
                         selectedComponentName={componentDefinitionToBeAdded?.name}
-                        showPaste
+                        showPaste={showPaste}
                         sourceNodeId={sourceNodeId}
                         updateWorkflowMutation={updateWorkflowMutation}
                     />

--- a/client/src/pages/platform/workflow-editor/components/WorkflowNodesPopoverMenu.tsx
+++ b/client/src/pages/platform/workflow-editor/components/WorkflowNodesPopoverMenu.tsx
@@ -43,7 +43,7 @@ const WorkflowNodesPopoverMenu = ({
     nodeIndex,
     onOpenChange: externalOnOpenChange,
     open: externalOpen,
-    showPaste = true,
+    showPaste = false,
     sourceNodeId,
     sourceNodeName,
 }: WorkflowNodesPopoverMenuProps) => {

--- a/client/src/pages/platform/workflow-editor/edges/WorkflowEdge.tsx
+++ b/client/src/pages/platform/workflow-editor/edges/WorkflowEdge.tsx
@@ -260,7 +260,7 @@ export default function WorkflowEdge({
                             </div>
                         </ContextMenuTrigger>
 
-                        <ContextMenuContent className="w-[280px] [padding:0px]">
+                        <ContextMenuContent className="w-workflow-node-context-menu-width p-0">
                             <ContextMenuItem
                                 className="dropdown-menu-item flex w-full flex-col items-start gap-1"
                                 disabled={!canPaste}

--- a/client/src/pages/platform/workflow-editor/edges/WorkflowEdge.tsx
+++ b/client/src/pages/platform/workflow-editor/edges/WorkflowEdge.tsx
@@ -3,7 +3,7 @@ import {ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger} fr
 import {NodeDataType} from '@/shared/types';
 import {BaseEdge, EdgeLabelRenderer, EdgeProps, getSmoothStepPath} from '@xyflow/react';
 import {ClipboardPlusIcon, PlusIcon} from 'lucide-react';
-import {useCallback, useEffect, useMemo, useState} from 'react';
+import {type DragEvent, type MouseEvent, useCallback, useEffect, useMemo, useState} from 'react';
 import {twMerge} from 'tailwind-merge';
 import {useShallow} from 'zustand/react/shallow';
 
@@ -164,19 +164,19 @@ export default function WorkflowEdge({
         }
     }, []);
 
-    const handleDragOver = useCallback((event: React.DragEvent) => {
+    const handleDragOver = useCallback((event: DragEvent) => {
         event.preventDefault();
 
         setDropzoneActive(true);
     }, []);
 
-    const handleDrop = useCallback((event: React.DragEvent) => {
+    const handleDrop = useCallback((event: DragEvent) => {
         event.preventDefault();
 
         setDropzoneActive(false);
     }, []);
 
-    const handleClick = useCallback((event: React.MouseEvent) => event.stopPropagation(), []);
+    const handleClick = useCallback((event: MouseEvent) => event.stopPropagation(), []);
 
     useEffect(() => {
         const handleGlobalDragEnd = () => {

--- a/client/src/pages/platform/workflow-editor/edges/WorkflowEdge.tsx
+++ b/client/src/pages/platform/workflow-editor/edges/WorkflowEdge.tsx
@@ -1,3 +1,4 @@
+import '@/shared/styles/dropdownMenu.css';
 import {ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger} from '@/components/ui/context-menu';
 import {NodeDataType} from '@/shared/types';
 import {BaseEdge, EdgeLabelRenderer, EdgeProps, getSmoothStepPath} from '@xyflow/react';
@@ -153,6 +154,30 @@ export default function WorkflowEdge({
         });
     }, [edges, id, nodes, sourceNode, sourceNodeId, updateWorkflowMutation]);
 
+    const handleDragEnter = useCallback(() => setDropzoneActive(true), []);
+
+    const handleDragLeave = useCallback((event: React.DragEvent) => {
+        const relatedTarget = event.relatedTarget as Node | null;
+
+        if (!relatedTarget || !event.currentTarget.contains(relatedTarget)) {
+            setDropzoneActive(false);
+        }
+    }, []);
+
+    const handleDragOver = useCallback((event: React.DragEvent) => {
+        event.preventDefault();
+
+        setDropzoneActive(true);
+    }, []);
+
+    const handleDrop = useCallback((event: React.DragEvent) => {
+        event.preventDefault();
+
+        setDropzoneActive(false);
+    }, []);
+
+    const handleClick = useCallback((event: React.MouseEvent) => event.stopPropagation(), []);
+
     useEffect(() => {
         const handleGlobalDragEnd = () => {
             setDropzoneActive(false);
@@ -191,86 +216,75 @@ export default function WorkflowEdge({
             )}
 
             <EdgeLabelRenderer key={id}>
-                <WorkflowNodesPopoverMenu
-                    edgeId={id}
-                    hideClusterElementComponents
-                    hideTriggerComponents
-                    sourceNodeId={sourceNodeId}
+                <div
+                    className="nodrag nopan p-8"
+                    id={id}
+                    onClick={handleClick}
+                    onDragEnter={handleDragEnter}
+                    onDragLeave={handleDragLeave}
+                    onDragOver={handleDragOver}
+                    onDrop={handleDrop}
+                    style={{
+                        pointerEvents: 'all',
+                        position: 'absolute',
+                        transform: `translate(-50%, -50%) translate(${buttonPosition.x}px,${buttonPosition.y}px)`,
+                        zIndex: isDropzoneActive ? 40 : 'auto',
+                    }}
                 >
-                    <div
-                        className="nodrag nopan p-8"
-                        id={id}
-                        onDragEnter={() => setDropzoneActive(true)}
-                        onDragLeave={(event) => {
-                            const relatedTarget = event.relatedTarget as Node | null;
-
-                            if (!relatedTarget || !event.currentTarget.contains(relatedTarget)) {
-                                setDropzoneActive(false);
-                            }
-                        }}
-                        onDragOver={(event) => {
-                            event.preventDefault();
-
-                            setDropzoneActive(true);
-                        }}
-                        onDrop={(event) => {
-                            event.preventDefault();
-
-                            setDropzoneActive(false);
-                        }}
-                        style={{
-                            pointerEvents: 'all',
-                            position: 'absolute',
-                            transform: `translate(-50%, -50%) translate(${buttonPosition.x}px,${buttonPosition.y}px)`,
-                            zIndex: isDropzoneActive ? 40 : 'auto',
-                        }}
-                    >
-                        <ContextMenu>
-                            <ContextMenuTrigger asChild disabled={!canPaste}>
-                                <div
-                                    className={twMerge(
-                                        'flex cursor-pointer items-center justify-center rounded transition-all',
-                                        isDropzoneActive
-                                            ? 'size-16 border-2 border-blue-100 bg-blue-100'
-                                            : 'size-6 border-2 border-stroke-neutral-tertiary bg-white hover:scale-110 hover:border-stroke-brand-secondary-hover'
-                                    )}
-                                    id={`${id}-button`}
+                    <ContextMenu>
+                        <ContextMenuTrigger asChild disabled={!canPaste}>
+                            <div>
+                                <WorkflowNodesPopoverMenu
+                                    edgeId={id}
+                                    hideClusterElementComponents
+                                    hideTriggerComponents
+                                    sourceNodeId={sourceNodeId}
                                 >
-                                    <PlusIcon
+                                    <div
                                         className={twMerge(
-                                            `text-muted-foreground`,
-                                            isDropzoneActive ? 'size-14 text-muted-foreground/50' : 'size-3.5'
+                                            'flex cursor-pointer items-center justify-center rounded transition-all',
+                                            isDropzoneActive
+                                                ? 'size-16 border-2 border-blue-100 bg-blue-100'
+                                                : 'size-6 border-2 border-stroke-neutral-tertiary bg-white hover:scale-110 hover:border-stroke-brand-secondary-hover'
                                         )}
-                                    />
+                                        id={`${id}-button`}
+                                    >
+                                        <PlusIcon
+                                            className={twMerge(
+                                                'text-muted-foreground',
+                                                isDropzoneActive ? 'size-14 text-muted-foreground/50' : 'size-3.5'
+                                            )}
+                                        />
+                                    </div>
+                                </WorkflowNodesPopoverMenu>
+                            </div>
+                        </ContextMenuTrigger>
+
+                        <ContextMenuContent className="w-[280px] [padding:0px]">
+                            <ContextMenuItem
+                                className="dropdown-menu-item flex w-full flex-col items-start gap-1"
+                                disabled={!canPaste}
+                                onClick={handlePasteClick}
+                            >
+                                <div className="flex w-full items-center gap-2 self-stretch text-content-neutral-primary">
+                                    <ClipboardPlusIcon className="size-4 shrink-0" />
+
+                                    <span>Paste Here</span>
                                 </div>
-                            </ContextMenuTrigger>
 
-                            <ContextMenuContent className="w-[280px]">
-                                <ContextMenuItem
-                                    className="flex w-full cursor-pointer flex-col items-start gap-1 px-[var(--spacing-1,4px)] py-0"
-                                    disabled={!canPaste}
-                                    onClick={handlePasteClick}
-                                >
-                                    <div className="flex w-full items-center gap-2 self-stretch text-content-neutral-primary">
-                                        <ClipboardPlusIcon className="size-4 shrink-0" />
+                                <div className="flex w-full items-center gap-2 text-content-neutral-secondary">
+                                    <span className="flex size-4 shrink-0 items-center justify-center overflow-hidden [&>svg]:size-4">
+                                        {copiedNode?.icon ?? null}
+                                    </span>
 
-                                        <span>Paste Here</span>
-                                    </div>
-
-                                    <div className="flex w-full items-center gap-2 text-content-neutral-secondary">
-                                        <span className="flex size-4 shrink-0 items-center justify-center">
-                                            {copiedNode?.icon ?? null}
-                                        </span>
-
-                                        <span className="line-clamp-1 flex-1 text-xs font-normal" title={displayLabel}>
-                                            {displayLabel}
-                                        </span>
-                                    </div>
-                                </ContextMenuItem>
-                            </ContextMenuContent>
-                        </ContextMenu>
-                    </div>
-                </WorkflowNodesPopoverMenu>
+                                    <span className="line-clamp-1 flex-1 text-xs font-normal" title={displayLabel}>
+                                        {displayLabel}
+                                    </span>
+                                </div>
+                            </ContextMenuItem>
+                        </ContextMenuContent>
+                    </ContextMenu>
+                </div>
             </EdgeLabelRenderer>
         </>
     );

--- a/client/src/pages/platform/workflow-editor/edges/WorkflowEdge.tsx
+++ b/client/src/pages/platform/workflow-editor/edges/WorkflowEdge.tsx
@@ -154,29 +154,29 @@ export default function WorkflowEdge({
         });
     }, [edges, id, nodes, sourceNode, sourceNodeId, updateWorkflowMutation]);
 
-    const handleDragEnter = useCallback(() => setDropzoneActive(true), []);
+    const handleDragEnter = () => setDropzoneActive(true);
 
-    const handleDragLeave = useCallback((event: React.DragEvent) => {
+    const handleDragLeave = (event: DragEvent) => {
         const relatedTarget = event.relatedTarget as Node | null;
 
         if (!relatedTarget || !event.currentTarget.contains(relatedTarget)) {
             setDropzoneActive(false);
         }
-    }, []);
+    };
 
-    const handleDragOver = useCallback((event: DragEvent) => {
+    const handleDragOver = (event: DragEvent) => {
         event.preventDefault();
 
         setDropzoneActive(true);
-    }, []);
+    };
 
-    const handleDrop = useCallback((event: DragEvent) => {
+    const handleDrop = (event: DragEvent) => {
         event.preventDefault();
 
         setDropzoneActive(false);
-    }, []);
+    };
 
-    const handleClick = useCallback((event: MouseEvent) => event.stopPropagation(), []);
+    const handleClick = (event: MouseEvent) => event.stopPropagation();
 
     useEffect(() => {
         const handleGlobalDragEnd = () => {
@@ -244,7 +244,7 @@ export default function WorkflowEdge({
                                         className={twMerge(
                                             'flex cursor-pointer items-center justify-center rounded border-2 transition-all',
                                             isDropzoneActive
-                                                ? 'size-16 border-surface-brand-secondary-hover bg-surface-brand-secondary-hover' // zamijeniti blue-100 s tokenom
+                                                ? 'size-16 border-surface-brand-secondary-hover bg-surface-brand-secondary-hover'
                                                 : 'size-6 border-stroke-neutral-tertiary bg-white hover:scale-110 hover:border-stroke-brand-secondary-hover'
                                         )}
                                         id={`${id}-button`}

--- a/client/src/pages/platform/workflow-editor/edges/WorkflowEdge.tsx
+++ b/client/src/pages/platform/workflow-editor/edges/WorkflowEdge.tsx
@@ -242,17 +242,19 @@ export default function WorkflowEdge({
                                 >
                                     <div
                                         className={twMerge(
-                                            'flex cursor-pointer items-center justify-center rounded transition-all',
+                                            'flex cursor-pointer items-center justify-center rounded border-2 transition-all',
                                             isDropzoneActive
-                                                ? 'size-16 border-2 border-blue-100 bg-blue-100'
-                                                : 'size-6 border-2 border-stroke-neutral-tertiary bg-white hover:scale-110 hover:border-stroke-brand-secondary-hover'
+                                                ? 'size-16 border-surface-brand-secondary-hover bg-surface-brand-secondary-hover' // zamijeniti blue-100 s tokenom
+                                                : 'size-6 border-stroke-neutral-tertiary bg-white hover:scale-110 hover:border-stroke-brand-secondary-hover'
                                         )}
                                         id={`${id}-button`}
                                     >
                                         <PlusIcon
                                             className={twMerge(
-                                                'text-muted-foreground',
-                                                isDropzoneActive ? 'size-14 text-muted-foreground/50' : 'size-3.5'
+                                                'text-content-neutral-secondary',
+                                                isDropzoneActive
+                                                    ? 'size-14 text-content-neutral-secondary/50'
+                                                    : 'size-3.5'
                                             )}
                                         />
                                     </div>

--- a/client/src/pages/platform/workflow-editor/nodes/PlaceholderNode.tsx
+++ b/client/src/pages/platform/workflow-editor/nodes/PlaceholderNode.tsx
@@ -1,3 +1,4 @@
+import '@/shared/styles/dropdownMenu.css';
 import {ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger} from '@/components/ui/context-menu';
 import {NodeDataType} from '@/shared/types';
 import {Handle, Position} from '@xyflow/react';
@@ -42,6 +43,8 @@ const PlaceholderNode = ({data, id}: {data: NodeDataType; id: string}) => {
     const rootClusterElementId = id.split('-')[0];
     const effectiveDirection = isClusterElement ? 'TB' : layoutDirection;
 
+    const canPaste = !!copiedNode && copiedWorkflowId === workflow.id;
+
     const copiedNodeLabel = copiedNode?.label || '';
 
     const displayLabel = useMemo(() => {
@@ -64,7 +67,13 @@ const PlaceholderNode = ({data, id}: {data: NodeDataType; id: string}) => {
         pasteNode({nodeIndex, taskDispatcherContext, updateWorkflowMutation});
     }, [id, nodeIndex, nodes, updateWorkflowMutation]);
 
-    const canPaste = !!copiedNode && copiedWorkflowId === workflow.id;
+    const handleDragEnter = useCallback(() => setDropzoneActive(true), []);
+
+    const handleDragLeave = useCallback(() => setDropzoneActive(false), []);
+
+    const handleDragOver = useCallback((event: React.DragEvent) => event.preventDefault(), []);
+
+    const handleDrop = useCallback(() => setDropzoneActive(false), []);
 
     return (
         <ContextMenu>
@@ -89,10 +98,10 @@ const PlaceholderNode = ({data, id}: {data: NodeDataType; id: string}) => {
                                     : 'size-7 bg-gray-300',
                                 isClusterElement && 'mx-0 size-6'
                             )}
-                            onDragEnter={() => setDropzoneActive(true)}
-                            onDragLeave={() => setDropzoneActive(false)}
-                            onDragOver={(event) => event.preventDefault()}
-                            onDrop={() => setDropzoneActive(false)}
+                            onDragEnter={handleDragEnter}
+                            onDragLeave={handleDragLeave}
+                            onDragOver={handleDragOver}
+                            onDrop={handleDrop}
                             title="Click to add a node"
                         >
                             {data.label}
@@ -113,9 +122,9 @@ const PlaceholderNode = ({data, id}: {data: NodeDataType; id: string}) => {
                 </div>
             </ContextMenuTrigger>
 
-            <ContextMenuContent className="w-[280px]">
+            <ContextMenuContent className="w-[280px] [padding:0px]">
                 <ContextMenuItem
-                    className="flex w-full cursor-pointer flex-col items-start gap-1 px-[var(--spacing-1,4px)] py-0"
+                    className="dropdown-menu-item flex w-full flex-col items-start gap-1"
                     disabled={!canPaste}
                     onClick={handlePasteClick}
                 >
@@ -126,7 +135,7 @@ const PlaceholderNode = ({data, id}: {data: NodeDataType; id: string}) => {
                     </div>
 
                     <div className="flex w-full items-center gap-2 text-content-neutral-secondary">
-                        <span className="flex size-4 shrink-0 items-center justify-center">
+                        <span className="flex size-4 shrink-0 items-center justify-center overflow-hidden [&>svg]:size-4">
                             {copiedNode?.icon ?? null}
                         </span>
 

--- a/client/src/pages/platform/workflow-editor/nodes/PlaceholderNode.tsx
+++ b/client/src/pages/platform/workflow-editor/nodes/PlaceholderNode.tsx
@@ -67,13 +67,13 @@ const PlaceholderNode = ({data, id}: {data: NodeDataType; id: string}) => {
         pasteNode({nodeIndex, taskDispatcherContext, updateWorkflowMutation});
     }, [id, nodeIndex, nodes, updateWorkflowMutation]);
 
-    const handleDragEnter = useCallback(() => setDropzoneActive(true), []);
+    const handleDragEnter = () => setDropzoneActive(true);
 
-    const handleDragLeave = useCallback(() => setDropzoneActive(false), []);
+    const handleDragLeave = () => setDropzoneActive(false);
 
-    const handleDragOver = useCallback((event: DragEvent) => event.preventDefault(), []);
+    const handleDragOver = (event: DragEvent) => event.preventDefault();
 
-    const handleDrop = useCallback(() => setDropzoneActive(false), []);
+    const handleDrop = () => setDropzoneActive(false);
 
     return (
         <ContextMenu>

--- a/client/src/pages/platform/workflow-editor/nodes/PlaceholderNode.tsx
+++ b/client/src/pages/platform/workflow-editor/nodes/PlaceholderNode.tsx
@@ -3,7 +3,7 @@ import {ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger} fr
 import {NodeDataType} from '@/shared/types';
 import {Handle, Position} from '@xyflow/react';
 import {ClipboardPlusIcon} from 'lucide-react';
-import {memo, useCallback, useMemo, useState} from 'react';
+import {DragEvent, memo, useCallback, useMemo, useState} from 'react';
 import {twMerge} from 'tailwind-merge';
 import {useShallow} from 'zustand/react/shallow';
 
@@ -71,7 +71,7 @@ const PlaceholderNode = ({data, id}: {data: NodeDataType; id: string}) => {
 
     const handleDragLeave = useCallback(() => setDropzoneActive(false), []);
 
-    const handleDragOver = useCallback((event: React.DragEvent) => event.preventDefault(), []);
+    const handleDragOver = useCallback((event: DragEvent) => event.preventDefault(), []);
 
     const handleDrop = useCallback(() => setDropzoneActive(false), []);
 

--- a/client/src/pages/platform/workflow-editor/nodes/PlaceholderNode.tsx
+++ b/client/src/pages/platform/workflow-editor/nodes/PlaceholderNode.tsx
@@ -122,7 +122,7 @@ const PlaceholderNode = ({data, id}: {data: NodeDataType; id: string}) => {
                 </div>
             </ContextMenuTrigger>
 
-            <ContextMenuContent className="w-[280px] [padding:0px]">
+            <ContextMenuContent className="w-workflow-node-context-menu-width p-0">
                 <ContextMenuItem
                     className="dropdown-menu-item flex w-full flex-col items-start gap-1"
                     disabled={!canPaste}

--- a/client/src/pages/platform/workflow-editor/nodes/WorkflowNode.tsx
+++ b/client/src/pages/platform/workflow-editor/nodes/WorkflowNode.tsx
@@ -485,7 +485,6 @@ WorkflowNodeContent.displayName = 'WorkflowNodeContent';
 
 const WorkflowNode = ({data, id}: {data: NodeDataType; id: string}) => {
     const [hoveredNodeName, setHoveredNodeName] = useState<string | undefined>();
-    const [isContextMenuOpen, setIsContextMenuOpen] = useState(false);
     const [renameValue, setRenameValue] = useState('');
     const [switchPopoverOpen, setSwitchPopoverOpen] = useState(false);
 
@@ -755,7 +754,7 @@ const WorkflowNode = ({data, id}: {data: NodeDataType; id: string}) => {
 
     const isRenaming = renamingNodeName === data.name;
 
-    const suppressHover = isContextMenuOpen || isRenaming || switchPopoverOpen;
+    const suppressHover = isRenaming || switchPopoverOpen;
 
     const canPaste = !!copiedNode && copiedWorkflowId === workflow.id;
 
@@ -808,7 +807,6 @@ const WorkflowNode = ({data, id}: {data: NodeDataType; id: string}) => {
                 canPaste={canPaste}
                 data={data}
                 hasSavedPosition={!!hasSavedNodePosition}
-                onContextMenuOpenChange={setIsContextMenuOpen}
                 onCopy={handleCopyNode}
                 onDelete={handleDelete}
                 onPaste={handlePasteNode}

--- a/client/src/pages/platform/workflow-editor/nodes/WorkflowNode.tsx
+++ b/client/src/pages/platform/workflow-editor/nodes/WorkflowNode.tsx
@@ -137,6 +137,7 @@ const WorkflowNodeContent = forwardRef<HTMLDivElement, WorkflowNodeContentProps>
                             hideTaskDispatchers
                             onOpenChange={setSwitchPopoverOpen}
                             open={switchPopoverOpen}
+                            showPaste={false}
                             sourceNodeId={id}
                         >
                             <Button

--- a/client/src/pages/platform/workflow-editor/nodes/WorkflowNode.tsx
+++ b/client/src/pages/platform/workflow-editor/nodes/WorkflowNode.tsx
@@ -137,7 +137,6 @@ const WorkflowNodeContent = forwardRef<HTMLDivElement, WorkflowNodeContentProps>
                             hideTaskDispatchers
                             onOpenChange={setSwitchPopoverOpen}
                             open={switchPopoverOpen}
-                            showPaste={false}
                             sourceNodeId={id}
                         >
                             <Button

--- a/client/src/pages/platform/workflow-editor/stores/useWorkflowEditorStore.ts
+++ b/client/src/pages/platform/workflow-editor/stores/useWorkflowEditorStore.ts
@@ -9,9 +9,6 @@ export interface WorkflowEditorI {
     clusterElementsCanvasOpen: boolean;
     setClusterElementsCanvasOpen: (clusterElementsCanvasOpen: boolean) => void;
 
-    contextMenuOpen: boolean;
-    setContextMenuOpen: (contextMenuOpen: boolean) => void;
-
     copiedNode: NodeDataType | undefined;
     setCopiedNode: (copiedNode: NodeDataType | undefined) => void;
 
@@ -69,12 +66,6 @@ const useWorkflowEditorStore = create<WorkflowEditorI>()(
             setClusterElementsCanvasOpen: (clusterElementsCanvasOpen) =>
                 set(() => ({
                     clusterElementsCanvasOpen,
-                })),
-
-            contextMenuOpen: false,
-            setContextMenuOpen: (contextMenuOpen) =>
-                set(() => ({
-                    contextMenuOpen,
                 })),
 
             copiedNode: undefined,

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -327,6 +327,7 @@ module.exports = {
                 'node-popover-width': 'var(--workflow-nodes-popover-component-menu-width)',
                 'sidebar-width': '56px',
                 'task-filter-dropdown-menu-width': 'calc(var(--workflow-nodes-popover-component-menu-width) - 50px)',
+                'workflow-node-context-menu-width': '280px',
                 'workflow-nodes-popover-actions-menu-width': '400px',
                 'workflow-nodes-popover-menu-width': '730px',
                 'workflow-outputs-sheet-dialog-width': '440px',


### PR DESCRIPTION
fixes #4897 

1. revert context-menu to original shadcn code:
`npx shadcn@latest add context-menu`

2. fix implementation across all context menu usages:

- client/src/pages/platform/workflow-editor/components/WorkflowNodeContextMenu.tsx
- client/src/pages/platform/workflow-editor/nodes/PlaceholderNode.tsx
- client/src/pages/platform/workflow-editor/edges/WorkflowEdge.tsx

3. remove duplicated context menu open state causing re-render -> use base context-menu shadcn component + dropdownMenu.css tw classes