### PR TITLE
732 client - Fix DateTimePicker test flakiness by anchoring calendar to selected date

### DIFF
--- a/client/src/components/DateTimePicker/DateTimePicker.test.tsx
+++ b/client/src/components/DateTimePicker/DateTimePicker.test.tsx
@@ -30,9 +30,7 @@ describe('DateTimePicker', () => {
 
         await userEvent.click(trigger);
 
-        // Calendar should be visible.
-        // We look for a day, e.g., 26th.
-        const day26 = screen.getByText('26');
+        const day26 = screen.getByLabelText('Tuesday, December 26th, 2023');
 
         await userEvent.click(day26);
 

--- a/client/src/components/DateTimePicker/DateTimePicker.tsx
+++ b/client/src/components/DateTimePicker/DateTimePicker.tsx
@@ -57,7 +57,7 @@ export default function DateTimePicker({onChange, value}: {onChange: (date: Date
             </PopoverTrigger>
 
             <PopoverContent align="start" className="w-auto p-0">
-                <Calendar autoFocus mode="single" onSelect={handleSelect} selected={date} />
+                <Calendar autoFocus defaultMonth={date} mode="single" onSelect={handleSelect} selected={date} />
 
                 <div className="border-t p-3">
                     <input


### PR DESCRIPTION
Pass `defaultMonth={date}` to Calendar so the popover opens at the selected
date's month instead of today's month. Use `getByLabelText` with the full
accessible name to disambiguate from outside-day collisions where the same
numeric label appears in adjacent months.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
