### PR TITLE
4000 Decouple knowledge base pgvector loader from the knowledge base feature flag

### DIFF
--- a/server/ee/libs/config/tenant-multi-knowledge-base-config/src/main/java/com/bytechef/ee/tenant/multi/config/MultiTenantKnowledgeBasePgVectorConfiguration.java
+++ b/server/ee/libs/config/tenant-multi-knowledge-base-config/src/main/java/com/bytechef/ee/tenant/multi/config/MultiTenantKnowledgeBasePgVectorConfiguration.java
@@ -7,13 +7,11 @@
 
 package com.bytechef.ee.tenant.multi.config;
 
-import com.bytechef.ee.tenant.multi.pgvector.MultiTenantPgVectorLoader;
 import com.bytechef.ee.tenant.multi.pgvector.MultiTenantPgVectorStore;
 import com.bytechef.platform.annotation.ConditionalOnEEVersion;
 import com.bytechef.platform.knowledgebase.service.KnowledgeBaseVectorStoreMetadataService;
 import com.bytechef.tenant.TenantContext;
 import com.bytechef.tenant.annotation.ConditionalOnMultiTenant;
-import com.bytechef.tenant.service.TenantService;
 import org.springframework.ai.embedding.BatchingStrategy;
 import org.springframework.ai.embedding.EmbeddingModel;
 import org.springframework.ai.vectorstore.VectorStore;
@@ -69,15 +67,5 @@ class MultiTenantKnowledgeBasePgVectorConfiguration {
             pgVectorJdbcTemplate, objectMapper,
             () -> TenantContext.getCurrentDatabaseSchema(MultiTenantPgVectorStore.VECTORSTORE_SCHEMA_SUFFIX) + "."
                 + vectorTableName);
-    }
-
-    @Bean
-    @ConditionalOnProperty(prefix = "spring.liquibase", name = "enabled", havingValue = "true", matchIfMissing = true)
-    MultiTenantPgVectorLoader knowledgeBaseMultiTenantPgVectorLoader(
-        @Qualifier("pgVectorJdbcTemplate") JdbcTemplate pgVectorJdbcTemplate, PgVectorStoreProperties properties,
-        TenantService tenantService) {
-
-        return new MultiTenantPgVectorLoader(
-            pgVectorJdbcTemplate, properties, "kb_" + properties.getTableName(), tenantService);
     }
 }

--- a/server/ee/libs/config/tenant-multi-knowledge-base-config/src/main/java/com/bytechef/ee/tenant/multi/config/MultiTenantKnowledgeBasePgVectorLoaderConfiguration.java
+++ b/server/ee/libs/config/tenant-multi-knowledge-base-config/src/main/java/com/bytechef/ee/tenant/multi/config/MultiTenantKnowledgeBasePgVectorLoaderConfiguration.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2025 ByteChef
+ *
+ * Licensed under the ByteChef Enterprise license (the "Enterprise License");
+ * you may not use this file except in compliance with the Enterprise License.
+ */
+
+package com.bytechef.ee.tenant.multi.config;
+
+import com.bytechef.ee.tenant.multi.pgvector.MultiTenantPgVectorLoader;
+import com.bytechef.platform.annotation.ConditionalOnEEVersion;
+import com.bytechef.tenant.annotation.ConditionalOnMultiTenant;
+import com.bytechef.tenant.service.TenantService;
+import org.springframework.ai.vectorstore.pgvector.autoconfigure.PgVectorStoreProperties;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * Registers the multi-tenant Knowledge Base PgVector loader independently of the {@code bytechef.ai.knowledge-base}
+ * feature flag. Mirrors {@link MultiTenantDataSourceConfiguration#multiTenantLiquibaseChangelogLoader}: the loader runs
+ * during a normal startup and during the dedicated {@code liquibase} migration run, so per-tenant vector tables are
+ * provisioned regardless of whether the Knowledge Base feature is enabled.
+ *
+ * @version ee
+ *
+ * @author Ivica Cardic
+ */
+@Configuration
+@ConditionalOnEEVersion
+@ConditionalOnMultiTenant
+@EnableConfigurationProperties(PgVectorStoreProperties.class)
+class MultiTenantKnowledgeBasePgVectorLoaderConfiguration {
+
+    @Bean
+    @ConditionalOnProperty(prefix = "spring.liquibase", name = "enabled", havingValue = "true", matchIfMissing = true)
+    MultiTenantPgVectorLoader knowledgeBaseMultiTenantPgVectorLoader(
+        @Qualifier("pgVectorJdbcTemplate") JdbcTemplate pgVectorJdbcTemplate, PgVectorStoreProperties properties,
+        TenantService tenantService) {
+
+        return new MultiTenantPgVectorLoader(
+            pgVectorJdbcTemplate, properties, "kb_" + properties.getTableName(), tenantService);
+    }
+}


### PR DESCRIPTION
Extract knowledgeBaseMultiTenantPgVectorLoader into its own EE + multi-tenant
gated configuration so per-tenant vector tables are provisioned during a normal
startup and the dedicated liquibase migration run, regardless of whether
bytechef.ai.knowledge-base.enabled is set.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
