### PR TITLE
5122 client - Show cluster element action description instead of component description

### DIFF
--- a/client/src/pages/platform/workflow-editor/components/WorkflowNodeDetailsPanel.tsx
+++ b/client/src/pages/platform/workflow-editor/components/WorkflowNodeDetailsPanel.tsx
@@ -23,6 +23,7 @@ import {Link} from 'react-router-dom';
 import {twMerge} from 'tailwind-merge';
 
 import {getClusterElementsLabel} from '../../cluster-element-editor/utils/clusterElementsUtils';
+import getNodeOperationDescription from '../utils/getNodeOperationDescription';
 import {DescriptionTabSkeleton, FieldsetSkeleton, PropertiesTabSkeleton} from './WorkflowEditorSkeletons';
 import useWorkflowNodeDetailsPanel from './hooks/useWorkflowNodeDetailsPanel';
 
@@ -180,15 +181,15 @@ const WorkflowNodeDetailsPanel = ({
                                         currentNode.clusterElementType &&
                                         getClusterElementsLabel(currentNode.clusterElementType)
                                     }
-                                    description={
-                                        currentNode?.trigger
-                                            ? currentTriggerDefinition?.description
-                                            : !!currentNode?.clusterElementType &&
-                                                currentNode?.workflowNodeName !==
-                                                    rootClusterElementNodeData?.workflowNodeName
-                                              ? currentComponentDefinition?.description
-                                              : currentActionDefinition?.description
-                                    }
+                                    description={getNodeOperationDescription({
+                                        actionDescription: currentActionDefinition?.description,
+                                        clusterElementOperations: filteredClusterElementOperations,
+                                        currentNode,
+                                        currentOperationName,
+                                        rootClusterElementWorkflowNodeName:
+                                            rootClusterElementNodeData?.workflowNodeName,
+                                        triggerDescription: currentTriggerDefinition?.description,
+                                    })}
                                     handleValueChange={handleOperationSelectChange}
                                     operations={
                                         (currentNode?.trigger

--- a/client/src/pages/platform/workflow-editor/utils/getNodeOperationDescription.test.ts
+++ b/client/src/pages/platform/workflow-editor/utils/getNodeOperationDescription.test.ts
@@ -1,0 +1,61 @@
+import {NodeDataType} from '@/shared/types';
+import {describe, expect, it} from 'vitest';
+
+import getNodeOperationDescription from './getNodeOperationDescription';
+
+describe('getNodeOperationDescription', () => {
+    it('returns the trigger description for trigger nodes', () => {
+        const description = getNodeOperationDescription({
+            actionDescription: 'action description',
+            currentNode: {trigger: true, workflowNodeName: 'trigger_1'} as NodeDataType,
+            currentOperationName: 'newEmail',
+            triggerDescription: 'trigger description',
+        });
+
+        expect(description).toBe('trigger description');
+    });
+
+    it('returns the action description for regular action nodes', () => {
+        const description = getNodeOperationDescription({
+            actionDescription: 'action description',
+            currentNode: {workflowNodeName: 'gmail_1'} as NodeDataType,
+            currentOperationName: 'sendEmail',
+        });
+
+        expect(description).toBe('action description');
+    });
+
+    it('returns the selected operation description for a non-root cluster element with multiple actions', () => {
+        const description = getNodeOperationDescription({
+            actionDescription: 'fallback action description',
+            clusterElementOperations: [
+                {description: 'Reads a document.', name: 'read'},
+                {description: 'Writes a document.', name: 'write'},
+            ],
+            currentNode: {
+                clusterElementType: 'DOCUMENT_READER',
+                workflowNodeName: 'documentReader_1',
+            } as NodeDataType,
+            currentOperationName: 'write',
+            rootClusterElementWorkflowNodeName: 'knowledgeBase_1',
+        });
+
+        // Regression guard for #5122: must be the selected action description, not the component description.
+        expect(description).toBe('Writes a document.');
+    });
+
+    it('falls back to the action description for the root cluster element node', () => {
+        const description = getNodeOperationDescription({
+            actionDescription: 'root component description',
+            clusterElementOperations: [{description: 'Reads a document.', name: 'read'}],
+            currentNode: {
+                clusterElementType: 'DOCUMENT_READER',
+                workflowNodeName: 'knowledgeBase_1',
+            } as NodeDataType,
+            currentOperationName: 'read',
+            rootClusterElementWorkflowNodeName: 'knowledgeBase_1',
+        });
+
+        expect(description).toBe('root component description');
+    });
+});

--- a/client/src/pages/platform/workflow-editor/utils/getNodeOperationDescription.ts
+++ b/client/src/pages/platform/workflow-editor/utils/getNodeOperationDescription.ts
@@ -1,0 +1,37 @@
+import {NodeDataType} from '@/shared/types';
+
+interface OperationWithDescriptionI {
+    description?: string;
+    name: string;
+}
+
+interface GetNodeOperationDescriptionProps {
+    actionDescription?: string;
+    clusterElementOperations?: Array<OperationWithDescriptionI>;
+    currentNode?: NodeDataType;
+    currentOperationName: string;
+    rootClusterElementWorkflowNodeName?: string;
+    triggerDescription?: string;
+}
+
+export default function getNodeOperationDescription({
+    actionDescription,
+    clusterElementOperations,
+    currentNode,
+    currentOperationName,
+    rootClusterElementWorkflowNodeName,
+    triggerDescription,
+}: GetNodeOperationDescriptionProps): string | undefined {
+    if (currentNode?.trigger) {
+        return triggerDescription;
+    }
+
+    const isNonRootClusterElement =
+        !!currentNode?.clusterElementType && currentNode.workflowNodeName !== rootClusterElementWorkflowNodeName;
+
+    if (isNonRootClusterElement) {
+        return clusterElementOperations?.find((operation) => operation.name === currentOperationName)?.description;
+    }
+
+    return actionDescription;
+}


### PR DESCRIPTION
The operation selector tooltip in the node details panel showed the parent
component description for non-root cluster element nodes. Resolve the currently
selected cluster element operation's description instead, via a new tested
getNodeOperationDescription helper.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
