### PR TITLE
5121 client - Fix cluster node rendering after Tailwind v4 upgrade

### DIFF
--- a/client/src/pages/platform/workflow-editor/nodes/AiAgentNode.tsx
+++ b/client/src/pages/platform/workflow-editor/nodes/AiAgentNode.tsx
@@ -355,7 +355,7 @@ const AiAgentNode = ({data, id}: {data: NodeDataType; id: string}) => {
                 >
                     <HoverCardTrigger>
                         <Button
-                            className="flex size-18 w-full flex-col items-center justify-center rounded-md border-2 border-stroke-neutral-tertiary bg-surface-neutral-primary p-4 shadow-sm hover:border-stroke-brand-secondary-hover hover:bg-surface-neutral-primary hover:shadow-none focus-visible:ring-stroke-brand-focus active:bg-surface-neutral-primary"
+                            className="flex h-auto min-h-18 w-full flex-col items-center justify-center rounded-md border-2 border-stroke-neutral-tertiary bg-surface-neutral-primary p-4 shadow-sm hover:border-stroke-brand-secondary-hover hover:bg-surface-neutral-primary hover:shadow-none focus-visible:ring-stroke-brand-focus active:bg-surface-neutral-primary"
                             onClick={handleNodeClick}
                         >
                             <span className="self-center text-content-neutral-primary [&_svg]:size-9">

--- a/client/src/pages/platform/workflow-editor/nodes/WorkflowNode.tsx
+++ b/client/src/pages/platform/workflow-editor/nodes/WorkflowNode.tsx
@@ -4,7 +4,7 @@ import WorkflowNodeContextMenu from '@/pages/platform/workflow-editor/components
 import WorkflowNodesPopoverMenu from '@/pages/platform/workflow-editor/components/WorkflowNodesPopoverMenu';
 import {useWorkflowEditor} from '@/pages/platform/workflow-editor/providers/workflowEditorProvider';
 import {getNodeLabel} from '@/pages/platform/workflow-editor/utils/getNodeLabel';
-import {NODE_WIDTH, ROOT_CLUSTER_WIDTH} from '@/shared/constants';
+import {NODE_WIDTH} from '@/shared/constants';
 import {useGetClusterElementDefinitionQuery} from '@/shared/queries/platform/clusterElementDefinitions.queries';
 import {useGetWorkflowNodeDescriptionQuery} from '@/shared/queries/platform/workflowNodeDescriptions.queries';
 import {useEnvironmentStore} from '@/shared/stores/useEnvironmentStore';
@@ -239,14 +239,15 @@ const WorkflowNodeContent = forwardRef<HTMLDivElement, WorkflowNodeContentProps>
                     <Button
                         aria-label={`${data.workflowNodeName} node`}
                         className={twMerge(
-                            'size-18 rounded-md border-2 border-stroke-neutral-tertiary bg-surface-neutral-primary p-4 text-primary hover:border-stroke-brand-secondary-hover hover:bg-surface-neutral-primary focus-visible:ring-stroke-brand-focus active:bg-surface-neutral-primary [&_svg]:size-9',
+                            'h-auto min-h-18 rounded-md border-2 border-stroke-neutral-tertiary bg-surface-neutral-primary p-4 text-primary hover:border-stroke-brand-secondary-hover hover:bg-surface-neutral-primary focus-visible:ring-stroke-brand-focus active:bg-surface-neutral-primary [&_svg]:size-9',
+                            // Roots size via the inline width style; w-18 (!important) would otherwise clobber it.
+                            !isMainRootClusterElement && !isNestedClusterRoot && 'w-18',
                             isSelected &&
                                 workflowNodeDetailsPanelOpen &&
                                 'border-stroke-brand-primary shadow-none hover:border-stroke-brand-primary',
                             isMainRootClusterElement && 'nodrag',
-                            (isMainRootClusterElement || isNestedClusterRoot) && `min-w-[${ROOT_CLUSTER_WIDTH}px] `,
-                            isNestedClusterRoot && 'overflow-hidden px-6',
-                            isClusterElement && !isMainRootClusterElement && 'rounded-full',
+                            isNestedClusterRoot && 'overflow-hidden rounded-2xl px-6',
+                            isClusterElement && !isMainRootClusterElement && !isNestedClusterRoot && 'rounded-full',
                             isClusterElement &&
                                 !isNestedClusterRoot &&
                                 !hasSavedClusterElementPosition &&


### PR DESCRIPTION
size-18 was a no-op in Tailwind v3 (no spacing.18 defined) and only served to
strip the Button default h-9, leaving nodes content-sized. Tailwind v4's dynamic
spacing scale makes size-18 a fixed 72px, clamping content-rich cluster and AI
agent nodes (shorter height, clipped info, distorted shapes). Replace with
h-auto min-h-18 so nodes grow with content while keeping a 72px floor.

Also fix nodes that are both a nested cluster root and a child element (e.g. a
RAG data source): they were forced into a 72px circle instead of a wide rounded
rectangle with their info inside. Because the config sets important: true, the
fixed w-18 (!important) clobbered the inline width style, so:
- apply w-18 only to non-root nodes (roots size via their inline width),
- exclude nested roots from rounded-full and give them rounded-2xl,
- drop the dead min-w-[${ROOT_CLUSTER_WIDTH}px] template-literal class
  (a runtime-interpolated arbitrary value Tailwind never emits CSS for).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
