### PR TITLE
5190 Add executions list indexes, codify principal_job drift index

### DIFF
--- a/server/libs/atlas/atlas-execution/atlas-execution-repository/atlas-execution-repository-jdbc/src/main/resources/config/liquibase/changelog/atlas/execution/20260611120000_atlas_execution_added_job_indexes.xml
+++ b/server/libs/atlas/atlas-execution/atlas-execution-repository/atlas-execution-repository-jdbc/src/main/resources/config/liquibase/changelog/atlas/execution/20260611120000_atlas_execution_added_job_indexes.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
+    <changeSet id="20260611120000" author="Ivica Cardic">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <indexExists indexName="idx_job_workflow_id_parent_task_execution_id"/>
+            </not>
+        </preConditions>
+
+        <createIndex indexName="idx_job_workflow_id_parent_task_execution_id" tableName="job">
+            <column name="workflow_id"/>
+            <column name="parent_task_execution_id"/>
+        </createIndex>
+    </changeSet>
+</databaseChangeLog>

--- a/server/libs/platform/platform-workflow/platform-workflow-execution/platform-workflow-execution-service/src/main/resources/config/liquibase/changelog/platform/execution/20260611120100_platform_execution_added_principal_job_indexes.xml
+++ b/server/libs/platform/platform-workflow/platform-workflow-execution/platform-workflow-execution-service/src/main/resources/config/liquibase/changelog/platform/execution/20260611120100_platform_execution_added_principal_job_indexes.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
+    <changeSet id="20260611120100" author="Ivica Cardic">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <indexExists indexName="principal_job_job_id_type_index"/>
+            </not>
+        </preConditions>
+
+        <createIndex indexName="principal_job_job_id_type_index" tableName="principal_job">
+            <column name="job_id"/>
+            <column name="type"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet id="20260611120101" author="Ivica Cardic">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <indexExists indexName="idx_principal_job_principal_id_type"/>
+            </not>
+        </preConditions>
+
+        <createIndex indexName="idx_principal_job_principal_id_type" tableName="principal_job">
+            <column name="principal_id"/>
+            <column name="type"/>
+        </createIndex>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
The /automation/executions list query (CustomPrincipalJobRepositoryImpl) relies
on principal_job(job_id, type) for a bounded backward index scan with early LIMIT
termination. That index existed only as hand-applied schema drift and was in no
changelog, so DBs built purely from migrations (fresh prod, CI, new tenants) fell
back to a full Seq Scan + Sort of principal_job on every page load (O(n log n) in
job count).

Codify principal_job(job_id, type) idempotently (indexExists precondition skips
DBs that already have it), and add the genuinely-missing selective indexes
principal_job(principal_id, type) and job(workflow_id, parent_task_execution_id).

Closes #5190

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
