### PR TITLE
4870 - Add Edit button to open Subflow from Execution Island

### DIFF
--- a/client/src/pages/automation/project/Project.tsx
+++ b/client/src/pages/automation/project/Project.tsx
@@ -33,6 +33,7 @@ const Project = () => {
         cancelWorkflowQueries,
         deleteClusterElementParameterMutation,
         deleteWorkflowNodeParameterMutation,
+        handleEditSubflowClick,
         handleProjectClick,
         handleWorkflowExecutionsTestOutputCloseClick,
         invalidateWorkflowQueries,
@@ -109,6 +110,7 @@ const Project = () => {
                                 {projectId && (
                                     <WorkflowEditorLayout
                                         leftSidebarOpen={projectLeftSidebarOpen}
+                                        onEditSubflowClick={handleEditSubflowClick}
                                         runDisabled={runDisabled}
                                         showWorkflowInputs={true}
                                         workflowReferenceId={projectWorkflowId}
@@ -123,6 +125,7 @@ const Project = () => {
                             {(workflowIsRunning || workflowTestExecution) && (
                                 <WorkflowExecutionsTestOutput
                                     onCloseClick={handleWorkflowExecutionsTestOutputCloseClick}
+                                    onEditSubflowClick={handleEditSubflowClick}
                                     workflowIsRunning={workflowIsRunning}
                                     workflowTestExecution={workflowTestExecution}
                                 />

--- a/client/src/pages/automation/project/hooks/useProject.ts
+++ b/client/src/pages/automation/project/hooks/useProject.ts
@@ -272,9 +272,10 @@ export const useProject = () => {
 
         useWorkflowNodeDetailsPanelStore.getState().reset();
 
-        const restoreParam = searchParams.get('restoreExecutionPanel');
-        const fromSubflow = searchParams.get('fromSubflow');
-        const isReturningFromSubflow = restoreParam === 'true' && fromSubflow !== 'true';
+        const restorePanelParam = searchParams.get('restoreExecutionPanel');
+        const fromSubflowParam = searchParams.get('fromSubflow');
+
+        const isReturningFromSubflow = restorePanelParam === 'true' && fromSubflowParam !== 'true';
 
         if (isReturningFromSubflow) {
             const {parentWorkflowTestExecution, setParentWorkflowTestExecution, setWorkflowTestExecution} =
@@ -285,6 +286,7 @@ export const useProject = () => {
         }
 
         const storedExecution = useWorkflowEditorStore.getState().workflowTestExecution;
+
         const shouldRestorePanel = isReturningFromSubflow && !!storedExecution;
 
         if (shouldRestorePanel) {

--- a/client/src/pages/automation/project/hooks/useProject.ts
+++ b/client/src/pages/automation/project/hooks/useProject.ts
@@ -16,10 +16,15 @@ import {
     useUpdateWorkflowNodeParameterMutation,
 } from '@/shared/mutations/platform/workflowNodeParameters.mutations';
 import useUpdatePlatformWorkflowMutation from '@/shared/mutations/platform/workflows.mutations';
+import {useGetComponentDefinitionsQuery as useGetComponentDefinitionsBaseQuery} from '@/shared/queries/automation/componentDefinitions.queries';
 import {useGetWorkspaceConnectionsQuery} from '@/shared/queries/automation/connections.queries';
 import {useGetProjectCategoriesQuery} from '@/shared/queries/automation/projectCategories.queries';
 import {useGetProjectTagsQuery} from '@/shared/queries/automation/projectTags.queries';
-import {ProjectWorkflowKeys, useGetProjectWorkflowQuery} from '@/shared/queries/automation/projectWorkflows.queries';
+import {
+    ProjectWorkflowKeys,
+    useGetProjectWorkflowQuery,
+    useGetProjectWorkflowsQuery,
+} from '@/shared/queries/automation/projectWorkflows.queries';
 import {WorkflowKeys} from '@/shared/queries/automation/workflows.queries';
 import {GetComponentDefinitionsRequestI} from '@/shared/queries/platform/componentDefinitions.queries';
 import {WorkflowNodeDescriptionKeys} from '@/shared/queries/platform/workflowNodeDescriptions.queries';
@@ -27,7 +32,7 @@ import {WorkflowNodeOutputKeys} from '@/shared/queries/platform/workflowNodeOutp
 import {WorkflowNodeParameterKeys} from '@/shared/queries/platform/workflowNodeParameters.queries';
 import {useEnvironmentStore} from '@/shared/stores/useEnvironmentStore';
 import {useQueryClient} from '@tanstack/react-query';
-import {useEffect, useRef, useState} from 'react';
+import {useCallback, useEffect, useRef, useState} from 'react';
 import {PanelImperativeHandle} from 'react-resizable-panels';
 import {useNavigate, useParams, useSearchParams} from 'react-router-dom';
 import {useShallow} from 'zustand/react/shallow';
@@ -44,12 +49,15 @@ export const useProject = () => {
     const setDataPillPanelOpen = useDataPillPanelStore((state) => state.setDataPillPanelOpen);
     const currentEnvironmentId = useEnvironmentStore((state) => state.currentEnvironmentId);
     const projectLeftSidebarOpen = useProjectsLeftSidebarStore((state) => state.projectLeftSidebarOpen);
-    const {setShowBottomPanelOpen, setShowEditWorkflowDialog} = useWorkflowEditorStore(
-        useShallow((state) => ({
-            setShowBottomPanelOpen: state.setShowBottomPanelOpen,
-            setShowEditWorkflowDialog: state.setShowEditWorkflowDialog,
-        }))
-    );
+    const {setShowBottomPanelOpen, setShowEditWorkflowDialog, setShowWorkflowCodeEditorSheet, showBottomPanel} =
+        useWorkflowEditorStore(
+            useShallow((state) => ({
+                setShowBottomPanelOpen: state.setShowBottomPanelOpen,
+                setShowEditWorkflowDialog: state.setShowEditWorkflowDialog,
+                setShowWorkflowCodeEditorSheet: state.setShowWorkflowCodeEditorSheet,
+                showBottomPanel: state.showBottomPanel,
+            }))
+        );
     const setWorkflowNodeDetailsPanelOpen = useWorkflowNodeDetailsPanelStore(
         (state) => state.setWorkflowNodeDetailsPanelOpen
     );
@@ -80,8 +88,10 @@ export const useProject = () => {
         !!projectId && !!projectWorkflowId
     );
 
+    const {data: projectWorkflows} = useGetProjectWorkflowsQuery(+projectId!, !!projectId);
+
     const useGetComponentDefinitionsQuery = (request: GetComponentDefinitionsRequestI, enabled?: boolean) => {
-        return useGetComponentDefinitionsQuery(request, enabled);
+        return useGetComponentDefinitionsBaseQuery(request, enabled);
     };
 
     const useGetConnectionsQuery = (request: RequestI, enabled?: boolean) => {
@@ -168,25 +178,84 @@ export const useProject = () => {
         });
     };
 
-    const handleProjectClick = (projectId: number, projectWorkflowId: number) => {
-        navigate(`/automation/projects/${projectId}/project-workflows/${projectWorkflowId}?${searchParams}`);
-    };
+    const handleEditSubflowClick = useCallback(
+        (workflowUuid: string) => {
+            const matchingWorkflow = projectWorkflows?.find((workflow) => workflow.workflowUuid === workflowUuid);
 
-    const handleWorkflowExecutionsTestOutputCloseClick = () => {
+            if (matchingWorkflow?.projectWorkflowId) {
+                const newSearchParams = new URLSearchParams(searchParams.toString());
+
+                const existingParentId = newSearchParams.get('parentProjectWorkflowId');
+
+                if (existingParentId) {
+                    const existingChain = newSearchParams.get('parentChain');
+                    const newChain = existingChain ? `${existingChain},${existingParentId}` : existingParentId;
+
+                    newSearchParams.set('parentChain', newChain);
+                }
+
+                newSearchParams.set('fromSubflow', 'true');
+                newSearchParams.set('parentProjectWorkflowId', projectWorkflowId!);
+
+                if (showBottomPanel) {
+                    newSearchParams.set('restoreExecutionPanel', 'true');
+                }
+
+                const {parentWorkflowTestExecution, setParentWorkflowTestExecution, workflowTestExecution} =
+                    useWorkflowEditorStore.getState();
+
+                if (!parentWorkflowTestExecution) {
+                    setParentWorkflowTestExecution(workflowTestExecution);
+                }
+
+                setShowBottomPanelOpen(false);
+                setShowWorkflowCodeEditorSheet(false);
+
+                if (bottomResizablePanelRef.current) {
+                    bottomResizablePanelRef.current.resize(0);
+                }
+
+                navigate(
+                    `/automation/projects/${projectId}/project-workflows/${matchingWorkflow.projectWorkflowId}?${newSearchParams}`
+                );
+            }
+        },
+        [
+            bottomResizablePanelRef,
+            navigate,
+            projectId,
+            projectWorkflowId,
+            projectWorkflows,
+            searchParams,
+            setShowBottomPanelOpen,
+            setShowWorkflowCodeEditorSheet,
+            showBottomPanel,
+        ]
+    );
+
+    const handleProjectClick = useCallback(
+        (projectId: number, projectWorkflowId: number) => {
+            const newSearchParams = new URLSearchParams(searchParams.toString());
+
+            newSearchParams.delete('fromSubflow');
+            newSearchParams.delete('parentChain');
+            newSearchParams.delete('parentProjectWorkflowId');
+            newSearchParams.delete('restoreExecutionPanel');
+
+            navigate(`/automation/projects/${projectId}/project-workflows/${projectWorkflowId}?${newSearchParams}`);
+        },
+        [navigate, searchParams]
+    );
+
+    const handleWorkflowExecutionsTestOutputCloseClick = useCallback(() => {
         setShowBottomPanelOpen(false);
 
         if (bottomResizablePanelRef.current) {
             bottomResizablePanelRef.current.resize(0);
         }
-    };
+    }, [bottomResizablePanelRef, setShowBottomPanelOpen]);
 
     useEffect(() => {
-        setShowBottomPanelOpen(false);
-
-        if (bottomResizablePanelRef.current) {
-            bottomResizablePanelRef.current.resize(0);
-        }
-
         // Reset state when the component unmounts
         return () => {
             setCopilotPanelOpen(false);
@@ -202,6 +271,36 @@ export const useProject = () => {
         setWorkflowTestChatPanelOpen(false);
 
         useWorkflowNodeDetailsPanelStore.getState().reset();
+
+        const restoreParam = searchParams.get('restoreExecutionPanel');
+        const fromSubflow = searchParams.get('fromSubflow');
+        const isReturningFromSubflow = restoreParam === 'true' && fromSubflow !== 'true';
+
+        if (isReturningFromSubflow) {
+            const {parentWorkflowTestExecution, setParentWorkflowTestExecution, setWorkflowTestExecution} =
+                useWorkflowEditorStore.getState();
+
+            setWorkflowTestExecution(parentWorkflowTestExecution);
+            setParentWorkflowTestExecution(undefined);
+        }
+
+        const storedExecution = useWorkflowEditorStore.getState().workflowTestExecution;
+        const shouldRestorePanel = isReturningFromSubflow && !!storedExecution;
+
+        if (shouldRestorePanel) {
+            setShowBottomPanelOpen(true);
+
+            if (bottomResizablePanelRef.current) {
+                bottomResizablePanelRef.current.resize(350);
+            }
+        } else {
+            setShowBottomPanelOpen(false);
+
+            if (bottomResizablePanelRef.current) {
+                bottomResizablePanelRef.current.resize(0);
+            }
+        }
+
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [projectWorkflowId]);
 
@@ -236,6 +335,7 @@ export const useProject = () => {
         deleteClusterElementParameterMutation,
         deleteWorkflowNodeParameterMutation,
         filterData,
+        handleEditSubflowClick,
         handleProjectClick,
         handleWorkflowExecutionsTestOutputCloseClick,
         invalidateWorkflowQueries,

--- a/client/src/pages/platform/workflow-editor/WorkflowEditorLayout.tsx
+++ b/client/src/pages/platform/workflow-editor/WorkflowEditorLayout.tsx
@@ -22,6 +22,7 @@ import {useParams} from 'react-router-dom';
 import {twMerge} from 'tailwind-merge';
 import {useShallow} from 'zustand/shallow';
 
+import SubflowBanner from './components/SubflowBanner';
 import WorkflowCodeEditorSheet from './components/WorkflowCodeEditorSheet';
 import {
     DataPillPanelSkeleton,
@@ -43,6 +44,7 @@ const WorkflowNodesSidebar = lazy(() => import('./components/WorkflowNodesSideba
 interface WorkflowEditorLayoutProps {
     includeComponents?: string[];
     leftSidebarOpen?: boolean;
+    onEditSubflowClick?: (workflowUuid: string) => void;
     runDisabled: boolean;
     showCopilot?: boolean;
     showWorkflowInputs: boolean;
@@ -52,6 +54,7 @@ interface WorkflowEditorLayoutProps {
 const WorkflowEditorLayout = ({
     includeComponents,
     leftSidebarOpen,
+    onEditSubflowClick,
     runDisabled,
     showCopilot = true,
     showWorkflowInputs,
@@ -192,6 +195,8 @@ const WorkflowEditorLayout = ({
                     copilotLayoutShifted && 'mr-0'
                 )}
             >
+                <SubflowBanner />
+
                 {componentDefinitions && taskDispatcherDefinitions && (
                     <Suspense>
                         <WorkflowEditor
@@ -286,6 +291,7 @@ const WorkflowEditorLayout = ({
             {showWorkflowCodeEditorSheet && (
                 <WorkflowCodeEditorSheet
                     invalidateWorkflowQueries={invalidateWorkflowQueries!}
+                    onEditSubflowClick={onEditSubflowClick}
                     onSheetOpenClose={setShowWorkflowCodeEditorSheet}
                     runDisabled={runDisabled}
                     sheetOpen={showWorkflowCodeEditorSheet}

--- a/client/src/pages/platform/workflow-editor/components/SubflowBanner.tsx
+++ b/client/src/pages/platform/workflow-editor/components/SubflowBanner.tsx
@@ -1,0 +1,82 @@
+import {InfoIcon, Undo2Icon, XIcon} from 'lucide-react';
+import {useEffect, useState} from 'react';
+import {useNavigate, useParams, useSearchParams} from 'react-router-dom';
+import {twMerge} from 'tailwind-merge';
+
+const SubflowBanner = ({className}: {className?: string}) => {
+    const [dismissed, setDismissed] = useState(false);
+
+    const [searchParams] = useSearchParams();
+    const navigate = useNavigate();
+    const {projectId, projectWorkflowId} = useParams();
+
+    const fromSubflow = searchParams.get('fromSubflow');
+    const parentProjectWorkflowId = searchParams.get('parentProjectWorkflowId');
+
+    useEffect(() => {
+        setDismissed(false);
+    }, [projectWorkflowId]);
+
+    if (fromSubflow !== 'true' || dismissed) {
+        return null;
+    }
+
+    const handleReturnClick = () => {
+        if (projectId && parentProjectWorkflowId) {
+            const newSearchParams = new URLSearchParams(searchParams.toString());
+            const parentChain = newSearchParams.get('parentChain');
+
+            if (parentChain) {
+                const chainItems = parentChain.split(',');
+                const grandparentId = chainItems.pop() ?? '';
+
+                if (chainItems.length > 0) {
+                    newSearchParams.set('parentChain', chainItems.join(','));
+                } else {
+                    newSearchParams.delete('parentChain');
+                }
+
+                newSearchParams.set('parentProjectWorkflowId', grandparentId);
+            } else {
+                newSearchParams.delete('fromSubflow');
+                newSearchParams.delete('parentProjectWorkflowId');
+            }
+
+            navigate(
+                `/automation/projects/${projectId}/project-workflows/${parentProjectWorkflowId}?${newSearchParams}`
+            );
+        } else {
+            navigate(-1);
+        }
+    };
+
+    return (
+        <div
+            className={twMerge(
+                'absolute left-2 top-2 z-10 flex w-[483px] items-center gap-2 rounded-md border border-stroke-warning-secondary bg-surface-warning-secondary px-3 py-2',
+                className
+            )}
+        >
+            <InfoIcon className="size-6 shrink-0 text-content-onwarning" />
+
+            <span className="flex-1 text-sm font-medium text-content-neutral-primary">
+                Currently inside of a subflow.
+            </span>
+
+            <button
+                className="flex items-center gap-1 text-sm font-medium text-content-neutral-primary hover:underline"
+                onClick={handleReturnClick}
+            >
+                <Undo2Icon className="size-4" />
+
+                <span>Return to parent flow</span>
+            </button>
+
+            <button className="opacity-50 hover:opacity-100" onClick={() => setDismissed(true)}>
+                <XIcon className="size-4 text-content-neutral-primary" />
+            </button>
+        </div>
+    );
+};
+
+export default SubflowBanner;

--- a/client/src/pages/platform/workflow-editor/components/SubflowBanner.tsx
+++ b/client/src/pages/platform/workflow-editor/components/SubflowBanner.tsx
@@ -1,3 +1,4 @@
+import Button from '@/components/Button/Button';
 import {InfoIcon, Undo2Icon, XIcon} from 'lucide-react';
 import {useEffect, useState} from 'react';
 import {useNavigate, useParams, useSearchParams} from 'react-router-dom';
@@ -10,24 +11,26 @@ const SubflowBanner = ({className}: {className?: string}) => {
     const navigate = useNavigate();
     const {projectId, projectWorkflowId} = useParams();
 
-    const fromSubflow = searchParams.get('fromSubflow');
-    const parentProjectWorkflowId = searchParams.get('parentProjectWorkflowId');
+    const fromSubflowParam = searchParams.get('fromSubflow');
+    const parentProjectWorkflowIdParam = searchParams.get('parentProjectWorkflowId');
 
     useEffect(() => {
         setDismissed(false);
     }, [projectWorkflowId]);
 
-    if (fromSubflow !== 'true' || dismissed) {
+    if (fromSubflowParam !== 'true' || dismissed) {
         return null;
     }
 
     const handleReturnClick = () => {
-        if (projectId && parentProjectWorkflowId) {
+        if (projectId && parentProjectWorkflowIdParam) {
             const newSearchParams = new URLSearchParams(searchParams.toString());
+
             const parentChain = newSearchParams.get('parentChain');
 
             if (parentChain) {
                 const chainItems = parentChain.split(',');
+
                 const grandparentId = chainItems.pop() ?? '';
 
                 if (chainItems.length > 0) {
@@ -43,7 +46,7 @@ const SubflowBanner = ({className}: {className?: string}) => {
             }
 
             navigate(
-                `/automation/projects/${projectId}/project-workflows/${parentProjectWorkflowId}?${newSearchParams}`
+                `/automation/projects/${projectId}/project-workflows/${parentProjectWorkflowIdParam}?${newSearchParams}`
             );
         } else {
             navigate(-1);
@@ -59,22 +62,28 @@ const SubflowBanner = ({className}: {className?: string}) => {
         >
             <InfoIcon className="size-6 shrink-0 text-content-onwarning" />
 
-            <span className="flex-1 text-sm font-medium text-content-neutral-primary">
+            <span className="flex-1 whitespace-nowrap text-sm font-medium text-content-neutral-primary">
                 Currently inside of a subflow.
             </span>
 
-            <button
-                className="flex items-center gap-1 text-sm font-medium text-content-neutral-primary hover:underline"
-                onClick={handleReturnClick}
-            >
-                <Undo2Icon className="size-4" />
+            <div className="flex shrink-0 items-center gap-1">
+                <Button
+                    className="active:text-content-primary text-sm font-medium hover:bg-transparent hover:underline active:bg-transparent"
+                    icon={<Undo2Icon className="size-4" />}
+                    label="Return to parent flow"
+                    onClick={handleReturnClick}
+                    size="xs"
+                    variant="ghost"
+                />
 
-                <span>Return to parent flow</span>
-            </button>
-
-            <button className="opacity-50 hover:opacity-100" onClick={() => setDismissed(true)}>
-                <XIcon className="size-4 text-content-neutral-primary" />
-            </button>
+                <Button
+                    className="active:text-content-primary opacity-50 hover:bg-transparent hover:opacity-100 active:bg-transparent"
+                    icon={<XIcon />}
+                    onClick={() => setDismissed(true)}
+                    size="iconXs"
+                    variant="ghost"
+                />
+            </div>
         </div>
     );
 };

--- a/client/src/pages/platform/workflow-editor/components/WorkflowCodeEditorSheet.tsx
+++ b/client/src/pages/platform/workflow-editor/components/WorkflowCodeEditorSheet.tsx
@@ -8,6 +8,7 @@ import {Tooltip, TooltipContent, TooltipTrigger} from '@/components/ui/tooltip';
 import WorkflowExecutionsTestOutput from '@/pages/platform/workflow-editor/components/WorkflowExecutionsTestOutput';
 import WorkflowTestConfigurationDialog from '@/pages/platform/workflow-editor/components/workflow-test-configuration/WorkflowTestConfigurationDialog';
 import useWorkflowCodeEditorSheet from '@/pages/platform/workflow-editor/hooks/useWorkflowCodeEditorSheet';
+import useWorkflowEditorStore from '@/pages/platform/workflow-editor/stores/useWorkflowEditorStore';
 import MonacoEditorLoader from '@/shared/components/MonacoEditorLoader';
 import CopilotPanel from '@/shared/components/copilot/CopilotPanel';
 import {Workflow, WorkflowTestConfiguration} from '@/shared/middleware/platform/configuration';
@@ -30,6 +31,7 @@ import {twMerge} from 'tailwind-merge';
 
 interface WorkflowCodeEditorSheetProps {
     invalidateWorkflowQueries: () => void;
+    onEditSubflowClick?: (workflowUuid: string) => void;
     onSheetOpenClose: (open: boolean) => void;
     runDisabled: boolean;
     sheetOpen: boolean;
@@ -42,6 +44,7 @@ const MonacoEditor = lazy(() => import('@/shared/components/MonacoEditorWrapper'
 
 const WorkflowCodeEditorSheet = ({
     invalidateWorkflowQueries,
+    onEditSubflowClick,
     onSheetOpenClose,
     runDisabled,
     sheetOpen,
@@ -78,6 +81,7 @@ const WorkflowCodeEditorSheet = ({
     } = useWorkflowCodeEditorSheet({invalidateWorkflowQueries, onSheetOpenClose, workflow});
 
     const ff_4076 = useFeatureFlagsStore()('ff-4076');
+    const showBottomPanel = useWorkflowEditorStore((state) => state.showBottomPanel);
 
     return (
         <Sheet onOpenChange={handleOpenChange} open={sheetOpen}>
@@ -271,7 +275,7 @@ const WorkflowCodeEditorSheet = ({
                                 </ResizablePanel>
                             )}
 
-                            {(workflowIsRunning || workflowTestExecution) && (
+                            {(workflowIsRunning || (workflowTestExecution && showBottomPanel)) && (
                                 <ResizablePanel className="rounded-lg bg-surface-neutral-primary" defaultSize={500}>
                                     {workflowIsRunning ? (
                                         <div className="flex size-full items-center justify-center gap-x-1 p-3 text-center">
@@ -284,6 +288,7 @@ const WorkflowCodeEditorSheet = ({
                                     ) : (
                                         workflowTestExecution && (
                                             <WorkflowExecutionsTestOutput
+                                                onEditSubflowClick={onEditSubflowClick}
                                                 resizablePanelSize={400}
                                                 workflowIsRunning={workflowIsRunning}
                                                 workflowTestExecution={workflowTestExecution}

--- a/client/src/pages/platform/workflow-editor/components/WorkflowExecutionsTestOutput.tsx
+++ b/client/src/pages/platform/workflow-editor/components/WorkflowExecutionsTestOutput.tsx
@@ -14,6 +14,7 @@ import useWorkflowExecutions from './properties/hooks/useWorkflowExecutions';
 
 interface WorkflowExecutionsTestOutputProps {
     onCloseClick?: () => void;
+    onEditSubflowClick?: (workflowUuid: string) => void;
     resizablePanelSize?: number;
     workflowIsRunning: boolean;
     workflowTestExecution?: WorkflowTestExecution;
@@ -21,6 +22,7 @@ interface WorkflowExecutionsTestOutputProps {
 
 const WorkflowExecutionsTestOutput = ({
     onCloseClick,
+    onEditSubflowClick,
     resizablePanelSize = 300,
     workflowIsRunning,
     workflowTestExecution,
@@ -51,7 +53,7 @@ const WorkflowExecutionsTestOutput = ({
                 )}
 
                 {onCloseClick && (
-                    <button className="p-2" onClick={() => onCloseClick()}>
+                    <button className="p-2" onClick={onCloseClick}>
                         <ChevronDownIcon className="h-5" />
                     </button>
                 )}
@@ -126,8 +128,9 @@ const WorkflowExecutionsTestOutput = ({
                                             <WorkflowExecutionsTabsPanel
                                                 activeTab={activeTab}
                                                 dialogOpen={dialogOpen}
-                                                isEditorEnvironment={true}
+                                                isEditorEnvironment
                                                 job={job}
+                                                onEditSubflowClick={onEditSubflowClick}
                                                 selectedItem={selectedExecution}
                                                 setActiveTab={setActiveTab}
                                                 setDialogOpen={setDialogOpen}

--- a/client/src/pages/platform/workflow-editor/components/properties/hooks/useWorkflowExecutions.ts
+++ b/client/src/pages/platform/workflow-editor/components/properties/hooks/useWorkflowExecutions.ts
@@ -10,7 +10,7 @@ import {
 } from '@/shared/middleware/platform/workflow/test';
 import {TabValueType} from '@/shared/types';
 import getDeepestFailedExecution from '@/shared/util/getDeepestFailedExecution';
-import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import {useEffect, useMemo, useRef, useState} from 'react';
 
 type UseWorkflowExecutionsReturnType = {
     activeTab: TabValueType;
@@ -80,11 +80,11 @@ const useWorkflowExecutions = ({
         stackTrace: [],
     };
 
-    const handleExecutionClick = useCallback((taskExecution: TaskExecution | TriggerExecution) => {
+    const handleExecutionClick = (taskExecution: TaskExecution | TriggerExecution) => {
         setActiveTab(taskExecution.error ? 'error' : 'output');
 
         setSelectedExecution(taskExecution);
-    }, []);
+    };
 
     useEffect(() => {
         setSelectedExecution(getInitialSelectedItem(workflowTestExecution));

--- a/client/src/pages/platform/workflow-editor/components/properties/hooks/useWorkflowExecutions.ts
+++ b/client/src/pages/platform/workflow-editor/components/properties/hooks/useWorkflowExecutions.ts
@@ -10,7 +10,7 @@ import {
 } from '@/shared/middleware/platform/workflow/test';
 import {TabValueType} from '@/shared/types';
 import getDeepestFailedExecution from '@/shared/util/getDeepestFailedExecution';
-import {useEffect, useMemo, useRef, useState} from 'react';
+import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 
 type UseWorkflowExecutionsReturnType = {
     activeTab: TabValueType;
@@ -80,11 +80,11 @@ const useWorkflowExecutions = ({
         stackTrace: [],
     };
 
-    const handleExecutionClick = (taskExecution: TaskExecution | TriggerExecution) => {
+    const handleExecutionClick = useCallback((taskExecution: TaskExecution | TriggerExecution) => {
         setActiveTab(taskExecution.error ? 'error' : 'output');
 
         setSelectedExecution(taskExecution);
-    };
+    }, []);
 
     useEffect(() => {
         setSelectedExecution(getInitialSelectedItem(workflowTestExecution));

--- a/client/src/pages/platform/workflow-editor/hooks/useWorkflowCodeEditorSheet.ts
+++ b/client/src/pages/platform/workflow-editor/hooks/useWorkflowCodeEditorSheet.ts
@@ -15,6 +15,7 @@ import {PanelImperativeHandle, usePanelCallbackRef} from 'react-resizable-panels
 import {useShallow} from 'zustand/shallow';
 
 import useWorkflowDataStore from '../stores/useWorkflowDataStore';
+import useWorkflowEditorStore from '../stores/useWorkflowEditorStore';
 
 import type {editor} from 'monaco-editor';
 
@@ -75,6 +76,7 @@ const useWorkflowCodeEditorSheet = ({
     const ai = useApplicationInfoStore((state) => state.ai);
     const setContext = useCopilotStore((state) => state.setContext);
     const currentEnvironmentId = useEnvironmentStore((state) => state.currentEnvironmentId);
+    const setShowBottomPanelOpen = useWorkflowEditorStore((state) => state.setShowBottomPanelOpen);
 
     const {projectName} = useWorkflowDataStore(
         useShallow((state) => ({
@@ -97,6 +99,7 @@ const useWorkflowCodeEditorSheet = ({
             setWorkflowTestExecution(execution);
             setWorkflowIsRunning(false);
             setJobId(null);
+            setShowBottomPanelOpen(true);
         },
         onStart: (jobId) => setJobId(jobId),
         workflowId: workflow.id!,
@@ -244,7 +247,9 @@ const useWorkflowCodeEditorSheet = ({
     }, [workflow.definition]);
 
     useEffect(() => {
-        if (!workflow.id || currentEnvironmentId === undefined) return;
+        if (!workflow.id || currentEnvironmentId === undefined) {
+            return;
+        }
 
         const jobId = getPersistedJobId();
 

--- a/client/src/pages/platform/workflow-editor/stores/useWorkflowEditorStore.ts
+++ b/client/src/pages/platform/workflow-editor/stores/useWorkflowEditorStore.ts
@@ -55,6 +55,9 @@ export interface WorkflowEditorI {
     showWorkflowOutputsSheet: boolean;
     setShowWorkflowOutputsSheet: (showWorkflowOutputsSheet: boolean) => void;
 
+    parentWorkflowTestExecution?: WorkflowTestExecution;
+    setParentWorkflowTestExecution: (parentWorkflowTestExecution?: WorkflowTestExecution) => void;
+
     workflowTestExecution?: WorkflowTestExecution;
     setWorkflowTestExecution: (workflowTestExecution?: WorkflowTestExecution) => void;
 }
@@ -150,6 +153,12 @@ const useWorkflowEditorStore = create<WorkflowEditorI>()(
             setWorkflowIsRunning: (workflowIsRunning) =>
                 set(() => ({
                     workflowIsRunning: workflowIsRunning,
+                })),
+
+            parentWorkflowTestExecution: undefined,
+            setParentWorkflowTestExecution: (parentWorkflowTestExecution?: WorkflowTestExecution) =>
+                set(() => ({
+                    parentWorkflowTestExecution,
                 })),
 
             workflowTestExecution: undefined,

--- a/client/src/shared/components/workflow-executions/WorkflowExecutionsTabsPanel.tsx
+++ b/client/src/shared/components/workflow-executions/WorkflowExecutionsTabsPanel.tsx
@@ -83,10 +83,12 @@ const WorkflowExecutionsTabsPanel = ({
           ? (selectedItem as TaskExecution).workflowTask?.name
           : undefined;
 
-    const subflowWorkflowUuid =
+    const subflowTaskExecution =
         !isTriggerExecution && selectedItem && 'workflowTask' in selectedItem
-            ? ((selectedItem as TaskExecution).workflowTask?.parameters?.workflowUuid as string | undefined)
+            ? (selectedItem as TaskExecution)
             : undefined;
+
+    const subflowWorkflowUuid = subflowTaskExecution?.workflowTask?.parameters?.workflowUuid as string | undefined;
 
     return (
         <Tabs
@@ -104,14 +106,13 @@ const WorkflowExecutionsTabsPanel = ({
                     <span className="text-xs text-muted-foreground">{`(${workflowNodeName})`}</span>
 
                     {subflowWorkflowUuid && onEditSubflowClick && (
-                        <button
-                            className="flex items-center justify-center gap-1 rounded-md border border-stroke-neutral-secondary bg-surface-neutral-primary px-1.5 py-0.5"
+                        <Button
+                            icon={<SquarePenIcon />}
+                            label="Edit"
                             onClick={() => onEditSubflowClick(subflowWorkflowUuid)}
-                        >
-                            <SquarePenIcon className="size-3 text-content-neutral-primary" />
-
-                            <span className="text-[12px] font-medium leading-4 text-content-neutral-primary">Edit</span>
-                        </button>
+                            size="xxs"
+                            variant="outline"
+                        />
                     )}
                 </div>
 

--- a/client/src/shared/components/workflow-executions/WorkflowExecutionsTabsPanel.tsx
+++ b/client/src/shared/components/workflow-executions/WorkflowExecutionsTabsPanel.tsx
@@ -17,17 +17,18 @@ import {getDisplayValue, hasDialogContentValue} from '@/shared/components/workfl
 import {Job, TaskExecution, TriggerExecution} from '@/shared/middleware/automation/workflow/execution';
 import {useFeatureFlagsStore} from '@/shared/stores/useFeatureFlagsStore';
 import {TabValueType} from '@/shared/types';
-import {AlertCircleIcon, ExpandIcon, ScrollTextIcon} from 'lucide-react';
-import {useMemo} from 'react';
+import {AlertCircleIcon, ExpandIcon, ScrollTextIcon, SquarePenIcon} from 'lucide-react';
+import {useCallback, useMemo} from 'react';
 
 interface WorkflowExecutionsTabsPanelProps {
     activeTab: TabValueType;
-    setActiveTab: (value: TabValueType) => void;
     dialogOpen: boolean;
-    setDialogOpen: (open: boolean) => void;
-    selectedItem: TriggerExecution | TaskExecution | undefined;
-    job: Job;
     isEditorEnvironment?: boolean;
+    job: Job;
+    onEditSubflowClick?: (workflowUuid: string) => void;
+    selectedItem: TriggerExecution | TaskExecution | undefined;
+    setActiveTab: (value: TabValueType) => void;
+    setDialogOpen: (open: boolean) => void;
     triggerExecution?: TriggerExecution;
 }
 
@@ -36,12 +37,15 @@ const WorkflowExecutionsTabsPanel = ({
     dialogOpen,
     isEditorEnvironment = false,
     job,
+    onEditSubflowClick,
     selectedItem,
     setActiveTab,
     setDialogOpen,
     triggerExecution,
 }: WorkflowExecutionsTabsPanelProps) => {
     const ff_2896 = useFeatureFlagsStore()('ff-2896');
+
+    const handleValueChange = useCallback((value: string) => setActiveTab(value as TabValueType), [setActiveTab]);
 
     const displayValue = useMemo(
         () =>
@@ -79,11 +83,16 @@ const WorkflowExecutionsTabsPanel = ({
           ? (selectedItem as TaskExecution).workflowTask?.name
           : undefined;
 
+    const subflowWorkflowUuid =
+        !isTriggerExecution && selectedItem && 'workflowTask' in selectedItem
+            ? ((selectedItem as TaskExecution).workflowTask?.parameters?.workflowUuid as string | undefined)
+            : undefined;
+
     return (
         <Tabs
             className="flex h-full flex-col"
             defaultValue={activeTab}
-            onValueChange={(value) => setActiveTab(value as TabValueType)}
+            onValueChange={handleValueChange}
             value={activeTab}
         >
             <div className="flex items-center justify-between p-3">
@@ -93,6 +102,17 @@ const WorkflowExecutionsTabsPanel = ({
                     <span className="text-sm font-semibold">{itemLabel || selectedItem?.title}</span>
 
                     <span className="text-xs text-muted-foreground">{`(${workflowNodeName})`}</span>
+
+                    {subflowWorkflowUuid && onEditSubflowClick && (
+                        <button
+                            className="flex items-center justify-center gap-1 rounded-md border border-stroke-neutral-secondary bg-surface-neutral-primary px-1.5 py-0.5"
+                            onClick={() => onEditSubflowClick(subflowWorkflowUuid)}
+                        >
+                            <SquarePenIcon className="size-3 text-content-neutral-primary" />
+
+                            <span className="text-[12px] font-medium leading-4 text-content-neutral-primary">Edit</span>
+                        </button>
+                    )}
                 </div>
 
                 <div className="flex items-center gap-2 text-xs text-muted-foreground">


### PR DESCRIPTION
fixes #4870 

## Description: 
- Adds an Edit button to the subflow task detail panel in the Execution Island. 
- Clicking it navigates to the subflow's workflow editor, closes the execution panel,  and shows a "Currently inside a subflow" banner with a "Return to parent flow" button.
- On return, the parent's execution panel is restored if it was open.
- Nested subflow navigation is supported via a parentChain URL param stack.
- Opening subflow executions is out of scope and tracked separately.

<img width="840" height="332" alt="image" src="https://github.com/user-attachments/assets/61fc2a5d-c865-4a8c-8cca-292c24007835" />
<img width="1009" height="179" alt="image" src="https://github.com/user-attachments/assets/a5306177-c475-40f7-a3f7-86acd69caf87" />

## Video example:
[Screencast from 2026-05-28 16-11-11.webm](https://github.com/user-attachments/assets/e982572f-a89e-49b2-93d7-d47a565e3e14)


## Possible enhancements for nested subflow executions:

Multi-level execution snapshot - currently only the top-level parent's execution is snapshotted. A map keyed by projectWorkflowId (mirroring the parentChain URL stack) would restore execution panels at every level of nesting, not just the root.
Intermediate panel restore - returning from subflow2 → subflow1 currently doesn't restore subflow1's execution panel (only root restore is implemented). Would require the multi-level snapshot above.
Execution panel per workflow - instead of a single global workflowTestExecution slot in Zustand, key executions by projectWorkflowId so each workflow remembers its own last execution independently of navigation.