### PR TITLE
5068 client - Invalidate connections list when workflow editor connection changes

### DIFF
--- a/client/src/pages/platform/workflow-editor/components/node-details-tabs/connection-tab/ConnectionTabConnectionSelect.test.tsx
+++ b/client/src/pages/platform/workflow-editor/components/node-details-tabs/connection-tab/ConnectionTabConnectionSelect.test.tsx
@@ -162,6 +162,14 @@ describe('ConnectionTabConnectionSelect', () => {
             }
         );
 
+        mockDeleteWorkflowTestConfigurationConnectionMutation.mockImplementation(
+            (mutationData: unknown, options?: {onSuccess?: () => void}) => {
+                if (options?.onSuccess) {
+                    options.onSuccess();
+                }
+            }
+        );
+
         mockInvalidateQueries = vi.fn().mockResolvedValue(undefined);
         mockRemoveQueries = vi.fn();
         mockSetCurrentNode = vi.fn();
@@ -512,6 +520,57 @@ describe('ConnectionTabConnectionSelect', () => {
                 },
                 expect.objectContaining({onSuccess: expect.any(Function)})
             );
+        });
+    });
+
+    it('should invalidate the connections query after a connection is selected', async () => {
+        render(
+            <ConnectionTabConnectionSelect
+                componentConnection={mockComponentConnection}
+                componentConnectionsCount={1}
+                componentDefinition={mockComponentDefinition}
+                workflowId="workflow-1"
+                workflowNodeName="node-1"
+            />
+        );
+
+        const selectTrigger = screen.getByRole('combobox');
+
+        fireEvent.click(selectTrigger);
+
+        const connection1Option = screen.getByText('Test Connection 1');
+
+        fireEvent.click(connection1Option);
+
+        await waitFor(() => {
+            expect(mockInvalidateQueries).toHaveBeenCalledWith({queryKey: ['connections']});
+        });
+    });
+
+    it('should invalidate the connections query after a connection is cleared', async () => {
+        const workflowTestConfigurationConnection = {
+            connectionId: 1,
+            workflowConnectionKey: 'connection_1',
+            workflowNodeName: 'node-1',
+        };
+
+        render(
+            <ConnectionTabConnectionSelect
+                componentConnection={mockComponentConnection}
+                componentConnectionsCount={1}
+                componentDefinition={mockComponentDefinition}
+                workflowId="workflow-1"
+                workflowNodeName="node-1"
+                workflowTestConfigurationConnection={workflowTestConfigurationConnection}
+            />
+        );
+
+        const clearButton = screen.getByTitle('Clear connection');
+
+        fireEvent.click(clearButton);
+
+        await waitFor(() => {
+            expect(mockInvalidateQueries).toHaveBeenCalledWith({queryKey: ['connections']});
         });
     });
 

--- a/client/src/pages/platform/workflow-editor/components/node-details-tabs/connection-tab/ConnectionTabConnectionSelect.tsx
+++ b/client/src/pages/platform/workflow-editor/components/node-details-tabs/connection-tab/ConnectionTabConnectionSelect.tsx
@@ -172,11 +172,16 @@ const ConnectionTabConnectionSelect = ({
                         queryClient.removeQueries({
                             queryKey: [...WorkflowNodeOptionKeys.clusterElementNodeOptions, workflowId],
                         });
+
+                        queryClient.invalidateQueries({
+                            queryKey: ConnectionKeys!.connections,
+                        });
                     },
                 }
             );
         },
         [
+            ConnectionKeys,
             currentEnvironmentId,
             queryClient,
             rootClusterElementNodeData?.workflowNodeName,
@@ -196,13 +201,22 @@ const ConnectionTabConnectionSelect = ({
             skipServerSyncRef.current = true;
             clearedConnectionIdRef.current = connectionId;
 
-            deleteWorkflowTestConfigurationConnectionMutation.mutate({
-                deleteWorkflowTestConfigurationConnectionRequest: {connectionId: previousConnectionId},
-                environmentId: currentEnvironmentId,
-                workflowConnectionKey,
-                workflowId,
-                workflowNodeName: rootClusterElementNodeData?.workflowNodeName || workflowNodeName,
-            });
+            deleteWorkflowTestConfigurationConnectionMutation.mutate(
+                {
+                    deleteWorkflowTestConfigurationConnectionRequest: {connectionId: previousConnectionId},
+                    environmentId: currentEnvironmentId,
+                    workflowConnectionKey,
+                    workflowId,
+                    workflowNodeName: rootClusterElementNodeData?.workflowNodeName || workflowNodeName,
+                },
+                {
+                    onSuccess: () => {
+                        queryClient.invalidateQueries({
+                            queryKey: ConnectionKeys!.connections,
+                        });
+                    },
+                }
+            );
 
             setConnectionId(undefined);
 
@@ -225,6 +239,7 @@ const ConnectionTabConnectionSelect = ({
             });
         },
         [
+            ConnectionKeys,
             connectionId,
             currentComponent,
             currentEnvironmentId,

--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-code-editor/property-code-editor-dialog/hooks/tests/usePropertyCodeEditorDialogRightPanelConnectionsSelect.test.ts
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-code-editor/property-code-editor-dialog/hooks/tests/usePropertyCodeEditorDialogRightPanelConnectionsSelect.test.ts
@@ -18,6 +18,7 @@ const hoisted = vi.hoisted(() => {
             {id: 1, name: 'Connection 1'},
             {id: 2, name: 'Connection 2'},
         ],
+        mockInvalidateQueries: vi.fn(),
         mockMutateClusterElement: vi.fn(),
         mockMutateWorkflowNode: vi.fn(),
         rootClusterElementNodeData: undefined as {workflowNodeName: string} | undefined,
@@ -75,7 +76,7 @@ vi.mock('@/shared/stores/useEnvironmentStore', () => ({
 
 vi.mock('@tanstack/react-query', () => ({
     useQueryClient: () => ({
-        invalidateQueries: vi.fn(),
+        invalidateQueries: hoisted.mockInvalidateQueries,
     }),
 }));
 
@@ -229,6 +230,41 @@ describe('usePropertyCodeEditorDialogRightPanelConnectionsSelect', () => {
             );
 
             expect(hoisted.mockMutateWorkflowNode).not.toHaveBeenCalled();
+        });
+
+        it('should invalidate the connections query in the workflow node mutation onSuccess', () => {
+            const {result} = renderHook(() => usePropertyCodeEditorDialogRightPanelConnectionsSelect(defaultProps));
+
+            act(() => {
+                result.current.handleValueChange(456, 'connection-key');
+            });
+
+            const [, options] = hoisted.mockMutateWorkflowNode.mock.calls[0];
+
+            act(() => {
+                options.onSuccess();
+            });
+
+            expect(hoisted.mockInvalidateQueries).toHaveBeenCalledWith({queryKey: ['connections']});
+        });
+
+        it('should invalidate the connections query in the cluster element mutation onSuccess', () => {
+            hoisted.currentNode = {clusterElementType: 'model', name: 'script_1'};
+            hoisted.rootClusterElementNodeData = {workflowNodeName: 'ai_agent_1'};
+
+            const {result} = renderHook(() => usePropertyCodeEditorDialogRightPanelConnectionsSelect(defaultProps));
+
+            act(() => {
+                result.current.handleValueChange(789, 'connection-key');
+            });
+
+            const [, options] = hoisted.mockMutateClusterElement.mock.calls[0];
+
+            act(() => {
+                options.onSuccess();
+            });
+
+            expect(hoisted.mockInvalidateQueries).toHaveBeenCalledWith({queryKey: ['connections']});
         });
     });
 

--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-code-editor/property-code-editor-dialog/hooks/usePropertyCodeEditorDialogRightPanelConnectionsSelect.ts
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-code-editor/property-code-editor-dialog/hooks/usePropertyCodeEditorDialogRightPanelConnectionsSelect.ts
@@ -88,6 +88,10 @@ const usePropertyCodeEditorDialogRightPanelConnectionsSelect = ({
                         queryClient.invalidateQueries({
                             queryKey: WorkflowTestConfigurationKeys.workflowTestConfigurations,
                         });
+
+                        queryClient.invalidateQueries({
+                            queryKey: ConnectionKeys.connections,
+                        });
                     },
                 }
             );
@@ -104,6 +108,10 @@ const usePropertyCodeEditorDialogRightPanelConnectionsSelect = ({
                     onSuccess: () => {
                         queryClient.invalidateQueries({
                             queryKey: WorkflowTestConfigurationKeys.workflowTestConfigurations,
+                        });
+
+                        queryClient.invalidateQueries({
+                            queryKey: ConnectionKeys.connections,
                         });
                     },
                 }


### PR DESCRIPTION
A connection's Active/Not Active badge on the Connections tab reflects its
server-side usage state. Attaching or clearing a connection in the workflow
editor changed that state but only invalidated the workflow test
configuration query, so the Connections tab served a stale cached list until
a full page reload.

Invalidate ConnectionKeys.connections in the connection-tab select/clear
handlers and in the code-editor dialog connection select so the Connections
tab reflects the change without a reload.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
