### PR TITLE
520

### DIFF
--- a/client/src/ee/pages/embedded/connected-users/components/connected-user-sheet/ConnectedUserSheetPanel.tsx
+++ b/client/src/ee/pages/embedded/connected-users/components/connected-user-sheet/ConnectedUserSheetPanel.tsx
@@ -29,7 +29,7 @@ const ConnectedUserSheetPanel = ({connectedUser}: ConnectedUserSheetPanelProps) 
                     </TabsTrigger>
 
                     <TabsTrigger className={tabsTriggerClassName} value="workflows">
-                        Workflows
+                        Automation Workflows
                     </TabsTrigger>
                 </TabsList>
 

--- a/client/src/ee/pages/embedded/connected-users/components/connected-user-sheet/ConnectedUserSheetPanel.tsx
+++ b/client/src/ee/pages/embedded/connected-users/components/connected-user-sheet/ConnectedUserSheetPanel.tsx
@@ -1,5 +1,6 @@
 import {Tabs, TabsContent, TabsList, TabsTrigger} from '@/components/ui/tabs';
 import ConnectedUserSheetPanelIntegrationList from '@/ee/pages/embedded/connected-users/components/connected-user-sheet/ConnectedUserSheetPanelIntegrationList';
+import ConnectedUserSheetPanelMcpServerList from '@/ee/pages/embedded/connected-users/components/connected-user-sheet/ConnectedUserSheetPanelMcpServerList';
 import ConnectedUserSheetPanelProfile from '@/ee/pages/embedded/connected-users/components/connected-user-sheet/ConnectedUserSheetPanelProfile';
 import ConnectedUserSheetPanelWorkflowList from '@/ee/pages/embedded/connected-users/components/connected-user-sheet/ConnectedUserSheetPanelWorkflowList';
 import {ConnectedUser} from '@/ee/shared/middleware/embedded/connected-user';
@@ -28,6 +29,10 @@ const ConnectedUserSheetPanel = ({connectedUser}: ConnectedUserSheetPanelProps) 
                         Integrations
                     </TabsTrigger>
 
+                    <TabsTrigger className={tabsTriggerClassName} value="mcp-servers">
+                        MCP Servers
+                    </TabsTrigger>
+
                     <TabsTrigger className={tabsTriggerClassName} value="workflows">
                         Automation Workflows
                     </TabsTrigger>
@@ -39,6 +44,12 @@ const ConnectedUserSheetPanel = ({connectedUser}: ConnectedUserSheetPanelProps) 
                             connectedUserId={connectedUser.id!}
                             connectedUserIntegrationInstances={connectedUser.integrationInstances}
                         />
+                    )}
+                </TabsContent>
+
+                <TabsContent value="mcp-servers">
+                    {connectedUser.id != null && (
+                        <ConnectedUserSheetPanelMcpServerList connectedUserId={connectedUser.id} />
                     )}
                 </TabsContent>
 

--- a/client/src/ee/pages/embedded/connected-users/components/connected-user-sheet/ConnectedUserSheetPanelIntegrationListItem.tsx
+++ b/client/src/ee/pages/embedded/connected-users/components/connected-user-sheet/ConnectedUserSheetPanelIntegrationListItem.tsx
@@ -1,5 +1,6 @@
 import Badge from '@/components/Badge/Badge';
 import Button from '@/components/Button/Button';
+import DeleteAlertDialog from '@/components/DeleteAlertDialog';
 import LoadingIcon from '@/components/LoadingIcon';
 import {Collapsible, CollapsibleContent, CollapsibleTrigger} from '@/components/ui/collapsible';
 import {DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger} from '@/components/ui/dropdown-menu';
@@ -8,7 +9,10 @@ import {Tooltip, TooltipContent, TooltipTrigger} from '@/components/ui/tooltip';
 import CredentialsStatus from '@/ee/pages/embedded/connected-users/components/CredentialsStatus';
 import ConnectedUserSheetPanelIntegrationWorkflowList from '@/ee/pages/embedded/connected-users/components/connected-user-sheet/ConnectedUserSheetPanelIntegrationWorkflowList';
 import {ConnectedUserIntegrationInstance} from '@/ee/shared/middleware/embedded/connected-user';
-import {useEnableIntegrationInstanceMutation} from '@/ee/shared/mutations/embedded/integrationInstances.mutations';
+import {
+    useDeleteIntegrationInstanceMutation,
+    useEnableIntegrationInstanceMutation,
+} from '@/ee/shared/mutations/embedded/integrationInstances.mutations';
 import {ConnectedUserKeys} from '@/ee/shared/queries/embedded/connectedUsers.queries';
 import {useGetIntegrationInstanceConfigurationQuery} from '@/ee/shared/queries/embedded/integrationInstanceConfigurations.queries';
 import {
@@ -19,6 +23,7 @@ import {useGetIntegrationVersionWorkflowsQuery} from '@/ee/shared/queries/embedd
 import {ComponentDefinitionBasic} from '@/shared/middleware/platform/configuration';
 import {useQueryClient} from '@tanstack/react-query';
 import {EllipsisVerticalIcon} from 'lucide-react';
+import {useState} from 'react';
 import InlineSVG from 'react-inlinesvg';
 import {twMerge} from 'tailwind-merge';
 
@@ -44,7 +49,19 @@ const ConnectedUserSheetPanelIntegrationListItem = ({
 
     const {data: integrationInstance} = useGetIntegrationInstanceQuery(connectedUserIntegrationInstance.id!);
 
+    const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+
     const queryClient = useQueryClient();
+
+    const deleteIntegrationInstanceMutation = useDeleteIntegrationInstanceMutation({
+        onSuccess: () => {
+            queryClient.invalidateQueries({
+                queryKey: ConnectedUserKeys.connectedUser(connectedUserId),
+            });
+
+            setShowDeleteDialog(false);
+        },
+    });
 
     const enableIntegrationInstanceMutation = useEnableIntegrationInstanceMutation({
         onSuccess: () => {
@@ -168,7 +185,12 @@ const ConnectedUserSheetPanelIntegrationListItem = ({
                             </DropdownMenuTrigger>
 
                             <DropdownMenuContent align="end">
-                                <DropdownMenuItem className="text-destructive">Delete</DropdownMenuItem>
+                                <DropdownMenuItem
+                                    className="text-destructive"
+                                    onClick={() => setShowDeleteDialog(true)}
+                                >
+                                    Delete
+                                </DropdownMenuItem>
                             </DropdownMenuContent>
                         </DropdownMenu>
                     </div>
@@ -185,6 +207,12 @@ const ConnectedUserSheetPanelIntegrationListItem = ({
                     />
                 )}
             </CollapsibleContent>
+
+            <DeleteAlertDialog
+                onCancel={() => setShowDeleteDialog(false)}
+                onDelete={() => deleteIntegrationInstanceMutation.mutate({id: connectedUserIntegrationInstance.id!})}
+                open={showDeleteDialog}
+            />
         </Collapsible>
     );
 };

--- a/client/src/ee/pages/embedded/connected-users/components/connected-user-sheet/ConnectedUserSheetPanelIntegrationListItem.tsx
+++ b/client/src/ee/pages/embedded/connected-users/components/connected-user-sheet/ConnectedUserSheetPanelIntegrationListItem.tsx
@@ -72,11 +72,17 @@ const ConnectedUserSheetPanelIntegrationListItem = ({
 
                                 <div
                                     className={twMerge(
-                                        'flex items-center space-x-1 text-base font-semibold',
+                                        'flex items-baseline gap-x-2 text-base font-semibold',
                                         !connectedUserIntegrationInstance.enabled && 'text-muted-foreground'
                                     )}
                                 >
                                     <span>{componentDefinition.title}</span>
+
+                                    {integrationInstance?.integrationInstanceConfiguration?.name && (
+                                        <span className="text-sm font-normal text-muted-foreground">
+                                            {integrationInstance.integrationInstanceConfiguration.name}
+                                        </span>
+                                    )}
                                 </div>
                             </div>
 

--- a/client/src/ee/pages/embedded/connected-users/components/connected-user-sheet/ConnectedUserSheetPanelIntegrationWorkflowList.tsx
+++ b/client/src/ee/pages/embedded/connected-users/components/connected-user-sheet/ConnectedUserSheetPanelIntegrationWorkflowList.tsx
@@ -18,7 +18,7 @@ const ConnectedUserSheetPanelIntegrationWorkflowList = ({
     workflows: Workflow[];
 }) => {
     return (
-        <div className="flex w-full flex-col py-3 pl-4">
+        <div className="flex w-full flex-col gap-y-3 py-3 pl-4">
             <h3 className="flex justify-start px-2 text-sm font-semibold uppercase text-muted-foreground">Workflows</h3>
 
             {workflows.length > 0 ? (

--- a/client/src/ee/pages/embedded/connected-users/components/connected-user-sheet/ConnectedUserSheetPanelIntegrationWorkflowListItem.tsx
+++ b/client/src/ee/pages/embedded/connected-users/components/connected-user-sheet/ConnectedUserSheetPanelIntegrationWorkflowListItem.tsx
@@ -53,12 +53,12 @@ const ConnectedUserSheetPanelIntegrationWorkflowListItem = ({
         <li className="flex items-center justify-between rounded-md p-2 py-1 hover:bg-gray-50" key={workflow.id}>
             <div className="text-sm font-semibold">{workflow.label}</div>
 
-            <div>
+            <div className="flex items-center space-x-2">
                 {filteredComponentDefinitions?.map((componentDefinition) => {
                     return (
                         componentDefinition && (
                             <InlineSVG
-                                className="mr-2 size-6 flex-none"
+                                className="size-6 flex-none"
                                 key={componentDefinition.name!}
                                 src={componentDefinition.icon!}
                             />

--- a/client/src/ee/pages/embedded/connected-users/components/connected-user-sheet/ConnectedUserSheetPanelIntegrationWorkflowListItem.tsx
+++ b/client/src/ee/pages/embedded/connected-users/components/connected-user-sheet/ConnectedUserSheetPanelIntegrationWorkflowListItem.tsx
@@ -53,15 +53,16 @@ const ConnectedUserSheetPanelIntegrationWorkflowListItem = ({
         <li className="flex items-center justify-between rounded-md p-2 py-1 hover:bg-gray-50" key={workflow.id}>
             <div className="text-sm font-semibold">{workflow.label}</div>
 
-            <div className="flex items-center space-x-2">
+            <div className="flex items-center space-x-1">
                 {filteredComponentDefinitions?.map((componentDefinition) => {
                     return (
                         componentDefinition && (
-                            <InlineSVG
-                                className="size-6 flex-none"
+                            <div
+                                className="flex items-center justify-center rounded-full border p-1"
                                 key={componentDefinition.name!}
-                                src={componentDefinition.icon!}
-                            />
+                            >
+                                <InlineSVG className="size-5 flex-none" src={componentDefinition.icon!} />
+                            </div>
                         )
                     );
                 })}

--- a/client/src/ee/pages/embedded/connected-users/components/connected-user-sheet/ConnectedUserSheetPanelIntegrationWorkflowListItem.tsx
+++ b/client/src/ee/pages/embedded/connected-users/components/connected-user-sheet/ConnectedUserSheetPanelIntegrationWorkflowListItem.tsx
@@ -1,6 +1,4 @@
-import Button from '@/components/Button/Button';
 import LoadingIcon from '@/components/LoadingIcon';
-import {DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger} from '@/components/ui/dropdown-menu';
 import {Switch} from '@/components/ui/switch';
 import {
     IntegrationInstance,
@@ -13,7 +11,6 @@ import {ConnectedUserKeys} from '@/ee/shared/queries/embedded/connectedUsers.que
 import {IntegrationInstanceKeys} from '@/ee/shared/queries/embedded/integrationInstances.queries';
 import {ComponentDefinitionBasic} from '@/shared/middleware/platform/configuration';
 import {useQueryClient} from '@tanstack/react-query';
-import {EllipsisVerticalIcon} from 'lucide-react';
 import InlineSVG from 'react-inlinesvg';
 
 const ConnectedUserSheetPanelIntegrationWorkflowListItem = ({
@@ -68,38 +65,22 @@ const ConnectedUserSheetPanelIntegrationWorkflowListItem = ({
                 })}
             </div>
 
-            <div className="flex items-center space-x-1">
-                <div className="relative flex items-center">
-                    {enableIntegrationInstanceWorkflowMutation.isPending && (
-                        <LoadingIcon className="absolute left-[-15px] top-[3px]" />
-                    )}
+            <div className="relative flex items-center">
+                {enableIntegrationInstanceWorkflowMutation.isPending && (
+                    <LoadingIcon className="absolute left-[-15px] top-[3px]" />
+                )}
 
-                    <Switch
-                        checked={integrationInstanceWorkflow?.enabled}
-                        disabled={!integrationInstanceConfigurationWorkflow?.enabled}
-                        onCheckedChange={(value) => {
-                            enableIntegrationInstanceWorkflowMutation.mutate({
-                                enable: value,
-                                id: integrationInstance.id!,
-                                workflowId: workflow.id!,
-                            });
-                        }}
-                    />
-                </div>
-
-                <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                        <Button
-                            icon={<EllipsisVerticalIcon className="size-4 hover:cursor-pointer" />}
-                            size="icon"
-                            variant="ghost"
-                        />
-                    </DropdownMenuTrigger>
-
-                    <DropdownMenuContent align="end">
-                        <DropdownMenuItem className="text-destructive">Delete</DropdownMenuItem>
-                    </DropdownMenuContent>
-                </DropdownMenu>
+                <Switch
+                    checked={integrationInstanceWorkflow?.enabled}
+                    disabled={!integrationInstanceConfigurationWorkflow?.enabled}
+                    onCheckedChange={(value) => {
+                        enableIntegrationInstanceWorkflowMutation.mutate({
+                            enable: value,
+                            id: integrationInstance.id!,
+                            workflowId: workflow.id!,
+                        });
+                    }}
+                />
             </div>
         </li>
     );

--- a/client/src/ee/pages/embedded/connected-users/components/connected-user-sheet/ConnectedUserSheetPanelIntegrationWorkflowListItem.tsx
+++ b/client/src/ee/pages/embedded/connected-users/components/connected-user-sheet/ConnectedUserSheetPanelIntegrationWorkflowListItem.tsx
@@ -65,7 +65,7 @@ const ConnectedUserSheetPanelIntegrationWorkflowListItem = ({
                 })}
             </div>
 
-            <div className="relative flex items-center">
+            <div className="relative mr-11 flex items-center">
                 {enableIntegrationInstanceWorkflowMutation.isPending && (
                     <LoadingIcon className="absolute left-[-15px] top-[3px]" />
                 )}

--- a/client/src/ee/pages/embedded/connected-users/components/connected-user-sheet/ConnectedUserSheetPanelMcpServerList.tsx
+++ b/client/src/ee/pages/embedded/connected-users/components/connected-user-sheet/ConnectedUserSheetPanelMcpServerList.tsx
@@ -15,7 +15,11 @@ const ConnectedUserSheetPanelMcpServerList = ({connectedUserId}: {connectedUserI
     return mcpServers.length > 0 ? (
         <div className="divide-y">
             {mcpServers.map((mcpServer) => (
-                <ConnectedUserMcpServerListItem key={mcpServer.id} mcpServer={mcpServer} />
+                <ConnectedUserMcpServerListItem
+                    connectedUserId={connectedUserId}
+                    key={mcpServer.id}
+                    mcpServer={mcpServer}
+                />
             ))}
         </div>
     ) : (

--- a/client/src/ee/pages/embedded/connected-users/components/connected-user-sheet/ConnectedUserSheetPanelMcpServerList.tsx
+++ b/client/src/ee/pages/embedded/connected-users/components/connected-user-sheet/ConnectedUserSheetPanelMcpServerList.tsx
@@ -1,0 +1,26 @@
+import ConnectedUserMcpServerListItem from '@/ee/pages/embedded/connected-users/components/connected-user-sheet/connected-user-mcp-server-list/ConnectedUserMcpServerListItem';
+import {useConnectedUserMcpServersQuery} from '@/shared/middleware/graphql';
+
+const ConnectedUserSheetPanelMcpServerList = ({connectedUserId}: {connectedUserId: number}) => {
+    const {data, isLoading} = useConnectedUserMcpServersQuery({
+        connectedUserId: connectedUserId.toString(),
+    });
+
+    if (isLoading) {
+        return <div className="py-4 text-sm text-muted-foreground">Loading...</div>;
+    }
+
+    const mcpServers = data?.connectedUserMcpServers ?? [];
+
+    return mcpServers.length > 0 ? (
+        <div className="divide-y">
+            {mcpServers.map((mcpServer) => (
+                <ConnectedUserMcpServerListItem key={mcpServer.id} mcpServer={mcpServer} />
+            ))}
+        </div>
+    ) : (
+        <div className="py-4 text-sm">No MCP servers expose this user's integrations.</div>
+    );
+};
+
+export default ConnectedUserSheetPanelMcpServerList;

--- a/client/src/ee/pages/embedded/connected-users/components/connected-user-sheet/connected-user-mcp-server-list/ConnectedUserMcpServerListItem.tsx
+++ b/client/src/ee/pages/embedded/connected-users/components/connected-user-sheet/connected-user-mcp-server-list/ConnectedUserMcpServerListItem.tsx
@@ -1,10 +1,27 @@
+import LoadingIcon from '@/components/LoadingIcon';
 import {Collapsible, CollapsibleContent, CollapsibleTrigger} from '@/components/ui/collapsible';
+import {Switch} from '@/components/ui/switch';
 import {Tooltip, TooltipContent, TooltipTrigger} from '@/components/ui/tooltip';
 import ConnectedUserMcpServerListItemToolRow from '@/ee/pages/embedded/connected-users/components/connected-user-sheet/connected-user-mcp-server-list/ConnectedUserMcpServerListItemToolRow';
-import {ConnectedUserMcpServer} from '@/shared/middleware/graphql';
+import {ConnectedUserMcpServer, useEnableConnectedUserMcpServerMutation} from '@/shared/middleware/graphql';
+import {useQueryClient} from '@tanstack/react-query';
 import {twMerge} from 'tailwind-merge';
 
-const ConnectedUserMcpServerListItem = ({mcpServer}: {mcpServer: ConnectedUserMcpServer}) => {
+const ConnectedUserMcpServerListItem = ({
+    connectedUserId,
+    mcpServer,
+}: {
+    connectedUserId: number;
+    mcpServer: ConnectedUserMcpServer;
+}) => {
+    const queryClient = useQueryClient();
+
+    const enableConnectedUserMcpServerMutation = useEnableConnectedUserMcpServerMutation({
+        onSuccess: () => {
+            queryClient.invalidateQueries({queryKey: ['connectedUserMcpServers']});
+        },
+    });
+
     const toolCount = mcpServer.tools.length;
 
     const lastModifiedDate = mcpServer.lastModifiedDate ? new Date(Date.parse(mcpServer.lastModifiedDate)) : undefined;
@@ -29,15 +46,34 @@ const ConnectedUserMcpServerListItem = ({mcpServer}: {mcpServer: ConnectedUserMc
                     </div>
                 </CollapsibleTrigger>
 
-                {lastModifiedDate && (
-                    <Tooltip>
-                        <TooltipTrigger className="text-xs text-muted-foreground">
-                            {`Updated ${lastModifiedDate.toLocaleDateString()} ${lastModifiedDate.toLocaleTimeString()}`}
-                        </TooltipTrigger>
+                <div className="flex min-w-52 flex-col items-end gap-y-2">
+                    <div className="relative flex items-center">
+                        {enableConnectedUserMcpServerMutation.isPending && (
+                            <LoadingIcon className="absolute left-[-15px] top-[3px]" />
+                        )}
 
-                        <TooltipContent>Last Modified Date</TooltipContent>
-                    </Tooltip>
-                )}
+                        <Switch
+                            checked={mcpServer.enabled}
+                            onCheckedChange={(value) => {
+                                enableConnectedUserMcpServerMutation.mutate({
+                                    connectedUserId: connectedUserId.toString(),
+                                    enable: value,
+                                    mcpServerId: mcpServer.id,
+                                });
+                            }}
+                        />
+                    </div>
+
+                    {lastModifiedDate && (
+                        <Tooltip>
+                            <TooltipTrigger className="text-xs text-muted-foreground">
+                                {`Updated ${lastModifiedDate.toLocaleDateString()} ${lastModifiedDate.toLocaleTimeString()}`}
+                            </TooltipTrigger>
+
+                            <TooltipContent>Last Modified Date</TooltipContent>
+                        </Tooltip>
+                    )}
+                </div>
             </div>
 
             <CollapsibleContent>

--- a/client/src/ee/pages/embedded/connected-users/components/connected-user-sheet/connected-user-mcp-server-list/ConnectedUserMcpServerListItem.tsx
+++ b/client/src/ee/pages/embedded/connected-users/components/connected-user-sheet/connected-user-mcp-server-list/ConnectedUserMcpServerListItem.tsx
@@ -1,10 +1,19 @@
+import Button from '@/components/Button/Button';
+import DeleteAlertDialog from '@/components/DeleteAlertDialog';
 import LoadingIcon from '@/components/LoadingIcon';
 import {Collapsible, CollapsibleContent, CollapsibleTrigger} from '@/components/ui/collapsible';
+import {DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger} from '@/components/ui/dropdown-menu';
 import {Switch} from '@/components/ui/switch';
 import {Tooltip, TooltipContent, TooltipTrigger} from '@/components/ui/tooltip';
 import ConnectedUserMcpServerListItemToolRow from '@/ee/pages/embedded/connected-users/components/connected-user-sheet/connected-user-mcp-server-list/ConnectedUserMcpServerListItemToolRow';
-import {ConnectedUserMcpServer, useEnableConnectedUserMcpServerMutation} from '@/shared/middleware/graphql';
+import {
+    ConnectedUserMcpServer,
+    useDeleteConnectedUserMcpServerMutation,
+    useEnableConnectedUserMcpServerMutation,
+} from '@/shared/middleware/graphql';
 import {useQueryClient} from '@tanstack/react-query';
+import {EllipsisVerticalIcon} from 'lucide-react';
+import {useState} from 'react';
 import {twMerge} from 'tailwind-merge';
 
 const ConnectedUserMcpServerListItem = ({
@@ -14,7 +23,17 @@ const ConnectedUserMcpServerListItem = ({
     connectedUserId: number;
     mcpServer: ConnectedUserMcpServer;
 }) => {
+    const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+
     const queryClient = useQueryClient();
+
+    const deleteConnectedUserMcpServerMutation = useDeleteConnectedUserMcpServerMutation({
+        onSuccess: () => {
+            queryClient.invalidateQueries({queryKey: ['connectedUserMcpServers']});
+
+            setShowDeleteDialog(false);
+        },
+    });
 
     const enableConnectedUserMcpServerMutation = useEnableConnectedUserMcpServerMutation({
         onSuccess: () => {
@@ -27,73 +46,107 @@ const ConnectedUserMcpServerListItem = ({
     const lastModifiedDate = mcpServer.lastModifiedDate ? new Date(Date.parse(mcpServer.lastModifiedDate)) : undefined;
 
     return (
-        <Collapsible key={mcpServer.id}>
-            <div className="flex w-full items-center justify-between px-2 hover:bg-muted/50">
-                <CollapsibleTrigger className="flex-1 py-3">
-                    <div className="flex flex-col items-start justify-center gap-y-2">
-                        <div
-                            className={twMerge(
-                                'text-base font-semibold',
-                                !mcpServer.enabled && 'text-muted-foreground'
+        <>
+            <Collapsible key={mcpServer.id}>
+                <div className="flex w-full items-center justify-between px-2 hover:bg-muted/50">
+                    <CollapsibleTrigger className="flex-1 py-3">
+                        <div className="flex flex-col items-start justify-center gap-y-2">
+                            <div
+                                className={twMerge(
+                                    'text-base font-semibold',
+                                    !mcpServer.enabled && 'text-muted-foreground'
+                                )}
+                            >
+                                {mcpServer.name}
+                            </div>
+
+                            <div className="text-xs font-semibold text-muted-foreground">
+                                {toolCount === 1 ? `${toolCount} tool` : `${toolCount} tools`}
+                            </div>
+                        </div>
+                    </CollapsibleTrigger>
+
+                    <div className="flex items-center gap-x-2">
+                        <div className="flex min-w-52 flex-col items-end gap-y-2">
+                            <div className="relative flex items-center">
+                                {enableConnectedUserMcpServerMutation.isPending && (
+                                    <LoadingIcon className="absolute left-[-15px] top-[3px]" />
+                                )}
+
+                                <Switch
+                                    checked={mcpServer.enabled}
+                                    onCheckedChange={(value) => {
+                                        enableConnectedUserMcpServerMutation.mutate({
+                                            connectedUserId: connectedUserId.toString(),
+                                            enable: value,
+                                            mcpServerId: mcpServer.id,
+                                        });
+                                    }}
+                                />
+                            </div>
+
+                            {lastModifiedDate && (
+                                <Tooltip>
+                                    <TooltipTrigger className="text-xs text-muted-foreground">
+                                        {`Updated ${lastModifiedDate.toLocaleDateString()} ${lastModifiedDate.toLocaleTimeString()}`}
+                                    </TooltipTrigger>
+
+                                    <TooltipContent>Last Modified Date</TooltipContent>
+                                </Tooltip>
                             )}
-                        >
-                            {mcpServer.name}
                         </div>
 
-                        <div className="text-xs font-semibold text-muted-foreground">
-                            {toolCount === 1 ? `${toolCount} tool` : `${toolCount} tools`}
-                        </div>
+                        <DropdownMenu>
+                            <DropdownMenuTrigger asChild>
+                                <Button
+                                    icon={<EllipsisVerticalIcon className="size-4 hover:cursor-pointer" />}
+                                    size="icon"
+                                    variant="ghost"
+                                />
+                            </DropdownMenuTrigger>
+
+                            <DropdownMenuContent align="end">
+                                <DropdownMenuItem
+                                    className="text-destructive"
+                                    onClick={() => setShowDeleteDialog(true)}
+                                >
+                                    Delete
+                                </DropdownMenuItem>
+                            </DropdownMenuContent>
+                        </DropdownMenu>
                     </div>
-                </CollapsibleTrigger>
-
-                <div className="flex min-w-52 flex-col items-end gap-y-2">
-                    <div className="relative flex items-center">
-                        {enableConnectedUserMcpServerMutation.isPending && (
-                            <LoadingIcon className="absolute left-[-15px] top-[3px]" />
-                        )}
-
-                        <Switch
-                            checked={mcpServer.enabled}
-                            onCheckedChange={(value) => {
-                                enableConnectedUserMcpServerMutation.mutate({
-                                    connectedUserId: connectedUserId.toString(),
-                                    enable: value,
-                                    mcpServerId: mcpServer.id,
-                                });
-                            }}
-                        />
-                    </div>
-
-                    {lastModifiedDate && (
-                        <Tooltip>
-                            <TooltipTrigger className="text-xs text-muted-foreground">
-                                {`Updated ${lastModifiedDate.toLocaleDateString()} ${lastModifiedDate.toLocaleTimeString()}`}
-                            </TooltipTrigger>
-
-                            <TooltipContent>Last Modified Date</TooltipContent>
-                        </Tooltip>
-                    )}
                 </div>
-            </div>
 
-            <CollapsibleContent>
-                {toolCount > 0 ? (
-                    <div className="flex w-full flex-col gap-y-3 py-3 pl-4">
-                        <h3 className="flex justify-start px-2 text-sm font-semibold uppercase text-muted-foreground">
-                            Tools
-                        </h3>
+                <CollapsibleContent>
+                    {toolCount > 0 ? (
+                        <div className="flex w-full flex-col gap-y-3 py-3 pl-4">
+                            <h3 className="flex justify-start px-2 text-sm font-semibold uppercase text-muted-foreground">
+                                Tools
+                            </h3>
 
-                        <ul>
-                            {mcpServer.tools.map((tool) => (
-                                <ConnectedUserMcpServerListItemToolRow key={tool.id} tool={tool} />
-                            ))}
-                        </ul>
-                    </div>
-                ) : (
-                    <div className="px-4 py-3 text-sm text-muted-foreground">No tools enabled for this user.</div>
-                )}
-            </CollapsibleContent>
-        </Collapsible>
+                            <ul>
+                                {mcpServer.tools.map((tool) => (
+                                    <ConnectedUserMcpServerListItemToolRow key={tool.id} tool={tool} />
+                                ))}
+                            </ul>
+                        </div>
+                    ) : (
+                        <div className="px-4 py-3 text-sm text-muted-foreground">No tools enabled for this user.</div>
+                    )}
+                </CollapsibleContent>
+            </Collapsible>
+
+            <DeleteAlertDialog
+                onCancel={() => setShowDeleteDialog(false)}
+                onDelete={() =>
+                    deleteConnectedUserMcpServerMutation.mutate({
+                        connectedUserId: connectedUserId.toString(),
+                        mcpServerId: mcpServer.id,
+                    })
+                }
+                open={showDeleteDialog}
+            />
+        </>
     );
 };
 

--- a/client/src/ee/pages/embedded/connected-users/components/connected-user-sheet/connected-user-mcp-server-list/ConnectedUserMcpServerListItem.tsx
+++ b/client/src/ee/pages/embedded/connected-users/components/connected-user-sheet/connected-user-mcp-server-list/ConnectedUserMcpServerListItem.tsx
@@ -1,4 +1,3 @@
-import Badge from '@/components/Badge/Badge';
 import {Collapsible, CollapsibleContent, CollapsibleTrigger} from '@/components/ui/collapsible';
 import {Tooltip, TooltipContent, TooltipTrigger} from '@/components/ui/tooltip';
 import ConnectedUserMcpServerListItemToolRow from '@/ee/pages/embedded/connected-users/components/connected-user-sheet/connected-user-mcp-server-list/ConnectedUserMcpServerListItemToolRow';
@@ -24,40 +23,26 @@ const ConnectedUserMcpServerListItem = ({mcpServer}: {mcpServer: ConnectedUserMc
                             {mcpServer.name}
                         </div>
 
-                        <div className="flex gap-4 text-xs text-muted-foreground">
-                            <span className="font-semibold">
-                                {toolCount === 1 ? `${toolCount} tool` : `${toolCount} tools`}
-                            </span>
-
-                            {lastModifiedDate && (
-                                <Tooltip>
-                                    <TooltipTrigger className="text-xs">
-                                        {`Updated ${lastModifiedDate.toLocaleDateString()} ${lastModifiedDate.toLocaleTimeString()}`}
-                                    </TooltipTrigger>
-
-                                    <TooltipContent>Last Modified Date</TooltipContent>
-                                </Tooltip>
-                            )}
+                        <div className="text-xs font-semibold text-muted-foreground">
+                            {toolCount === 1 ? `${toolCount} tool` : `${toolCount} tools`}
                         </div>
                     </div>
                 </CollapsibleTrigger>
 
-                <Tooltip>
-                    <TooltipTrigger asChild>
-                        <Badge
-                            label={mcpServer.enabled ? 'ENABLED' : 'DISABLED'}
-                            styleType={mcpServer.enabled ? 'secondary-filled' : 'secondary-outline'}
-                            weight="semibold"
-                        />
-                    </TooltipTrigger>
+                {lastModifiedDate && (
+                    <Tooltip>
+                        <TooltipTrigger className="text-xs text-muted-foreground">
+                            {`Updated ${lastModifiedDate.toLocaleDateString()} ${lastModifiedDate.toLocaleTimeString()}`}
+                        </TooltipTrigger>
 
-                    <TooltipContent>Server status (managed at the workspace level)</TooltipContent>
-                </Tooltip>
+                        <TooltipContent>Last Modified Date</TooltipContent>
+                    </Tooltip>
+                )}
             </div>
 
             <CollapsibleContent>
                 {toolCount > 0 ? (
-                    <div className="flex w-full flex-col py-3 pl-4">
+                    <div className="flex w-full flex-col gap-y-3 py-3 pl-4">
                         <h3 className="flex justify-start px-2 text-sm font-semibold uppercase text-muted-foreground">
                             Tools
                         </h3>

--- a/client/src/ee/pages/embedded/connected-users/components/connected-user-sheet/connected-user-mcp-server-list/ConnectedUserMcpServerListItem.tsx
+++ b/client/src/ee/pages/embedded/connected-users/components/connected-user-sheet/connected-user-mcp-server-list/ConnectedUserMcpServerListItem.tsx
@@ -1,0 +1,79 @@
+import Badge from '@/components/Badge/Badge';
+import {Collapsible, CollapsibleContent, CollapsibleTrigger} from '@/components/ui/collapsible';
+import {Tooltip, TooltipContent, TooltipTrigger} from '@/components/ui/tooltip';
+import ConnectedUserMcpServerListItemToolRow from '@/ee/pages/embedded/connected-users/components/connected-user-sheet/connected-user-mcp-server-list/ConnectedUserMcpServerListItemToolRow';
+import {ConnectedUserMcpServer} from '@/shared/middleware/graphql';
+import {twMerge} from 'tailwind-merge';
+
+const ConnectedUserMcpServerListItem = ({mcpServer}: {mcpServer: ConnectedUserMcpServer}) => {
+    const toolCount = mcpServer.tools.length;
+
+    const lastModifiedDate = mcpServer.lastModifiedDate ? new Date(Date.parse(mcpServer.lastModifiedDate)) : undefined;
+
+    return (
+        <Collapsible key={mcpServer.id}>
+            <div className="flex w-full items-center justify-between px-2 hover:bg-muted/50">
+                <CollapsibleTrigger className="flex-1 py-3">
+                    <div className="flex flex-col items-start justify-center gap-y-2">
+                        <div
+                            className={twMerge(
+                                'text-base font-semibold',
+                                !mcpServer.enabled && 'text-muted-foreground'
+                            )}
+                        >
+                            {mcpServer.name}
+                        </div>
+
+                        <div className="flex gap-4 text-xs text-muted-foreground">
+                            <span className="font-semibold">
+                                {toolCount === 1 ? `${toolCount} tool` : `${toolCount} tools`}
+                            </span>
+
+                            {lastModifiedDate && (
+                                <Tooltip>
+                                    <TooltipTrigger className="text-xs">
+                                        {`Updated ${lastModifiedDate.toLocaleDateString()} ${lastModifiedDate.toLocaleTimeString()}`}
+                                    </TooltipTrigger>
+
+                                    <TooltipContent>Last Modified Date</TooltipContent>
+                                </Tooltip>
+                            )}
+                        </div>
+                    </div>
+                </CollapsibleTrigger>
+
+                <Tooltip>
+                    <TooltipTrigger asChild>
+                        <Badge
+                            label={mcpServer.enabled ? 'ENABLED' : 'DISABLED'}
+                            styleType={mcpServer.enabled ? 'secondary-filled' : 'secondary-outline'}
+                            weight="semibold"
+                        />
+                    </TooltipTrigger>
+
+                    <TooltipContent>Server status (managed at the workspace level)</TooltipContent>
+                </Tooltip>
+            </div>
+
+            <CollapsibleContent>
+                {toolCount > 0 ? (
+                    <div className="flex w-full flex-col py-3 pl-4">
+                        <h3 className="flex justify-start px-2 text-sm font-semibold uppercase text-muted-foreground">
+                            Tools
+                        </h3>
+
+                        <ul>
+                            {mcpServer.tools.map((tool) => (
+                                <ConnectedUserMcpServerListItemToolRow key={tool.id} tool={tool} />
+                            ))}
+                        </ul>
+                    </div>
+                ) : (
+                    <div className="px-4 py-3 text-sm text-muted-foreground">No tools enabled for this user.</div>
+                )}
+            </CollapsibleContent>
+        </Collapsible>
+    );
+};
+
+export default ConnectedUserMcpServerListItem;

--- a/client/src/ee/pages/embedded/connected-users/components/connected-user-sheet/connected-user-mcp-server-list/ConnectedUserMcpServerListItemToolRow.tsx
+++ b/client/src/ee/pages/embedded/connected-users/components/connected-user-sheet/connected-user-mcp-server-list/ConnectedUserMcpServerListItemToolRow.tsx
@@ -30,7 +30,7 @@ const ConnectedUserMcpServerListItemToolRow = ({tool}: {tool: ConnectedUserMcpSe
                 <span>{tool.name}</span>
             </div>
 
-            <div className="relative flex items-center">
+            <div className="relative mr-11 flex items-center">
                 {enableConnectedUserMcpToolMutation.isPending && (
                     <LoadingIcon className="absolute left-[-15px] top-[3px]" />
                 )}

--- a/client/src/ee/pages/embedded/connected-users/components/connected-user-sheet/connected-user-mcp-server-list/ConnectedUserMcpServerListItemToolRow.tsx
+++ b/client/src/ee/pages/embedded/connected-users/components/connected-user-sheet/connected-user-mcp-server-list/ConnectedUserMcpServerListItemToolRow.tsx
@@ -1,0 +1,49 @@
+import LoadingIcon from '@/components/LoadingIcon';
+import {Switch} from '@/components/ui/switch';
+import {useGetComponentDefinitionsQuery} from '@/ee/shared/queries/embedded/componentDefinitions.queries';
+import {ConnectedUserMcpServerTool, useEnableConnectedUserMcpToolMutation} from '@/shared/middleware/graphql';
+import {useQueryClient} from '@tanstack/react-query';
+import InlineSVG from 'react-inlinesvg';
+
+const ConnectedUserMcpServerListItemToolRow = ({tool}: {tool: ConnectedUserMcpServerTool}) => {
+    const {data: componentDefinitions} = useGetComponentDefinitionsQuery({connectionDefinitions: true});
+
+    const componentDefinition = componentDefinitions?.find((definition) => definition.name === tool.componentName);
+
+    const queryClient = useQueryClient();
+
+    const enableConnectedUserMcpToolMutation = useEnableConnectedUserMcpToolMutation({
+        onSuccess: () => {
+            queryClient.invalidateQueries({queryKey: ['connectedUserMcpServers']});
+        },
+    });
+
+    return (
+        <li className="flex items-center justify-between rounded-md p-2 py-1 hover:bg-gray-50">
+            <div className="flex items-center gap-x-2 text-sm font-semibold">
+                {componentDefinition?.icon && (
+                    <div className="flex items-center justify-center rounded-full border p-1">
+                        <InlineSVG className="size-5 flex-none" src={componentDefinition.icon} />
+                    </div>
+                )}
+
+                <span>{tool.name}</span>
+            </div>
+
+            <div className="relative flex items-center">
+                {enableConnectedUserMcpToolMutation.isPending && (
+                    <LoadingIcon className="absolute left-[-15px] top-[3px]" />
+                )}
+
+                <Switch
+                    checked={tool.enabled}
+                    onCheckedChange={(value) => {
+                        enableConnectedUserMcpToolMutation.mutate({enable: value, id: tool.id});
+                    }}
+                />
+            </div>
+        </li>
+    );
+};
+
+export default ConnectedUserMcpServerListItemToolRow;

--- a/client/src/ee/pages/embedded/connected-users/components/connected-user-sheet/connected-user-project-workflow-list/ConnectedUserProjectWorkflowListItem.tsx
+++ b/client/src/ee/pages/embedded/connected-users/components/connected-user-sheet/connected-user-project-workflow-list/ConnectedUserProjectWorkflowListItem.tsx
@@ -1,15 +1,28 @@
 import Badge from '@/components/Badge/Badge';
+import LoadingIcon from '@/components/LoadingIcon';
+import {Switch} from '@/components/ui/switch';
 import {Tooltip, TooltipContent, TooltipTrigger} from '@/components/ui/tooltip';
-import {ConnectedUserProjectWorkflow} from '@/shared/middleware/graphql';
+import {ConnectedUserProjectWorkflow, useEnableConnectedUserProjectWorkflowMutation} from '@/shared/middleware/graphql';
+import {useQueryClient} from '@tanstack/react-query';
 
 const ConnectedUserProjectWorkflowListItem = ({
     connectedUserProjectWorkflow,
 }: {
     connectedUserProjectWorkflow: ConnectedUserProjectWorkflow;
 }) => {
+    const queryClient = useQueryClient();
+
+    const enableConnectedUserProjectWorkflowMutation = useEnableConnectedUserProjectWorkflowMutation({
+        onSuccess: () => {
+            queryClient.invalidateQueries({queryKey: ['connectedUserProjects']});
+        },
+    });
+
     const lastExecutionDate = connectedUserProjectWorkflow.lastExecutionDate
         ? new Date(Date.parse(connectedUserProjectWorkflow.lastExecutionDate))
         : undefined;
+
+    const isDraft = connectedUserProjectWorkflow.workflowVersion == null;
 
     return (
         <li className="flex items-center justify-between rounded-md px-2 py-3.5 hover:bg-gray-50">
@@ -23,11 +36,7 @@ const ConnectedUserProjectWorkflowListItem = ({
                 <Tooltip>
                     <TooltipTrigger asChild>
                         <Badge
-                            label={
-                                connectedUserProjectWorkflow.workflowVersion == null
-                                    ? 'V1 DRAFT'
-                                    : `V${connectedUserProjectWorkflow.workflowVersion}`
-                            }
+                            label={isDraft ? 'V1 DRAFT' : `V${connectedUserProjectWorkflow.workflowVersion}`}
                             styleType="secondary-filled"
                             weight="semibold"
                         />
@@ -50,6 +59,31 @@ const ConnectedUserProjectWorkflowListItem = ({
                     ) : (
                         <span className="text-xs">No executions</span>
                     )}
+                </div>
+
+                <div className="relative flex items-center">
+                    {enableConnectedUserProjectWorkflowMutation.isPending && (
+                        <LoadingIcon className="absolute left-[-15px] top-[3px]" />
+                    )}
+
+                    <Tooltip>
+                        <TooltipTrigger asChild>
+                            <Switch
+                                checked={connectedUserProjectWorkflow.enabled}
+                                disabled={isDraft}
+                                onCheckedChange={(value) => {
+                                    enableConnectedUserProjectWorkflowMutation.mutate({
+                                        enable: value,
+                                        id: connectedUserProjectWorkflow.id,
+                                    });
+                                }}
+                            />
+                        </TooltipTrigger>
+
+                        <TooltipContent>
+                            {isDraft ? 'Publish the workflow before enabling it' : 'Enable workflow'}
+                        </TooltipContent>
+                    </Tooltip>
                 </div>
             </div>
         </li>

--- a/client/src/ee/pages/embedded/connected-users/components/connected-user-sheet/connected-user-project-workflow-list/ConnectedUserProjectWorkflowListItem.tsx
+++ b/client/src/ee/pages/embedded/connected-users/components/connected-user-sheet/connected-user-project-workflow-list/ConnectedUserProjectWorkflowListItem.tsx
@@ -1,16 +1,35 @@
 import Badge from '@/components/Badge/Badge';
+import Button from '@/components/Button/Button';
+import DeleteAlertDialog from '@/components/DeleteAlertDialog';
 import LoadingIcon from '@/components/LoadingIcon';
+import {DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger} from '@/components/ui/dropdown-menu';
 import {Switch} from '@/components/ui/switch';
 import {Tooltip, TooltipContent, TooltipTrigger} from '@/components/ui/tooltip';
-import {ConnectedUserProjectWorkflow, useEnableConnectedUserProjectWorkflowMutation} from '@/shared/middleware/graphql';
+import {
+    ConnectedUserProjectWorkflow,
+    useDeleteConnectedUserProjectWorkflowMutation,
+    useEnableConnectedUserProjectWorkflowMutation,
+} from '@/shared/middleware/graphql';
 import {useQueryClient} from '@tanstack/react-query';
+import {EllipsisVerticalIcon} from 'lucide-react';
+import {useState} from 'react';
 
 const ConnectedUserProjectWorkflowListItem = ({
     connectedUserProjectWorkflow,
 }: {
     connectedUserProjectWorkflow: ConnectedUserProjectWorkflow;
 }) => {
+    const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+
     const queryClient = useQueryClient();
+
+    const deleteConnectedUserProjectWorkflowMutation = useDeleteConnectedUserProjectWorkflowMutation({
+        onSuccess: () => {
+            queryClient.invalidateQueries({queryKey: ['connectedUserProjects']});
+
+            setShowDeleteDialog(false);
+        },
+    });
 
     const enableConnectedUserProjectWorkflowMutation = useEnableConnectedUserProjectWorkflowMutation({
         onSuccess: () => {
@@ -25,68 +44,96 @@ const ConnectedUserProjectWorkflowListItem = ({
     const isDraft = connectedUserProjectWorkflow.workflowVersion == null;
 
     return (
-        <li className="flex items-center justify-between rounded-md px-2 py-3.5 hover:bg-gray-50">
-            <div className="flex flex-1 cursor-pointer items-center">
-                <span className="w-80 text-sm font-semibold">{connectedUserProjectWorkflow.workflow.label}</span>
+        <>
+            <li className="flex items-center justify-between rounded-md px-2 py-3.5 hover:bg-gray-50">
+                <div className="flex min-w-0 flex-1 items-center">
+                    <span className="truncate text-sm font-semibold">
+                        {connectedUserProjectWorkflow.workflow.label}
+                    </span>
+                </div>
 
-                <div className="ml-6 flex space-x-1"></div>
-            </div>
-
-            <div className="flex items-center gap-x-4 text-content-neutral-secondary">
-                <Tooltip>
-                    <TooltipTrigger asChild>
-                        <Badge
-                            label={isDraft ? 'V1 DRAFT' : `V${connectedUserProjectWorkflow.workflowVersion}`}
-                            styleType="secondary-filled"
-                            weight="semibold"
-                        />
-                    </TooltipTrigger>
-
-                    <TooltipContent>The workflow version</TooltipContent>
-                </Tooltip>
-
-                <div className="flex w-48 items-center justify-end">
-                    {connectedUserProjectWorkflow?.lastExecutionDate ? (
+                <div className="flex items-center gap-x-2">
+                    <div className="flex items-center gap-x-4 text-content-neutral-secondary">
                         <Tooltip>
-                            <TooltipTrigger className="flex items-center justify-end text-sm">
-                                <span className="text-xs">
-                                    {`Executed at ${lastExecutionDate?.toLocaleDateString()} ${lastExecutionDate?.toLocaleTimeString()}`}
-                                </span>
+                            <TooltipTrigger asChild>
+                                <Badge
+                                    label={isDraft ? 'V1 DRAFT' : `V${connectedUserProjectWorkflow.workflowVersion}`}
+                                    styleType="secondary-filled"
+                                    weight="semibold"
+                                />
                             </TooltipTrigger>
 
-                            <TooltipContent>Last Execution Date</TooltipContent>
+                            <TooltipContent>The workflow version</TooltipContent>
                         </Tooltip>
-                    ) : (
-                        <span className="text-xs">No executions</span>
-                    )}
-                </div>
 
-                <div className="relative flex items-center">
-                    {enableConnectedUserProjectWorkflowMutation.isPending && (
-                        <LoadingIcon className="absolute left-[-15px] top-[3px]" />
-                    )}
+                        <div className="flex min-w-52 flex-col items-end gap-y-2">
+                            <div className="relative flex items-center">
+                                {enableConnectedUserProjectWorkflowMutation.isPending && (
+                                    <LoadingIcon className="absolute left-[-15px] top-[3px]" />
+                                )}
 
-                    <Tooltip>
-                        <TooltipTrigger asChild>
-                            <Switch
-                                checked={connectedUserProjectWorkflow.enabled}
-                                disabled={isDraft}
-                                onCheckedChange={(value) => {
-                                    enableConnectedUserProjectWorkflowMutation.mutate({
-                                        enable: value,
-                                        id: connectedUserProjectWorkflow.id,
-                                    });
-                                }}
+                                <Tooltip>
+                                    <TooltipTrigger asChild>
+                                        <Switch
+                                            checked={connectedUserProjectWorkflow.enabled}
+                                            disabled={isDraft}
+                                            onCheckedChange={(value) => {
+                                                enableConnectedUserProjectWorkflowMutation.mutate({
+                                                    enable: value,
+                                                    id: connectedUserProjectWorkflow.id,
+                                                });
+                                            }}
+                                        />
+                                    </TooltipTrigger>
+
+                                    <TooltipContent>
+                                        {isDraft ? 'Publish the workflow before enabling it' : 'Enable workflow'}
+                                    </TooltipContent>
+                                </Tooltip>
+                            </div>
+
+                            <Tooltip>
+                                <TooltipTrigger className="flex items-center text-sm">
+                                    {lastExecutionDate ? (
+                                        <span className="text-xs">
+                                            {`Executed at ${lastExecutionDate.toLocaleDateString()} ${lastExecutionDate.toLocaleTimeString()}`}
+                                        </span>
+                                    ) : (
+                                        <span className="text-xs">No executions</span>
+                                    )}
+                                </TooltipTrigger>
+
+                                <TooltipContent>Last Execution Date</TooltipContent>
+                            </Tooltip>
+                        </div>
+                    </div>
+
+                    <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                            <Button
+                                icon={<EllipsisVerticalIcon className="size-4 hover:cursor-pointer" />}
+                                size="icon"
+                                variant="ghost"
                             />
-                        </TooltipTrigger>
+                        </DropdownMenuTrigger>
 
-                        <TooltipContent>
-                            {isDraft ? 'Publish the workflow before enabling it' : 'Enable workflow'}
-                        </TooltipContent>
-                    </Tooltip>
+                        <DropdownMenuContent align="end">
+                            <DropdownMenuItem className="text-destructive" onClick={() => setShowDeleteDialog(true)}>
+                                Delete
+                            </DropdownMenuItem>
+                        </DropdownMenuContent>
+                    </DropdownMenu>
                 </div>
-            </div>
-        </li>
+            </li>
+
+            <DeleteAlertDialog
+                onCancel={() => setShowDeleteDialog(false)}
+                onDelete={() =>
+                    deleteConnectedUserProjectWorkflowMutation.mutate({id: connectedUserProjectWorkflow.id})
+                }
+                open={showDeleteDialog}
+            />
+        </>
     );
 };
 

--- a/client/src/ee/pages/embedded/connected-users/components/connected-user-sheet/connected-user-project-workflow-list/ConnectedUserProjectWorkflowListItem.tsx
+++ b/client/src/ee/pages/embedded/connected-users/components/connected-user-sheet/connected-user-project-workflow-list/ConnectedUserProjectWorkflowListItem.tsx
@@ -72,24 +72,15 @@ const ConnectedUserProjectWorkflowListItem = ({
                                     <LoadingIcon className="absolute left-[-15px] top-[3px]" />
                                 )}
 
-                                <Tooltip>
-                                    <TooltipTrigger asChild>
-                                        <Switch
-                                            checked={connectedUserProjectWorkflow.enabled}
-                                            disabled={isDraft}
-                                            onCheckedChange={(value) => {
-                                                enableConnectedUserProjectWorkflowMutation.mutate({
-                                                    enable: value,
-                                                    id: connectedUserProjectWorkflow.id,
-                                                });
-                                            }}
-                                        />
-                                    </TooltipTrigger>
-
-                                    <TooltipContent>
-                                        {isDraft ? 'Publish the workflow before enabling it' : 'Enable workflow'}
-                                    </TooltipContent>
-                                </Tooltip>
+                                <Switch
+                                    checked={connectedUserProjectWorkflow.enabled}
+                                    onCheckedChange={(value) => {
+                                        enableConnectedUserProjectWorkflowMutation.mutate({
+                                            enable: value,
+                                            id: connectedUserProjectWorkflow.id,
+                                        });
+                                    }}
+                                />
                             </div>
 
                             <Tooltip>

--- a/client/src/ee/pages/embedded/connected-users/components/connected-user-sheet/connected-user-project-workflow-list/ConnectedUserProjectWorkflowListItem.tsx
+++ b/client/src/ee/pages/embedded/connected-users/components/connected-user-sheet/connected-user-project-workflow-list/ConnectedUserProjectWorkflowListItem.tsx
@@ -23,7 +23,11 @@ const ConnectedUserProjectWorkflowListItem = ({
                 <Tooltip>
                     <TooltipTrigger asChild>
                         <Badge
-                            label={`V${connectedUserProjectWorkflow.workflowVersion}`}
+                            label={
+                                connectedUserProjectWorkflow.workflowVersion == null
+                                    ? 'V1 DRAFT'
+                                    : `V${connectedUserProjectWorkflow.workflowVersion}`
+                            }
                             styleType="secondary-filled"
                             weight="semibold"
                         />

--- a/client/src/ee/shared/mutations/embedded/integrationInstances.mutations.ts
+++ b/client/src/ee/shared/mutations/embedded/integrationInstances.mutations.ts
@@ -1,10 +1,28 @@
-import {EnableIntegrationInstanceRequest, IntegrationInstanceApi} from '@/ee/shared/middleware/embedded/configuration';
+import {
+    DeleteIntegrationInstanceRequest,
+    EnableIntegrationInstanceRequest,
+    IntegrationInstanceApi,
+} from '@/ee/shared/middleware/embedded/configuration';
 import {useMutation} from '@tanstack/react-query';
+
+interface DeleteIntegrationInstanceMutationProps {
+    onError?: (error: Error, variables: DeleteIntegrationInstanceRequest) => void;
+    onSuccess?: (result: void, variables: DeleteIntegrationInstanceRequest) => void;
+}
 
 interface EnableIntegrationInstanceMutationProps {
     onError?: (error: Error, variables: EnableIntegrationInstanceRequest) => void;
     onSuccess?: (result: void, variables: EnableIntegrationInstanceRequest) => void;
 }
+
+export const useDeleteIntegrationInstanceMutation = (mutationProps?: DeleteIntegrationInstanceMutationProps) =>
+    useMutation<void, Error, DeleteIntegrationInstanceRequest>({
+        mutationFn: (deleteIntegrationInstanceRequest: DeleteIntegrationInstanceRequest) => {
+            return new IntegrationInstanceApi().deleteIntegrationInstance(deleteIntegrationInstanceRequest);
+        },
+        onError: mutationProps?.onError,
+        onSuccess: mutationProps?.onSuccess,
+    });
 
 export const useEnableIntegrationInstanceMutation = (mutationProps?: EnableIntegrationInstanceMutationProps) =>
     useMutation<void, Error, EnableIntegrationInstanceRequest>({

--- a/client/src/graphql/embedded/configuration/connectedUserMcpServers.graphql
+++ b/client/src/graphql/embedded/configuration/connectedUserMcpServers.graphql
@@ -1,0 +1,17 @@
+query connectedUserMcpServers($connectedUserId: ID!) {
+    connectedUserMcpServers(connectedUserId: $connectedUserId) {
+        id
+        name
+        enabled
+        environmentId
+        lastModifiedDate
+        tools {
+            id
+            componentName
+            componentVersion
+            integrationInstanceId
+            name
+            enabled
+        }
+    }
+}

--- a/client/src/graphql/embedded/configuration/deleteConnectedUserMcpServer.graphql
+++ b/client/src/graphql/embedded/configuration/deleteConnectedUserMcpServer.graphql
@@ -1,0 +1,3 @@
+mutation deleteConnectedUserMcpServer($connectedUserId: ID!, $mcpServerId: ID!) {
+    deleteConnectedUserMcpServer(connectedUserId: $connectedUserId, mcpServerId: $mcpServerId)
+}

--- a/client/src/graphql/embedded/configuration/deleteConnectedUserProjectWorkflow.graphql
+++ b/client/src/graphql/embedded/configuration/deleteConnectedUserProjectWorkflow.graphql
@@ -1,0 +1,3 @@
+mutation deleteConnectedUserProjectWorkflow($id: ID!) {
+    deleteConnectedUserProjectWorkflow(id: $id)
+}

--- a/client/src/graphql/embedded/configuration/enableConnectedUserMcpServer.graphql
+++ b/client/src/graphql/embedded/configuration/enableConnectedUserMcpServer.graphql
@@ -1,0 +1,3 @@
+mutation enableConnectedUserMcpServer($connectedUserId: ID!, $mcpServerId: ID!, $enable: Boolean!) {
+    enableConnectedUserMcpServer(connectedUserId: $connectedUserId, mcpServerId: $mcpServerId, enable: $enable)
+}

--- a/client/src/graphql/embedded/configuration/enableConnectedUserMcpTool.graphql
+++ b/client/src/graphql/embedded/configuration/enableConnectedUserMcpTool.graphql
@@ -1,0 +1,3 @@
+mutation enableConnectedUserMcpTool($id: ID!, $enable: Boolean!) {
+    enableConnectedUserMcpTool(id: $id, enable: $enable)
+}

--- a/client/src/graphql/embedded/configuration/enableConnectedUserProjectWorkflow.graphql
+++ b/client/src/graphql/embedded/configuration/enableConnectedUserProjectWorkflow.graphql
@@ -1,0 +1,3 @@
+mutation enableConnectedUserProjectWorkflow($id: ID!, $enable: Boolean!) {
+    enableConnectedUserProjectWorkflow(id: $id, enable: $enable)
+}

--- a/client/src/shared/middleware/graphql.ts
+++ b/client/src/shared/middleware/graphql.ts
@@ -551,6 +551,26 @@ export type ConnectedUser = {
   version?: Maybe<Scalars['Int']['output']>;
 };
 
+export type ConnectedUserMcpServer = {
+  __typename?: 'ConnectedUserMcpServer';
+  enabled: Scalars['Boolean']['output'];
+  environmentId: Scalars['ID']['output'];
+  id: Scalars['ID']['output'];
+  lastModifiedDate?: Maybe<Scalars['String']['output']>;
+  name: Scalars['String']['output'];
+  tools: Array<ConnectedUserMcpServerTool>;
+};
+
+export type ConnectedUserMcpServerTool = {
+  __typename?: 'ConnectedUserMcpServerTool';
+  componentName: Scalars['String']['output'];
+  componentVersion: Scalars['Int']['output'];
+  enabled: Scalars['Boolean']['output'];
+  id: Scalars['ID']['output'];
+  integrationInstanceId: Scalars['ID']['output'];
+  name: Scalars['String']['output'];
+};
+
 export type ConnectedUserPage = {
   __typename?: 'ConnectedUserPage';
   content: Array<Maybe<ConnectedUser>>;
@@ -1484,6 +1504,8 @@ export type Mutation = {
   deleteApprovalTask?: Maybe<Scalars['Boolean']['output']>;
   deleteAutomationWorkflowProject: Scalars['Boolean']['output'];
   deleteAutomationWorkflowProjectWorkflow: Scalars['Boolean']['output'];
+  deleteConnectedUserMcpServer?: Maybe<Scalars['Boolean']['output']>;
+  deleteConnectedUserProjectWorkflow?: Maybe<Scalars['Boolean']['output']>;
   deleteCustomComponent: Scalars['Boolean']['output'];
   deleteDataTableRow: Scalars['Boolean']['output'];
   deleteEmbeddedMcpServer?: Maybe<Scalars['Boolean']['output']>;
@@ -1510,6 +1532,9 @@ export type Mutation = {
   duplicateAutomationWorkflowProjectWorkflow: Scalars['ID']['output'];
   duplicateDataTable: Scalars['Boolean']['output'];
   enableApiConnector: Scalars['Boolean']['output'];
+  enableConnectedUserMcpServer?: Maybe<Scalars['Boolean']['output']>;
+  enableConnectedUserMcpTool?: Maybe<Scalars['Boolean']['output']>;
+  enableConnectedUserProjectWorkflow?: Maybe<Scalars['Boolean']['output']>;
   enableCustomComponent: Scalars['Boolean']['output'];
   exportSharedProject?: Maybe<Scalars['Boolean']['output']>;
   exportSharedWorkflow: Scalars['Boolean']['output'];
@@ -1802,6 +1827,17 @@ export type MutationDeleteAutomationWorkflowProjectWorkflowArgs = {
 };
 
 
+export type MutationDeleteConnectedUserMcpServerArgs = {
+  connectedUserId: Scalars['ID']['input'];
+  mcpServerId: Scalars['ID']['input'];
+};
+
+
+export type MutationDeleteConnectedUserProjectWorkflowArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
 export type MutationDeleteCustomComponentArgs = {
   id: Scalars['ID']['input'];
 };
@@ -1928,6 +1964,25 @@ export type MutationDuplicateDataTableArgs = {
 
 
 export type MutationEnableApiConnectorArgs = {
+  enable: Scalars['Boolean']['input'];
+  id: Scalars['ID']['input'];
+};
+
+
+export type MutationEnableConnectedUserMcpServerArgs = {
+  connectedUserId: Scalars['ID']['input'];
+  enable: Scalars['Boolean']['input'];
+  mcpServerId: Scalars['ID']['input'];
+};
+
+
+export type MutationEnableConnectedUserMcpToolArgs = {
+  enable: Scalars['Boolean']['input'];
+  id: Scalars['ID']['input'];
+};
+
+
+export type MutationEnableConnectedUserProjectWorkflowArgs = {
   enable: Scalars['Boolean']['input'];
   id: Scalars['ID']['input'];
 };
@@ -2551,6 +2606,7 @@ export type Query = {
   componentDefinitionVersions: Array<ComponentDefinition>;
   componentDefinitions: Array<ComponentDefinition>;
   connectedUser?: Maybe<ConnectedUser>;
+  connectedUserMcpServers: Array<ConnectedUserMcpServer>;
   connectedUserProjects: Array<ConnectedUserProject>;
   connectedUsers?: Maybe<ConnectedUserPage>;
   connectionComponentDefinition: ComponentDefinition;
@@ -2854,6 +2910,11 @@ export type QueryComponentDefinitionsArgs = {
 
 export type QueryConnectedUserArgs = {
   id?: InputMaybe<Scalars['ID']['input']>;
+};
+
+
+export type QueryConnectedUserMcpServersArgs = {
+  connectedUserId: Scalars['ID']['input'];
 };
 
 
@@ -4495,6 +4556,13 @@ export type PublishAutomationWorkflowProjectMutationVariables = Exact<{
 
 export type PublishAutomationWorkflowProjectMutation = { __typename?: 'Mutation', publishAutomationWorkflowProject: boolean };
 
+export type ConnectedUserMcpServersQueryVariables = Exact<{
+  connectedUserId: Scalars['ID']['input'];
+}>;
+
+
+export type ConnectedUserMcpServersQuery = { __typename?: 'Query', connectedUserMcpServers: Array<{ __typename?: 'ConnectedUserMcpServer', id: string, name: string, enabled: boolean, environmentId: string, lastModifiedDate?: string | null, tools: Array<{ __typename?: 'ConnectedUserMcpServerTool', id: string, componentName: string, componentVersion: number, integrationInstanceId: string, name: string, enabled: boolean }> }> };
+
 export type ConnectedUserProjectsQueryVariables = Exact<{
   connectedUserId?: InputMaybe<Scalars['ID']['input']>;
   environmentId?: InputMaybe<Scalars['ID']['input']>;
@@ -4516,6 +4584,21 @@ export type CreateMcpIntegrationInstanceConfigurationMutationVariables = Exact<{
 
 
 export type CreateMcpIntegrationInstanceConfigurationMutation = { __typename?: 'Mutation', createMcpIntegrationInstanceConfiguration?: { __typename?: 'McpIntegrationInstanceConfiguration', id: string, integrationInstanceConfigurationId: string, mcpServerId: string } | null };
+
+export type DeleteConnectedUserMcpServerMutationVariables = Exact<{
+  connectedUserId: Scalars['ID']['input'];
+  mcpServerId: Scalars['ID']['input'];
+}>;
+
+
+export type DeleteConnectedUserMcpServerMutation = { __typename?: 'Mutation', deleteConnectedUserMcpServer?: boolean | null };
+
+export type DeleteConnectedUserProjectWorkflowMutationVariables = Exact<{
+  id: Scalars['ID']['input'];
+}>;
+
+
+export type DeleteConnectedUserProjectWorkflowMutation = { __typename?: 'Mutation', deleteConnectedUserProjectWorkflow?: boolean | null };
 
 export type DeleteEmbeddedMcpServerMutationVariables = Exact<{
   mcpServerId: Scalars['ID']['input'];
@@ -4556,6 +4639,31 @@ export type EmbeddedMcpServersQueryVariables = Exact<{ [key: string]: never; }>;
 
 
 export type EmbeddedMcpServersQuery = { __typename?: 'Query', embeddedMcpServers?: Array<{ __typename?: 'McpServer', id: string, enabled: boolean, environmentId: string, lastModifiedDate?: any | null, name: string, type: PlatformType, url: string, mcpComponents?: Array<{ __typename?: 'McpComponent', componentName: string, componentVersion: number, connectionId?: string | null, id: string, lastModifiedDate?: any | null, mcpServerId: string, title?: string | null, mcpTools?: Array<{ __typename?: 'McpTool', id: string, mcpComponentId: string, name: string, title?: string | null, parameters?: any | null } | null> | null } | null> | null, tags?: Array<{ __typename?: 'Tag', id: string, name: string } | null> | null } | null> | null };
+
+export type EnableConnectedUserMcpServerMutationVariables = Exact<{
+  connectedUserId: Scalars['ID']['input'];
+  mcpServerId: Scalars['ID']['input'];
+  enable: Scalars['Boolean']['input'];
+}>;
+
+
+export type EnableConnectedUserMcpServerMutation = { __typename?: 'Mutation', enableConnectedUserMcpServer?: boolean | null };
+
+export type EnableConnectedUserMcpToolMutationVariables = Exact<{
+  id: Scalars['ID']['input'];
+  enable: Scalars['Boolean']['input'];
+}>;
+
+
+export type EnableConnectedUserMcpToolMutation = { __typename?: 'Mutation', enableConnectedUserMcpTool?: boolean | null };
+
+export type EnableConnectedUserProjectWorkflowMutationVariables = Exact<{
+  id: Scalars['ID']['input'];
+  enable: Scalars['Boolean']['input'];
+}>;
+
+
+export type EnableConnectedUserProjectWorkflowMutation = { __typename?: 'Mutation', enableConnectedUserProjectWorkflow?: boolean | null };
 
 export type IntegrationByIdQueryVariables = Exact<{
   id: Scalars['ID']['input'];
@@ -8487,6 +8595,42 @@ export const usePublishAutomationWorkflowProjectMutation = <
   }
     )};
 
+export const ConnectedUserMcpServersDocument = new TypedDocumentString(`
+    query connectedUserMcpServers($connectedUserId: ID!) {
+  connectedUserMcpServers(connectedUserId: $connectedUserId) {
+    id
+    name
+    enabled
+    environmentId
+    lastModifiedDate
+    tools {
+      id
+      componentName
+      componentVersion
+      integrationInstanceId
+      name
+      enabled
+    }
+  }
+}
+    `);
+
+export const useConnectedUserMcpServersQuery = <
+      TData = ConnectedUserMcpServersQuery,
+      TError = unknown
+    >(
+      variables: ConnectedUserMcpServersQueryVariables,
+      options?: Omit<UseQueryOptions<ConnectedUserMcpServersQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<ConnectedUserMcpServersQuery, TError, TData>['queryKey'] }
+    ) => {
+    
+    return useQuery<ConnectedUserMcpServersQuery, TError, TData>(
+      {
+    queryKey: ['connectedUserMcpServers', variables],
+    queryFn: fetcher<ConnectedUserMcpServersQuery, ConnectedUserMcpServersQueryVariables>(ConnectedUserMcpServersDocument, variables),
+    ...options
+  }
+    )};
+
 export const ConnectedUserProjectsDocument = new TypedDocumentString(`
     query connectedUserProjects($connectedUserId: ID, $environmentId: ID) {
   connectedUserProjects(
@@ -8585,6 +8729,47 @@ export const useCreateMcpIntegrationInstanceConfigurationMutation = <
       {
     mutationKey: ['createMcpIntegrationInstanceConfiguration'],
     mutationFn: (variables?: CreateMcpIntegrationInstanceConfigurationMutationVariables) => fetcher<CreateMcpIntegrationInstanceConfigurationMutation, CreateMcpIntegrationInstanceConfigurationMutationVariables>(CreateMcpIntegrationInstanceConfigurationDocument, variables)(),
+    ...options
+  }
+    )};
+
+export const DeleteConnectedUserMcpServerDocument = new TypedDocumentString(`
+    mutation deleteConnectedUserMcpServer($connectedUserId: ID!, $mcpServerId: ID!) {
+  deleteConnectedUserMcpServer(
+    connectedUserId: $connectedUserId
+    mcpServerId: $mcpServerId
+  )
+}
+    `);
+
+export const useDeleteConnectedUserMcpServerMutation = <
+      TError = unknown,
+      TContext = unknown
+    >(options?: UseMutationOptions<DeleteConnectedUserMcpServerMutation, TError, DeleteConnectedUserMcpServerMutationVariables, TContext>) => {
+    
+    return useMutation<DeleteConnectedUserMcpServerMutation, TError, DeleteConnectedUserMcpServerMutationVariables, TContext>(
+      {
+    mutationKey: ['deleteConnectedUserMcpServer'],
+    mutationFn: (variables?: DeleteConnectedUserMcpServerMutationVariables) => fetcher<DeleteConnectedUserMcpServerMutation, DeleteConnectedUserMcpServerMutationVariables>(DeleteConnectedUserMcpServerDocument, variables)(),
+    ...options
+  }
+    )};
+
+export const DeleteConnectedUserProjectWorkflowDocument = new TypedDocumentString(`
+    mutation deleteConnectedUserProjectWorkflow($id: ID!) {
+  deleteConnectedUserProjectWorkflow(id: $id)
+}
+    `);
+
+export const useDeleteConnectedUserProjectWorkflowMutation = <
+      TError = unknown,
+      TContext = unknown
+    >(options?: UseMutationOptions<DeleteConnectedUserProjectWorkflowMutation, TError, DeleteConnectedUserProjectWorkflowMutationVariables, TContext>) => {
+    
+    return useMutation<DeleteConnectedUserProjectWorkflowMutation, TError, DeleteConnectedUserProjectWorkflowMutationVariables, TContext>(
+      {
+    mutationKey: ['deleteConnectedUserProjectWorkflow'],
+    mutationFn: (variables?: DeleteConnectedUserProjectWorkflowMutationVariables) => fetcher<DeleteConnectedUserProjectWorkflowMutation, DeleteConnectedUserProjectWorkflowMutationVariables>(DeleteConnectedUserProjectWorkflowDocument, variables)(),
     ...options
   }
     )};
@@ -8730,6 +8915,67 @@ export const useEmbeddedMcpServersQuery = <
       {
     queryKey: variables === undefined ? ['embeddedMcpServers'] : ['embeddedMcpServers', variables],
     queryFn: fetcher<EmbeddedMcpServersQuery, EmbeddedMcpServersQueryVariables>(EmbeddedMcpServersDocument, variables),
+    ...options
+  }
+    )};
+
+export const EnableConnectedUserMcpServerDocument = new TypedDocumentString(`
+    mutation enableConnectedUserMcpServer($connectedUserId: ID!, $mcpServerId: ID!, $enable: Boolean!) {
+  enableConnectedUserMcpServer(
+    connectedUserId: $connectedUserId
+    mcpServerId: $mcpServerId
+    enable: $enable
+  )
+}
+    `);
+
+export const useEnableConnectedUserMcpServerMutation = <
+      TError = unknown,
+      TContext = unknown
+    >(options?: UseMutationOptions<EnableConnectedUserMcpServerMutation, TError, EnableConnectedUserMcpServerMutationVariables, TContext>) => {
+    
+    return useMutation<EnableConnectedUserMcpServerMutation, TError, EnableConnectedUserMcpServerMutationVariables, TContext>(
+      {
+    mutationKey: ['enableConnectedUserMcpServer'],
+    mutationFn: (variables?: EnableConnectedUserMcpServerMutationVariables) => fetcher<EnableConnectedUserMcpServerMutation, EnableConnectedUserMcpServerMutationVariables>(EnableConnectedUserMcpServerDocument, variables)(),
+    ...options
+  }
+    )};
+
+export const EnableConnectedUserMcpToolDocument = new TypedDocumentString(`
+    mutation enableConnectedUserMcpTool($id: ID!, $enable: Boolean!) {
+  enableConnectedUserMcpTool(id: $id, enable: $enable)
+}
+    `);
+
+export const useEnableConnectedUserMcpToolMutation = <
+      TError = unknown,
+      TContext = unknown
+    >(options?: UseMutationOptions<EnableConnectedUserMcpToolMutation, TError, EnableConnectedUserMcpToolMutationVariables, TContext>) => {
+    
+    return useMutation<EnableConnectedUserMcpToolMutation, TError, EnableConnectedUserMcpToolMutationVariables, TContext>(
+      {
+    mutationKey: ['enableConnectedUserMcpTool'],
+    mutationFn: (variables?: EnableConnectedUserMcpToolMutationVariables) => fetcher<EnableConnectedUserMcpToolMutation, EnableConnectedUserMcpToolMutationVariables>(EnableConnectedUserMcpToolDocument, variables)(),
+    ...options
+  }
+    )};
+
+export const EnableConnectedUserProjectWorkflowDocument = new TypedDocumentString(`
+    mutation enableConnectedUserProjectWorkflow($id: ID!, $enable: Boolean!) {
+  enableConnectedUserProjectWorkflow(id: $id, enable: $enable)
+}
+    `);
+
+export const useEnableConnectedUserProjectWorkflowMutation = <
+      TError = unknown,
+      TContext = unknown
+    >(options?: UseMutationOptions<EnableConnectedUserProjectWorkflowMutation, TError, EnableConnectedUserProjectWorkflowMutationVariables, TContext>) => {
+    
+    return useMutation<EnableConnectedUserProjectWorkflowMutation, TError, EnableConnectedUserProjectWorkflowMutationVariables, TContext>(
+      {
+    mutationKey: ['enableConnectedUserProjectWorkflow'],
+    mutationFn: (variables?: EnableConnectedUserProjectWorkflowMutationVariables) => fetcher<EnableConnectedUserProjectWorkflowMutation, EnableConnectedUserProjectWorkflowMutationVariables>(EnableConnectedUserProjectWorkflowDocument, variables)(),
     ...options
   }
     )};

--- a/server/ee/libs/embedded/embedded-configuration/embedded-configuration-api/src/main/java/com/bytechef/ee/embedded/configuration/facade/ConnectedUserProjectFacade.java
+++ b/server/ee/libs/embedded/embedded-configuration/embedded-configuration-api/src/main/java/com/bytechef/ee/embedded/configuration/facade/ConnectedUserProjectFacade.java
@@ -27,6 +27,8 @@ public interface ConnectedUserProjectFacade {
     void enableProjectWorkflow(
         String externalUserId, String workflowUuid, boolean enable, Long environmentId);
 
+    void enableProjectWorkflow(long connectedUserProjectWorkflowId, boolean enable);
+
     ConnectedUserProjectWorkflowDTO getConnectedUserProjectWorkflow(
         String externalUserId, String workflowUuid, Long environmentId);
 

--- a/server/ee/libs/embedded/embedded-configuration/embedded-configuration-api/src/main/java/com/bytechef/ee/embedded/configuration/facade/ConnectedUserProjectFacade.java
+++ b/server/ee/libs/embedded/embedded-configuration/embedded-configuration-api/src/main/java/com/bytechef/ee/embedded/configuration/facade/ConnectedUserProjectFacade.java
@@ -24,6 +24,8 @@ public interface ConnectedUserProjectFacade {
 
     void deleteProjectWorkflow(String externalUserId, String workflowUuid, Environment environment);
 
+    void deleteProjectWorkflow(long connectedUserProjectWorkflowId);
+
     void enableProjectWorkflow(
         String externalUserId, String workflowUuid, boolean enable, Long environmentId);
 

--- a/server/ee/libs/embedded/embedded-configuration/embedded-configuration-api/src/main/java/com/bytechef/ee/embedded/configuration/facade/IntegrationInstanceFacade.java
+++ b/server/ee/libs/embedded/embedded-configuration/embedded-configuration-api/src/main/java/com/bytechef/ee/embedded/configuration/facade/IntegrationInstanceFacade.java
@@ -17,6 +17,8 @@ import java.util.Map;
  */
 public interface IntegrationInstanceFacade {
 
+    void deleteIntegrationInstance(long integrationInstanceId);
+
     void enableIntegrationInstance(long integrationInstanceId, boolean enable);
 
     void enableIntegrationInstanceWorkflow(long integrationInstanceId, String workflowId, boolean enable);

--- a/server/ee/libs/embedded/embedded-configuration/embedded-configuration-graphql/src/main/java/com/bytechef/ee/embedded/configuration/web/graphql/ConnectedUserProjectGraphQlController.java
+++ b/server/ee/libs/embedded/embedded-configuration/embedded-configuration-graphql/src/main/java/com/bytechef/ee/embedded/configuration/web/graphql/ConnectedUserProjectGraphQlController.java
@@ -49,6 +49,13 @@ public class ConnectedUserProjectGraphQlController {
     }
 
     @MutationMapping
+    public boolean deleteConnectedUserProjectWorkflow(@Argument long id) {
+        connectedUserProjectFacade.deleteProjectWorkflow(id);
+
+        return true;
+    }
+
+    @MutationMapping
     public boolean enableConnectedUserProjectWorkflow(@Argument long id, @Argument boolean enable) {
         connectedUserProjectFacade.enableProjectWorkflow(id, enable);
 

--- a/server/ee/libs/embedded/embedded-configuration/embedded-configuration-graphql/src/main/java/com/bytechef/ee/embedded/configuration/web/graphql/ConnectedUserProjectGraphQlController.java
+++ b/server/ee/libs/embedded/embedded-configuration/embedded-configuration-graphql/src/main/java/com/bytechef/ee/embedded/configuration/web/graphql/ConnectedUserProjectGraphQlController.java
@@ -15,6 +15,7 @@ import com.bytechef.platform.configuration.service.EnvironmentService;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.List;
 import org.springframework.graphql.data.method.annotation.Argument;
+import org.springframework.graphql.data.method.annotation.MutationMapping;
 import org.springframework.graphql.data.method.annotation.QueryMapping;
 import org.springframework.stereotype.Controller;
 
@@ -45,5 +46,12 @@ public class ConnectedUserProjectGraphQlController {
 
         return connectedUserProjectFacade.getConnectedUserProjects(
             connectedUserId, environmentService.getEnvironment(environmentId));
+    }
+
+    @MutationMapping
+    public boolean enableConnectedUserProjectWorkflow(@Argument long id, @Argument boolean enable) {
+        connectedUserProjectFacade.enableProjectWorkflow(id, enable);
+
+        return true;
     }
 }

--- a/server/ee/libs/embedded/embedded-configuration/embedded-configuration-graphql/src/main/resources/graphql/connected-user-project.graphqls
+++ b/server/ee/libs/embedded/embedded-configuration/embedded-configuration-graphql/src/main/resources/graphql/connected-user-project.graphqls
@@ -3,6 +3,7 @@ extend type Query {
 }
 
 extend type Mutation {
+    deleteConnectedUserProjectWorkflow(id: ID!): Boolean
     enableConnectedUserProjectWorkflow(id: ID!, enable: Boolean!): Boolean
 }
 

--- a/server/ee/libs/embedded/embedded-configuration/embedded-configuration-graphql/src/main/resources/graphql/connected-user-project.graphqls
+++ b/server/ee/libs/embedded/embedded-configuration/embedded-configuration-graphql/src/main/resources/graphql/connected-user-project.graphqls
@@ -2,6 +2,10 @@ extend type Query {
     connectedUserProjects(connectedUserId: ID, environmentId: ID): [ConnectedUserProject!]!
 }
 
+extend type Mutation {
+    enableConnectedUserProjectWorkflow(id: ID!, enable: Boolean!): Boolean
+}
+
 type ConnectedUserProject {
     id: ID!
     connectedUser: ConnectedUser!

--- a/server/ee/libs/embedded/embedded-configuration/embedded-configuration-rest/embedded-configuration-rest-impl/src/main/java/com/bytechef/ee/embedded/configuration/web/rest/IntegrationInstanceApiController.java
+++ b/server/ee/libs/embedded/embedded-configuration/embedded-configuration-rest/embedded-configuration-rest-impl/src/main/java/com/bytechef/ee/embedded/configuration/web/rest/IntegrationInstanceApiController.java
@@ -11,6 +11,7 @@ import com.bytechef.atlas.coordinator.annotation.ConditionalOnCoordinator;
 import com.bytechef.ee.embedded.configuration.facade.IntegrationInstanceFacade;
 import com.bytechef.ee.embedded.configuration.web.rest.model.IntegrationInstanceModel;
 import com.bytechef.platform.annotation.ConditionalOnEEVersion;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -30,11 +31,20 @@ public class IntegrationInstanceApiController implements IntegrationInstanceApi 
     private final ConversionService conversionService;
     private final IntegrationInstanceFacade integrationInstanceFacade;
 
+    @SuppressFBWarnings("EI")
     public IntegrationInstanceApiController(
         ConversionService conversionService, IntegrationInstanceFacade integrationInstanceFacade) {
 
         this.conversionService = conversionService;
         this.integrationInstanceFacade = integrationInstanceFacade;
+    }
+
+    @Override
+    public ResponseEntity<Void> deleteIntegrationInstance(Long id) {
+        integrationInstanceFacade.deleteIntegrationInstance(id);
+
+        return ResponseEntity.noContent()
+            .build();
     }
 
     @Override

--- a/server/ee/libs/embedded/embedded-configuration/embedded-configuration-service/src/main/java/com/bytechef/ee/embedded/configuration/facade/ConnectedUserProjectFacadeImpl.java
+++ b/server/ee/libs/embedded/embedded-configuration/embedded-configuration-service/src/main/java/com/bytechef/ee/embedded/configuration/facade/ConnectedUserProjectFacadeImpl.java
@@ -222,6 +222,24 @@ public class ConnectedUserProjectFacadeImpl implements ConnectedUserProjectFacad
     }
 
     @Override
+    public void enableProjectWorkflow(long connectedUserProjectWorkflowId, boolean enable) {
+        ConnectedUserProjectWorkflow connectedUserProjectWorkflow = connectedUserProjectWorkflowService
+            .getConnectedUserProjectWorkflow(connectedUserProjectWorkflowId);
+
+        ConnectedUserProject connectedUserProject = connectUserProjectService.getConnectedUserProject(
+            connectedUserProjectWorkflow.getConnectedUserProjectId());
+
+        ConnectedUser connectedUser = connectedUserService.getConnectedUser(connectedUserProject.getConnectedUserId());
+
+        ProjectWorkflow projectWorkflow = projectWorkflowService.getProjectWorkflow(
+            connectedUserProjectWorkflow.getProjectWorkflowId());
+
+        enableProjectWorkflow(
+            connectedUser.getExternalId(), projectWorkflow.getUuidAsString(), enable,
+            connectedUser.getEnvironmentId());
+    }
+
+    @Override
     public ConnectedUserProjectWorkflowDTO getConnectedUserProjectWorkflow(
         String externalUserId, String workflowUuid, Long environmentId) {
 

--- a/server/ee/libs/embedded/embedded-configuration/embedded-configuration-service/src/main/java/com/bytechef/ee/embedded/configuration/facade/ConnectedUserProjectFacadeImpl.java
+++ b/server/ee/libs/embedded/embedded-configuration/embedded-configuration-service/src/main/java/com/bytechef/ee/embedded/configuration/facade/ConnectedUserProjectFacadeImpl.java
@@ -187,6 +187,23 @@ public class ConnectedUserProjectFacadeImpl implements ConnectedUserProjectFacad
     }
 
     @Override
+    public void deleteProjectWorkflow(long connectedUserProjectWorkflowId) {
+        ConnectedUserProjectWorkflow connectedUserProjectWorkflow = connectedUserProjectWorkflowService
+            .getConnectedUserProjectWorkflow(connectedUserProjectWorkflowId);
+
+        ConnectedUserProject connectedUserProject = connectUserProjectService.getConnectedUserProject(
+            connectedUserProjectWorkflow.getConnectedUserProjectId());
+
+        ConnectedUser connectedUser = connectedUserService.getConnectedUser(connectedUserProject.getConnectedUserId());
+
+        ProjectWorkflow projectWorkflow = projectWorkflowService.getProjectWorkflow(
+            connectedUserProjectWorkflow.getProjectWorkflowId());
+
+        deleteProjectWorkflow(
+            connectedUser.getExternalId(), projectWorkflow.getUuidAsString(), connectedUser.getEnvironment());
+    }
+
+    @Override
     public void enableProjectWorkflow(
         String externalUserId, String workflowUuid, boolean enable, Long environmentId) {
 

--- a/server/ee/libs/embedded/embedded-configuration/embedded-configuration-service/src/main/java/com/bytechef/ee/embedded/configuration/facade/IntegrationInstanceFacadeImpl.java
+++ b/server/ee/libs/embedded/embedded-configuration/embedded-configuration-service/src/main/java/com/bytechef/ee/embedded/configuration/facade/IntegrationInstanceFacadeImpl.java
@@ -103,6 +103,20 @@ public class IntegrationInstanceFacadeImpl implements IntegrationInstanceFacade 
     }
 
     @Override
+    public void deleteIntegrationInstance(long integrationInstanceId) {
+        IntegrationInstance integrationInstance = integrationInstanceService.getIntegrationInstance(
+            integrationInstanceId);
+
+        if (integrationInstance.isEnabled()) {
+            enableIntegrationInstanceWorkflowTriggers(integrationInstanceId, false);
+        }
+
+        integrationInstanceWorkflowService.deleteByIntegrationInstanceId(integrationInstanceId);
+
+        integrationInstanceService.delete(integrationInstanceId);
+    }
+
+    @Override
     public void enableIntegrationInstance(long integrationInstanceId, boolean enable) {
         IntegrationInstance integrationInstance = integrationInstanceService.getIntegrationInstance(
             integrationInstanceId);

--- a/server/ee/libs/embedded/embedded-mcp/embedded-mcp-api/src/main/java/com/bytechef/ee/embedded/mcp/dto/ConnectedUserMcpServerDTO.java
+++ b/server/ee/libs/embedded/embedded-mcp/embedded-mcp-api/src/main/java/com/bytechef/ee/embedded/mcp/dto/ConnectedUserMcpServerDTO.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2025 ByteChef
+ *
+ * Licensed under the ByteChef Enterprise license (the "Enterprise License");
+ * you may not use this file except in compliance with the Enterprise License.
+ */
+
+package com.bytechef.ee.embedded.mcp.dto;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * @version ee
+ *
+ * @author Ivica Cardic
+ */
+@SuppressFBWarnings("EI")
+public record ConnectedUserMcpServerDTO(
+    long id, String name, boolean enabled, long environmentId, Instant lastModifiedDate,
+    List<ConnectedUserMcpServerToolDTO> tools) {
+}

--- a/server/ee/libs/embedded/embedded-mcp/embedded-mcp-api/src/main/java/com/bytechef/ee/embedded/mcp/dto/ConnectedUserMcpServerToolDTO.java
+++ b/server/ee/libs/embedded/embedded-mcp/embedded-mcp-api/src/main/java/com/bytechef/ee/embedded/mcp/dto/ConnectedUserMcpServerToolDTO.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2025 ByteChef
+ *
+ * Licensed under the ByteChef Enterprise license (the "Enterprise License");
+ * you may not use this file except in compliance with the Enterprise License.
+ */
+
+package com.bytechef.ee.embedded.mcp.dto;
+
+/**
+ * @version ee
+ *
+ * @author Ivica Cardic
+ */
+public record ConnectedUserMcpServerToolDTO(
+    long id, String componentName, int componentVersion, long integrationInstanceId, String name, boolean enabled) {
+}

--- a/server/ee/libs/embedded/embedded-mcp/embedded-mcp-api/src/main/java/com/bytechef/ee/embedded/mcp/facade/ConnectedUserMcpServerFacade.java
+++ b/server/ee/libs/embedded/embedded-mcp/embedded-mcp-api/src/main/java/com/bytechef/ee/embedded/mcp/facade/ConnectedUserMcpServerFacade.java
@@ -17,6 +17,8 @@ import java.util.List;
  */
 public interface ConnectedUserMcpServerFacade {
 
+    void enableConnectedUserMcpServer(long connectedUserId, long mcpServerId, boolean enable);
+
     void enableMcpTool(long mcpIntegrationInstanceToolId, boolean enable);
 
     List<ConnectedUserMcpServerDTO> getConnectedUserMcpServers(long connectedUserId);

--- a/server/ee/libs/embedded/embedded-mcp/embedded-mcp-api/src/main/java/com/bytechef/ee/embedded/mcp/facade/ConnectedUserMcpServerFacade.java
+++ b/server/ee/libs/embedded/embedded-mcp/embedded-mcp-api/src/main/java/com/bytechef/ee/embedded/mcp/facade/ConnectedUserMcpServerFacade.java
@@ -17,6 +17,8 @@ import java.util.List;
  */
 public interface ConnectedUserMcpServerFacade {
 
+    void deleteConnectedUserMcpServer(long connectedUserId, long mcpServerId);
+
     void enableConnectedUserMcpServer(long connectedUserId, long mcpServerId, boolean enable);
 
     void enableMcpTool(long mcpIntegrationInstanceToolId, boolean enable);

--- a/server/ee/libs/embedded/embedded-mcp/embedded-mcp-api/src/main/java/com/bytechef/ee/embedded/mcp/facade/ConnectedUserMcpServerFacade.java
+++ b/server/ee/libs/embedded/embedded-mcp/embedded-mcp-api/src/main/java/com/bytechef/ee/embedded/mcp/facade/ConnectedUserMcpServerFacade.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2025 ByteChef
+ *
+ * Licensed under the ByteChef Enterprise license (the "Enterprise License");
+ * you may not use this file except in compliance with the Enterprise License.
+ */
+
+package com.bytechef.ee.embedded.mcp.facade;
+
+import com.bytechef.ee.embedded.mcp.dto.ConnectedUserMcpServerDTO;
+import java.util.List;
+
+/**
+ * @version ee
+ *
+ * @author Ivica Cardic
+ */
+public interface ConnectedUserMcpServerFacade {
+
+    void enableMcpTool(long mcpIntegrationInstanceToolId, boolean enable);
+
+    List<ConnectedUserMcpServerDTO> getConnectedUserMcpServers(long connectedUserId);
+}

--- a/server/ee/libs/embedded/embedded-mcp/embedded-mcp-api/src/main/java/com/bytechef/ee/embedded/mcp/service/McpIntegrationInstanceToolService.java
+++ b/server/ee/libs/embedded/embedded-mcp/embedded-mcp-api/src/main/java/com/bytechef/ee/embedded/mcp/service/McpIntegrationInstanceToolService.java
@@ -21,6 +21,8 @@ public interface McpIntegrationInstanceToolService {
     McpIntegrationInstanceTool createMcpIntegrationInstanceTool(
         long integrationInstanceId, long mcpToolId, boolean enabled);
 
+    void delete(long id);
+
     void deleteByIntegrationInstanceId(long integrationInstanceId);
 
     void deleteByMcpToolId(long mcpToolId);

--- a/server/ee/libs/embedded/embedded-mcp/embedded-mcp-graphql/src/main/java/com/bytechef/ee/embedded/mcp/web/graphql/ConnectedUserMcpServerGraphQlController.java
+++ b/server/ee/libs/embedded/embedded-mcp/embedded-mcp-graphql/src/main/java/com/bytechef/ee/embedded/mcp/web/graphql/ConnectedUserMcpServerGraphQlController.java
@@ -42,6 +42,15 @@ class ConnectedUserMcpServerGraphQlController {
     }
 
     @MutationMapping
+    boolean enableConnectedUserMcpServer(
+        @Argument long connectedUserId, @Argument long mcpServerId, @Argument boolean enable) {
+
+        connectedUserMcpServerFacade.enableConnectedUserMcpServer(connectedUserId, mcpServerId, enable);
+
+        return true;
+    }
+
+    @MutationMapping
     boolean enableConnectedUserMcpTool(@Argument long id, @Argument boolean enable) {
         connectedUserMcpServerFacade.enableMcpTool(id, enable);
 

--- a/server/ee/libs/embedded/embedded-mcp/embedded-mcp-graphql/src/main/java/com/bytechef/ee/embedded/mcp/web/graphql/ConnectedUserMcpServerGraphQlController.java
+++ b/server/ee/libs/embedded/embedded-mcp/embedded-mcp-graphql/src/main/java/com/bytechef/ee/embedded/mcp/web/graphql/ConnectedUserMcpServerGraphQlController.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2025 ByteChef
+ *
+ * Licensed under the ByteChef Enterprise license (the "Enterprise License");
+ * you may not use this file except in compliance with the Enterprise License.
+ */
+
+package com.bytechef.ee.embedded.mcp.web.graphql;
+
+import com.bytechef.atlas.coordinator.annotation.ConditionalOnCoordinator;
+import com.bytechef.ee.embedded.mcp.dto.ConnectedUserMcpServerDTO;
+import com.bytechef.ee.embedded.mcp.facade.ConnectedUserMcpServerFacade;
+import com.bytechef.platform.annotation.ConditionalOnEEVersion;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.List;
+import org.springframework.graphql.data.method.annotation.Argument;
+import org.springframework.graphql.data.method.annotation.MutationMapping;
+import org.springframework.graphql.data.method.annotation.QueryMapping;
+import org.springframework.stereotype.Controller;
+
+/**
+ * GraphQL controller exposing MCP servers a connected user is reachable through.
+ *
+ * @author Ivica Cardic
+ * @version ee
+ */
+@Controller
+@ConditionalOnCoordinator
+@ConditionalOnEEVersion
+class ConnectedUserMcpServerGraphQlController {
+
+    private final ConnectedUserMcpServerFacade connectedUserMcpServerFacade;
+
+    @SuppressFBWarnings("EI")
+    ConnectedUserMcpServerGraphQlController(ConnectedUserMcpServerFacade connectedUserMcpServerFacade) {
+        this.connectedUserMcpServerFacade = connectedUserMcpServerFacade;
+    }
+
+    @QueryMapping
+    List<ConnectedUserMcpServerDTO> connectedUserMcpServers(@Argument long connectedUserId) {
+        return connectedUserMcpServerFacade.getConnectedUserMcpServers(connectedUserId);
+    }
+
+    @MutationMapping
+    boolean enableConnectedUserMcpTool(@Argument long id, @Argument boolean enable) {
+        connectedUserMcpServerFacade.enableMcpTool(id, enable);
+
+        return true;
+    }
+}

--- a/server/ee/libs/embedded/embedded-mcp/embedded-mcp-graphql/src/main/java/com/bytechef/ee/embedded/mcp/web/graphql/ConnectedUserMcpServerGraphQlController.java
+++ b/server/ee/libs/embedded/embedded-mcp/embedded-mcp-graphql/src/main/java/com/bytechef/ee/embedded/mcp/web/graphql/ConnectedUserMcpServerGraphQlController.java
@@ -42,6 +42,13 @@ class ConnectedUserMcpServerGraphQlController {
     }
 
     @MutationMapping
+    boolean deleteConnectedUserMcpServer(@Argument long connectedUserId, @Argument long mcpServerId) {
+        connectedUserMcpServerFacade.deleteConnectedUserMcpServer(connectedUserId, mcpServerId);
+
+        return true;
+    }
+
+    @MutationMapping
     boolean enableConnectedUserMcpServer(
         @Argument long connectedUserId, @Argument long mcpServerId, @Argument boolean enable) {
 

--- a/server/ee/libs/embedded/embedded-mcp/embedded-mcp-graphql/src/main/resources/graphql/connected-user-mcp-server.graphqls
+++ b/server/ee/libs/embedded/embedded-mcp/embedded-mcp-graphql/src/main/resources/graphql/connected-user-mcp-server.graphqls
@@ -3,6 +3,7 @@ extend type Query {
 }
 
 extend type Mutation {
+    enableConnectedUserMcpServer(connectedUserId: ID!, mcpServerId: ID!, enable: Boolean!): Boolean
     enableConnectedUserMcpTool(id: ID!, enable: Boolean!): Boolean
 }
 

--- a/server/ee/libs/embedded/embedded-mcp/embedded-mcp-graphql/src/main/resources/graphql/connected-user-mcp-server.graphqls
+++ b/server/ee/libs/embedded/embedded-mcp/embedded-mcp-graphql/src/main/resources/graphql/connected-user-mcp-server.graphqls
@@ -3,6 +3,7 @@ extend type Query {
 }
 
 extend type Mutation {
+    deleteConnectedUserMcpServer(connectedUserId: ID!, mcpServerId: ID!): Boolean
     enableConnectedUserMcpServer(connectedUserId: ID!, mcpServerId: ID!, enable: Boolean!): Boolean
     enableConnectedUserMcpTool(id: ID!, enable: Boolean!): Boolean
 }

--- a/server/ee/libs/embedded/embedded-mcp/embedded-mcp-graphql/src/main/resources/graphql/connected-user-mcp-server.graphqls
+++ b/server/ee/libs/embedded/embedded-mcp/embedded-mcp-graphql/src/main/resources/graphql/connected-user-mcp-server.graphqls
@@ -1,0 +1,25 @@
+extend type Query {
+    connectedUserMcpServers(connectedUserId: ID!): [ConnectedUserMcpServer!]!
+}
+
+extend type Mutation {
+    enableConnectedUserMcpTool(id: ID!, enable: Boolean!): Boolean
+}
+
+type ConnectedUserMcpServer {
+    id: ID!
+    name: String!
+    enabled: Boolean!
+    environmentId: ID!
+    lastModifiedDate: String
+    tools: [ConnectedUserMcpServerTool!]!
+}
+
+type ConnectedUserMcpServerTool {
+    id: ID!
+    componentName: String!
+    componentVersion: Int!
+    integrationInstanceId: ID!
+    name: String!
+    enabled: Boolean!
+}

--- a/server/ee/libs/embedded/embedded-mcp/embedded-mcp-service/src/main/java/com/bytechef/ee/embedded/mcp/facade/ConnectedUserMcpServerFacadeImpl.java
+++ b/server/ee/libs/embedded/embedded-mcp/embedded-mcp-service/src/main/java/com/bytechef/ee/embedded/mcp/facade/ConnectedUserMcpServerFacadeImpl.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2025 ByteChef
+ *
+ * Licensed under the ByteChef Enterprise license (the "Enterprise License");
+ * you may not use this file except in compliance with the Enterprise License.
+ */
+
+package com.bytechef.ee.embedded.mcp.facade;
+
+import com.bytechef.ee.embedded.configuration.domain.IntegrationInstance;
+import com.bytechef.ee.embedded.configuration.service.IntegrationInstanceService;
+import com.bytechef.ee.embedded.mcp.domain.McpIntegrationInstanceTool;
+import com.bytechef.ee.embedded.mcp.dto.ConnectedUserMcpServerDTO;
+import com.bytechef.ee.embedded.mcp.dto.ConnectedUserMcpServerToolDTO;
+import com.bytechef.ee.embedded.mcp.service.McpIntegrationInstanceToolService;
+import com.bytechef.platform.annotation.ConditionalOnEEVersion;
+import com.bytechef.platform.mcp.domain.McpComponent;
+import com.bytechef.platform.mcp.domain.McpServer;
+import com.bytechef.platform.mcp.domain.McpTool;
+import com.bytechef.platform.mcp.service.McpComponentService;
+import com.bytechef.platform.mcp.service.McpServerService;
+import com.bytechef.platform.mcp.service.McpToolService;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * @version ee
+ *
+ * @author Ivica Cardic
+ */
+@Service
+@Transactional
+@ConditionalOnEEVersion
+public class ConnectedUserMcpServerFacadeImpl implements ConnectedUserMcpServerFacade {
+
+    private final IntegrationInstanceService integrationInstanceService;
+    private final McpComponentService mcpComponentService;
+    private final McpIntegrationInstanceToolService mcpIntegrationInstanceToolService;
+    private final McpServerService mcpServerService;
+    private final McpToolService mcpToolService;
+
+    @SuppressFBWarnings("EI")
+    public ConnectedUserMcpServerFacadeImpl(
+        IntegrationInstanceService integrationInstanceService, McpComponentService mcpComponentService,
+        McpIntegrationInstanceToolService mcpIntegrationInstanceToolService, McpServerService mcpServerService,
+        McpToolService mcpToolService) {
+
+        this.integrationInstanceService = integrationInstanceService;
+        this.mcpComponentService = mcpComponentService;
+        this.mcpIntegrationInstanceToolService = mcpIntegrationInstanceToolService;
+        this.mcpServerService = mcpServerService;
+        this.mcpToolService = mcpToolService;
+    }
+
+    @Override
+    public void enableMcpTool(long mcpIntegrationInstanceToolId, boolean enable) {
+        mcpIntegrationInstanceToolService.updateEnabled(mcpIntegrationInstanceToolId, enable);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<ConnectedUserMcpServerDTO> getConnectedUserMcpServers(long connectedUserId) {
+        List<IntegrationInstance> integrationInstances = integrationInstanceService
+            .getConnectedUserIntegrationInstances(connectedUserId);
+
+        // Group per-tool rows by the MCP server they ultimately belong to so the UI can render one
+        // collapsible card per server with the user's enabled-tool list inside.
+        Map<Long, List<ConnectedUserMcpServerToolDTO>> toolsByServerId = new HashMap<>();
+        Map<Long, McpComponent> mcpComponentCache = new HashMap<>();
+
+        for (IntegrationInstance integrationInstance : integrationInstances) {
+            List<McpIntegrationInstanceTool> toolRows = mcpIntegrationInstanceToolService
+                .getMcpIntegrationInstanceTools(integrationInstance.getId());
+
+            for (McpIntegrationInstanceTool toolRow : toolRows) {
+                Optional<McpTool> mcpToolOptional = mcpToolService.fetchMcpTool(toolRow.getMcpToolId());
+
+                if (mcpToolOptional.isEmpty()) {
+                    continue;
+                }
+
+                McpTool mcpTool = mcpToolOptional.get();
+
+                McpComponent mcpComponent = mcpComponentCache.computeIfAbsent(
+                    mcpTool.getMcpComponentId(), mcpComponentService::getMcpComponent);
+
+                toolsByServerId.computeIfAbsent(mcpComponent.getMcpServerId(), key -> new ArrayList<>())
+                    .add(new ConnectedUserMcpServerToolDTO(
+                        toolRow.getId(), mcpComponent.getComponentName(), mcpComponent.getComponentVersion(),
+                        integrationInstance.getId(), mcpTool.getName(), toolRow.isEnabled()));
+            }
+        }
+
+        List<ConnectedUserMcpServerDTO> connectedUserMcpServers = new ArrayList<>();
+
+        for (Map.Entry<Long, List<ConnectedUserMcpServerToolDTO>> entry : toolsByServerId.entrySet()) {
+            McpServer mcpServer = mcpServerService.getMcpServer(entry.getKey());
+
+            List<ConnectedUserMcpServerToolDTO> tools = entry.getValue();
+
+            tools.sort(Comparator.comparing(ConnectedUserMcpServerToolDTO::name));
+
+            connectedUserMcpServers.add(new ConnectedUserMcpServerDTO(
+                mcpServer.getId(), mcpServer.getName(), mcpServer.isEnabled(), mcpServer.getEnvironmentId(),
+                mcpServer.getLastModifiedDate(), tools));
+        }
+
+        connectedUserMcpServers.sort(Comparator.comparing(ConnectedUserMcpServerDTO::name));
+
+        return connectedUserMcpServers;
+    }
+}

--- a/server/ee/libs/embedded/embedded-mcp/embedded-mcp-service/src/main/java/com/bytechef/ee/embedded/mcp/facade/ConnectedUserMcpServerFacadeImpl.java
+++ b/server/ee/libs/embedded/embedded-mcp/embedded-mcp-service/src/main/java/com/bytechef/ee/embedded/mcp/facade/ConnectedUserMcpServerFacadeImpl.java
@@ -60,6 +60,41 @@ public class ConnectedUserMcpServerFacadeImpl implements ConnectedUserMcpServerF
     }
 
     @Override
+    public void deleteConnectedUserMcpServer(long connectedUserId, long mcpServerId) {
+        // Remove every per-user tool row whose underlying McpComponent points at the given server.
+        // Since the read query rebuilds the (server -> tools) shape from these rows, removing them
+        // makes the server vanish from this user's MCP Servers tab without any soft-delete flag.
+        Map<Long, McpComponent> mcpComponentCache = new HashMap<>();
+
+        List<IntegrationInstance> integrationInstances = integrationInstanceService
+            .getConnectedUserIntegrationInstances(connectedUserId);
+
+        for (IntegrationInstance integrationInstance : integrationInstances) {
+            List<McpIntegrationInstanceTool> toolRows = mcpIntegrationInstanceToolService
+                .getMcpIntegrationInstanceTools(integrationInstance.getId());
+
+            for (McpIntegrationInstanceTool toolRow : toolRows) {
+                Optional<McpTool> mcpToolOptional = mcpToolService.fetchMcpTool(toolRow.getMcpToolId());
+
+                if (mcpToolOptional.isEmpty()) {
+                    continue;
+                }
+
+                McpTool mcpTool = mcpToolOptional.get();
+
+                McpComponent mcpComponent = mcpComponentCache.computeIfAbsent(
+                    mcpTool.getMcpComponentId(), mcpComponentService::getMcpComponent);
+
+                if (mcpComponent.getMcpServerId() != mcpServerId) {
+                    continue;
+                }
+
+                mcpIntegrationInstanceToolService.delete(toolRow.getId());
+            }
+        }
+    }
+
+    @Override
     public void enableConnectedUserMcpServer(long connectedUserId, long mcpServerId, boolean enable) {
         // Bulk-flip every per-user tool whose underlying McpComponent points at the given server.
         // Computed "server enabled for user" = any tool enabled; toggling the card thus disables or

--- a/server/ee/libs/embedded/embedded-mcp/embedded-mcp-service/src/main/java/com/bytechef/ee/embedded/mcp/facade/ConnectedUserMcpServerFacadeImpl.java
+++ b/server/ee/libs/embedded/embedded-mcp/embedded-mcp-service/src/main/java/com/bytechef/ee/embedded/mcp/facade/ConnectedUserMcpServerFacadeImpl.java
@@ -60,6 +60,41 @@ public class ConnectedUserMcpServerFacadeImpl implements ConnectedUserMcpServerF
     }
 
     @Override
+    public void enableConnectedUserMcpServer(long connectedUserId, long mcpServerId, boolean enable) {
+        // Bulk-flip every per-user tool whose underlying McpComponent points at the given server.
+        // Computed "server enabled for user" = any tool enabled; toggling the card thus disables or
+        // re-enables the whole group rather than introducing a separate per-(user, server) state row.
+        Map<Long, McpComponent> mcpComponentCache = new HashMap<>();
+
+        List<IntegrationInstance> integrationInstances = integrationInstanceService
+            .getConnectedUserIntegrationInstances(connectedUserId);
+
+        for (IntegrationInstance integrationInstance : integrationInstances) {
+            List<McpIntegrationInstanceTool> toolRows = mcpIntegrationInstanceToolService
+                .getMcpIntegrationInstanceTools(integrationInstance.getId());
+
+            for (McpIntegrationInstanceTool toolRow : toolRows) {
+                Optional<McpTool> mcpToolOptional = mcpToolService.fetchMcpTool(toolRow.getMcpToolId());
+
+                if (mcpToolOptional.isEmpty()) {
+                    continue;
+                }
+
+                McpTool mcpTool = mcpToolOptional.get();
+
+                McpComponent mcpComponent = mcpComponentCache.computeIfAbsent(
+                    mcpTool.getMcpComponentId(), mcpComponentService::getMcpComponent);
+
+                if (mcpComponent.getMcpServerId() != mcpServerId) {
+                    continue;
+                }
+
+                mcpIntegrationInstanceToolService.updateEnabled(toolRow.getId(), enable);
+            }
+        }
+    }
+
+    @Override
     public void enableMcpTool(long mcpIntegrationInstanceToolId, boolean enable) {
         mcpIntegrationInstanceToolService.updateEnabled(mcpIntegrationInstanceToolId, enable);
     }
@@ -107,8 +142,13 @@ public class ConnectedUserMcpServerFacadeImpl implements ConnectedUserMcpServerF
 
             tools.sort(Comparator.comparing(ConnectedUserMcpServerToolDTO::name));
 
+            // "enabled for user" is computed per-user, not taken from the workspace-level flag: the
+            // server is considered active for this user when at least one of their tools is enabled.
+            boolean enabledForUser = tools.stream()
+                .anyMatch(ConnectedUserMcpServerToolDTO::enabled);
+
             connectedUserMcpServers.add(new ConnectedUserMcpServerDTO(
-                mcpServer.getId(), mcpServer.getName(), mcpServer.isEnabled(), mcpServer.getEnvironmentId(),
+                mcpServer.getId(), mcpServer.getName(), enabledForUser, mcpServer.getEnvironmentId(),
                 mcpServer.getLastModifiedDate(), tools));
         }
 

--- a/server/ee/libs/embedded/embedded-mcp/embedded-mcp-service/src/main/java/com/bytechef/ee/embedded/mcp/service/McpIntegrationInstanceToolServiceImpl.java
+++ b/server/ee/libs/embedded/embedded-mcp/embedded-mcp-service/src/main/java/com/bytechef/ee/embedded/mcp/service/McpIntegrationInstanceToolServiceImpl.java
@@ -36,6 +36,11 @@ public class McpIntegrationInstanceToolServiceImpl implements McpIntegrationInst
     }
 
     @Override
+    public void delete(long id) {
+        mcpIntegrationInstanceToolRepository.deleteById(id);
+    }
+
+    @Override
     public void deleteByIntegrationInstanceId(long integrationInstanceId) {
         mcpIntegrationInstanceToolRepository.deleteByIntegrationInstanceId(integrationInstanceId);
     }


### PR DESCRIPTION
- **520 client - Render V1 DRAFT badge for unpublished connected-user project workflows**
- **520 Add enableConnectedUserProjectWorkflow GraphQL mutation**
- **520 client - Add enable/disable toggle to connected-user project workflows**
- **520 Add deleteConnectedUserProjectWorkflow GraphQL mutation**
- **520 client - Align workflows tab layout with integrations and wire delete action**
- **520 client - Drop draft-disable on workflow toggle to match Integrations tab visuals**
- **520 client - Fix component-icons stacking in connected-user integration workflow rows**
- **520 client - Wrap workflow component icons in circle-bordered chips**
- **520 client - Surface IntegrationInstanceConfiguration name to disambiguate connected-user integration rows**
- **520 Implement internal DELETE /integration-instances/{id} endpoint**
- **520 client - Wire integration row Delete and drop placeholder Delete from workflow rows**
- **520 Add connectedUserMcpServers GraphQL query and per-tool enable mutation**
- **520 client - Add MCP Servers tab to the Connected User sheet**
- **520 client - Polish connected-user nested lists: toggle alignment, section spacing, MCP server right meta**
- **520 Add enableConnectedUserMcpServer mutation and redefine card-level enabled state**
- **520 client - Add server-level enable toggle to the MCP Servers card**
- **520 Add deleteConnectedUserMcpServer mutation**
- **520 client - Wire kebab Delete on the MCP Servers card**
- **520 client - Align MCP tool toggles with the parent server card toggle**
- **520 client - Generate**
