### PR TITLE
5041 - truncate component name in Node Details Panel

### DIFF
--- a/client/src/pages/platform/workflow-editor/components/WorkflowNodeDetailsPanel.tsx
+++ b/client/src/pages/platform/workflow-editor/components/WorkflowNodeDetailsPanel.tsx
@@ -102,7 +102,7 @@ const WorkflowNodeDetailsPanel = ({
                 {currentNode?.workflowNodeName && currentWorkflowNode && (
                     <div className="flex h-full flex-col divide-y divide-muted bg-background">
                         <header className="flex items-center justify-between p-4 text-lg font-medium">
-                            <div className="flex items-center gap-2 flex-1 min-w-0">
+                            <div className="flex min-w-0 flex-1 items-center gap-2">
                                 {currentWorkflowNode.icon && (
                                     <InlineSVG
                                         className="size-8 shrink-0"
@@ -111,13 +111,14 @@ const WorkflowNodeDetailsPanel = ({
                                     />
                                 )}
 
-                                <div className="flex flex-col items-start flex-1 min-w-0">
-                                    <div className="flex items-center gap-2 min-w-0 max-w-full">
-
+                                <div className="flex min-w-0 flex-1 flex-col items-start">
+                                    <div className="flex min-w-0 max-w-full items-center gap-2">
                                         {(currentNode?.label?.length ?? 0) > 32 ? (
                                             <Tooltip>
                                                 <TooltipTrigger asChild>
-                                                    <span className="text-lg font-semibold flex-1 min-w-0 truncate">{currentNode?.label}</span>
+                                                    <span className="min-w-0 flex-1 truncate text-lg font-semibold">
+                                                        {currentNode?.label}
+                                                    </span>
                                                 </TooltipTrigger>
 
                                                 <TooltipPortal>
@@ -127,7 +128,7 @@ const WorkflowNodeDetailsPanel = ({
                                                 </TooltipPortal>
                                             </Tooltip>
                                         ) : (
-                                            <span className="text-lg font-semibold flex-1 min-w-0 truncate">
+                                            <span className="min-w-0 flex-1 truncate text-lg font-semibold">
                                                 {currentNode?.label}
                                             </span>
                                         )}
@@ -149,7 +150,7 @@ const WorkflowNodeDetailsPanel = ({
                                         )}
                                     </div>
 
-                                    <span className="text-sm text-muted-foreground truncate w-full">
+                                    <span className="w-full truncate text-sm text-muted-foreground">
                                         ({currentNode?.workflowNodeName})
                                     </span>
                                 </div>

--- a/client/src/pages/platform/workflow-editor/components/WorkflowNodeDetailsPanel.tsx
+++ b/client/src/pages/platform/workflow-editor/components/WorkflowNodeDetailsPanel.tsx
@@ -102,23 +102,41 @@ const WorkflowNodeDetailsPanel = ({
                 {currentNode?.workflowNodeName && currentWorkflowNode && (
                     <div className="flex h-full flex-col divide-y divide-muted bg-background">
                         <header className="flex items-center justify-between p-4 text-lg font-medium">
-                            <div className="flex items-center gap-2">
+                            <div className="flex items-center gap-2 flex-1 min-w-0">
                                 {currentWorkflowNode.icon && (
                                     <InlineSVG
-                                        className="size-8"
+                                        className="size-8 shrink-0"
                                         loader={<LoadingIcon className="ml-0 mr-2 size-6" />}
                                         src={currentWorkflowNode.icon}
                                     />
                                 )}
 
-                                <div className="flex flex-col items-start">
-                                    <div className="flex items-center gap-2">
-                                        <span className="text-lg font-semibold">{currentNode?.label}</span>
+                                <div className="flex flex-col items-start flex-1 min-w-0">
+                                    <div className="flex items-center gap-2 min-w-0 max-w-full">
+                                        {/* <span className="text-lg font-semibold flex-1 min-w-0 truncate">{currentNode?.label}</span> */}
+
+                                        {(currentNode?.label?.length ?? 0) > 32 ? (
+                                            <Tooltip delayDuration={300}>
+                                                <TooltipTrigger asChild>
+                                                    <span className="text-lg font-semibold flex-1 min-w-0 truncate">{currentNode?.label}</span>
+                                                </TooltipTrigger>
+
+                                                <TooltipPortal>
+                                                    <TooltipContent className="max-w-md break-all" side="bottom">
+                                                        {currentNode?.label}
+                                                    </TooltipContent>
+                                                </TooltipPortal>
+                                            </Tooltip>
+                                        ) : (
+                                            <span className="text-lg font-semibold flex-1 min-w-0 truncate">
+                                                {currentNode?.label}
+                                            </span>
+                                        )}
 
                                         {currentWorkflowNode.description && (
                                             <Tooltip delayDuration={500}>
                                                 <TooltipTrigger>
-                                                    <InfoIcon className="size-4 shrink-0" />
+                                                    <InfoIcon className="size-4" />
                                                 </TooltipTrigger>
 
                                                 <TooltipPortal>
@@ -132,7 +150,7 @@ const WorkflowNodeDetailsPanel = ({
                                         )}
                                     </div>
 
-                                    <span className="text-sm text-muted-foreground">
+                                    <span className="text-sm text-muted-foreground truncate w-full">
                                         ({currentNode?.workflowNodeName})
                                     </span>
                                 </div>

--- a/client/src/pages/platform/workflow-editor/components/WorkflowNodeDetailsPanel.tsx
+++ b/client/src/pages/platform/workflow-editor/components/WorkflowNodeDetailsPanel.tsx
@@ -113,10 +113,9 @@ const WorkflowNodeDetailsPanel = ({
 
                                 <div className="flex flex-col items-start flex-1 min-w-0">
                                     <div className="flex items-center gap-2 min-w-0 max-w-full">
-                                        {/* <span className="text-lg font-semibold flex-1 min-w-0 truncate">{currentNode?.label}</span> */}
 
                                         {(currentNode?.label?.length ?? 0) > 32 ? (
-                                            <Tooltip delayDuration={300}>
+                                            <Tooltip>
                                                 <TooltipTrigger asChild>
                                                     <span className="text-lg font-semibold flex-1 min-w-0 truncate">{currentNode?.label}</span>
                                                 </TooltipTrigger>
@@ -134,7 +133,7 @@ const WorkflowNodeDetailsPanel = ({
                                         )}
 
                                         {currentWorkflowNode.description && (
-                                            <Tooltip delayDuration={500}>
+                                            <Tooltip>
                                                 <TooltipTrigger>
                                                     <InfoIcon className="size-4" />
                                                 </TooltipTrigger>


### PR DESCRIPTION
- component name text will be truncated after exceeding allowed width
- added a tooltip to show the full name when it's truncated (logic is if it's longer than 32 characters)

https://github.com/user-attachments/assets/d4dfe8a7-7577-4d64-b145-15fe3bcc2f6f

