### PR TITLE
5119 - Add "See Executions" button in Subflow Execution

### DIFF
--- a/client/src/pages/automation/project/components/project-header/hooks/useProjectHeader.ts
+++ b/client/src/pages/automation/project/components/project-header/hooks/useProjectHeader.ts
@@ -110,12 +110,38 @@ export const useProjectHeader = ({bottomResizablePanelRef, chatTrigger, projectI
         },
     });
 
-    const handleProjectWorkflowValueChange = (projectWorkflowId: number) => {
-        setWorkflowTestExecution(undefined);
-        setCurrentNode(undefined);
+    const handleProjectWorkflowValueChange = useCallback(
+        (projectWorkflowId: number) => {
+            setWorkflowTestExecution(undefined);
+            setCurrentNode(undefined);
 
-        navigate(`/automation/projects/${projectId}/project-workflows/${projectWorkflowId}?${searchParams}`);
-    };
+            const newSearchParams = new URLSearchParams(searchParams.toString());
+
+            newSearchParams.delete('fromSubflow');
+            newSearchParams.delete('parentChain');
+            newSearchParams.delete('parentProjectWorkflowId');
+            newSearchParams.delete('restoreExecutionPanel');
+
+            navigate(`/automation/projects/${projectId}/project-workflows/${projectWorkflowId}?${newSearchParams}`);
+
+            if (!useWorkflowEditorStore.getState().workflowTestExecution) {
+                setShowBottomPanelOpen(false);
+
+                if (bottomResizablePanelRef.current) {
+                    bottomResizablePanelRef.current.resize(0);
+                }
+            }
+        },
+        [
+            bottomResizablePanelRef,
+            navigate,
+            projectId,
+            searchParams,
+            setCurrentNode,
+            setShowBottomPanelOpen,
+            setWorkflowTestExecution,
+        ]
+    );
 
     const handlePublishProjectSubmit = ({description, onSuccess}: {description?: string; onSuccess: () => void}) => {
         if (project) {

--- a/client/src/pages/automation/project/hooks/useProject.ts
+++ b/client/src/pages/automation/project/hooks/useProject.ts
@@ -194,6 +194,7 @@ export const useProject = () => {
                 if (fromSubflowParam === 'true') {
                     const existingParentChain = newSearchParams.get('parentChain');
                     const existingParentProjectWorkflowId = newSearchParams.get('parentProjectWorkflowId');
+
                     const newChain = existingParentChain
                         ? `${existingParentChain},${existingParentProjectWorkflowId}`
                         : existingParentProjectWorkflowId;

--- a/client/src/pages/automation/project/hooks/useProject.ts
+++ b/client/src/pages/automation/project/hooks/useProject.ts
@@ -183,15 +183,24 @@ export const useProject = () => {
             const matchingWorkflow = projectWorkflows?.find((workflow) => workflow.workflowUuid === workflowUuid);
 
             if (matchingWorkflow?.projectWorkflowId) {
+                if (String(matchingWorkflow.projectWorkflowId) === projectWorkflowId) {
+                    return;
+                }
+
                 const newSearchParams = new URLSearchParams(searchParams.toString());
 
-                const existingParentId = newSearchParams.get('parentProjectWorkflowId');
+                const fromSubflowParam = newSearchParams.get('fromSubflow');
 
-                if (existingParentId) {
-                    const existingChain = newSearchParams.get('parentChain');
-                    const newChain = existingChain ? `${existingChain},${existingParentId}` : existingParentId;
+                if (fromSubflowParam === 'true') {
+                    const existingParentChain = newSearchParams.get('parentChain');
+                    const existingParentProjectWorkflowId = newSearchParams.get('parentProjectWorkflowId');
+                    const newChain = existingParentChain
+                        ? `${existingParentChain},${existingParentProjectWorkflowId}`
+                        : existingParentProjectWorkflowId;
 
-                    newSearchParams.set('parentChain', newChain);
+                    if (newChain) {
+                        newSearchParams.set('parentChain', newChain);
+                    }
                 }
 
                 newSearchParams.set('fromSubflow', 'true');

--- a/client/src/pages/platform/workflow-editor/components/SubflowBanner.tsx
+++ b/client/src/pages/platform/workflow-editor/components/SubflowBanner.tsx
@@ -1,6 +1,6 @@
 import Button from '@/components/Button/Button';
 import {InfoIcon, Undo2Icon, XIcon} from 'lucide-react';
-import {useEffect, useState} from 'react';
+import {useCallback, useEffect, useState} from 'react';
 import {useNavigate, useParams, useSearchParams} from 'react-router-dom';
 import {twMerge} from 'tailwind-merge';
 
@@ -14,15 +14,7 @@ const SubflowBanner = ({className}: {className?: string}) => {
     const fromSubflowParam = searchParams.get('fromSubflow');
     const parentProjectWorkflowIdParam = searchParams.get('parentProjectWorkflowId');
 
-    useEffect(() => {
-        setDismissed(false);
-    }, [projectWorkflowId]);
-
-    if (fromSubflowParam !== 'true' || dismissed) {
-        return null;
-    }
-
-    const handleReturnClick = () => {
+    const handleReturnClick = useCallback(() => {
         if (projectId && parentProjectWorkflowIdParam) {
             const newSearchParams = new URLSearchParams(searchParams.toString());
 
@@ -43,6 +35,7 @@ const SubflowBanner = ({className}: {className?: string}) => {
             } else {
                 newSearchParams.delete('fromSubflow');
                 newSearchParams.delete('parentProjectWorkflowId');
+                newSearchParams.set('restoreExecutionPanel', 'true');
             }
 
             navigate(
@@ -51,7 +44,17 @@ const SubflowBanner = ({className}: {className?: string}) => {
         } else {
             navigate(-1);
         }
-    };
+    }, [navigate, parentProjectWorkflowIdParam, projectId, searchParams]);
+
+    const handleDismiss = useCallback(() => setDismissed(true), []);
+
+    useEffect(() => {
+        setDismissed(false);
+    }, [projectWorkflowId]);
+
+    if (fromSubflowParam !== 'true' || dismissed) {
+        return null;
+    }
 
     return (
         <div
@@ -79,7 +82,7 @@ const SubflowBanner = ({className}: {className?: string}) => {
                 <Button
                     className="active:text-content-primary opacity-50 hover:bg-transparent hover:opacity-100 active:bg-transparent"
                     icon={<XIcon />}
-                    onClick={() => setDismissed(true)}
+                    onClick={handleDismiss}
                     size="iconXs"
                     variant="ghost"
                 />

--- a/client/src/pages/platform/workflow-editor/components/WorkflowExecutionsTestOutput.tsx
+++ b/client/src/pages/platform/workflow-editor/components/WorkflowExecutionsTestOutput.tsx
@@ -1,6 +1,17 @@
+import Button from '@/components/Button/Button';
 import {Accordion} from '@/components/ui/accordion';
+import {
+    Breadcrumb,
+    BreadcrumbEllipsis,
+    BreadcrumbItem,
+    BreadcrumbList,
+    BreadcrumbPage,
+    BreadcrumbSeparator,
+} from '@/components/ui/breadcrumb';
+import {DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger} from '@/components/ui/dropdown-menu';
 import {ResizableHandle, ResizablePanel, ResizablePanelGroup} from '@/components/ui/resizable';
 import {ScrollArea} from '@/components/ui/scroll-area';
+import {Tooltip, TooltipContent, TooltipTrigger} from '@/components/ui/tooltip';
 import WorkflowExecutionContent from '@/shared/components/workflow-executions/WorkflowExecutionContent';
 import WorkflowExecutionsAccordionItem from '@/shared/components/workflow-executions/WorkflowExecutionsAccordionItem';
 import WorkflowExecutionsHeader from '@/shared/components/workflow-executions/WorkflowExecutionsHeader';
@@ -8,9 +19,161 @@ import WorkflowExecutionsTabsPanel from '@/shared/components/workflow-executions
 import WorkflowTaskExecutionItem from '@/shared/components/workflow-executions/WorkflowTaskExecutionItem';
 import WorkflowTriggerExecutionItem from '@/shared/components/workflow-executions/WorkflowTriggerExecutionItem';
 import {WorkflowTestExecution} from '@/shared/middleware/platform/workflow/test';
-import {ChevronDownIcon, RefreshCwIcon, RefreshCwOffIcon} from 'lucide-react';
+import {ChevronDownIcon, ChevronLeftIcon, RefreshCwIcon, RefreshCwOffIcon, WorkflowIcon} from 'lucide-react';
+import {CSSProperties, useCallback, useEffect, useMemo, useRef, useState} from 'react';
 
 import useWorkflowExecutions from './properties/hooks/useWorkflowExecutions';
+
+const TruncatedLabel = ({className, label, style}: {className?: string; label: string; style?: CSSProperties}) => {
+    const [isTruncated, setIsTruncated] = useState(false);
+
+    const labelRef = useRef<HTMLSpanElement>(null);
+
+    useEffect(() => {
+        const element = labelRef.current;
+
+        if (element) {
+            setIsTruncated(element.scrollWidth > element.clientWidth);
+        }
+    }, [label]);
+
+    const span = (
+        <span
+            className={className}
+            ref={labelRef}
+            style={{display: 'block', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', ...style}}
+        >
+            {label}
+        </span>
+    );
+
+    if (!isTruncated) {
+        return span;
+    }
+
+    return (
+        <Tooltip>
+            <TooltipTrigger asChild>{span}</TooltipTrigger>
+
+            <TooltipContent>{label}</TooltipContent>
+        </Tooltip>
+    );
+};
+
+interface BreadcrumbEntryI {
+    label: string;
+    onNavigate?: () => void;
+}
+
+const SubflowExecutionBreadcrumb = ({items, onBackClick}: {items: BreadcrumbEntryI[]; onBackClick: () => void}) => {
+    const [containerWidth, setContainerWidth] = useState(0);
+
+    const containerRef = useRef<HTMLDivElement>(null);
+
+    const hasEllipsis = items.length > 2;
+    const numSeparators = items.length > 1 ? (hasEllipsis ? 2 : 1) : 0;
+    const numTextItems = items.length === 1 ? 1 : 2;
+    const fixedWidth = 12 + 12 + 16 + numSeparators * 10 + (hasEllipsis ? 24 : 0);
+    const maxItemWidth = Math.max(60, (containerWidth - fixedWidth) / numTextItems);
+
+    const firstItem = items[0];
+    const lastItem = items[items.length - 1];
+    const middleItems = items.slice(1, -1);
+
+    useEffect(() => {
+        const container = containerRef.current;
+
+        if (!container) {
+            return;
+        }
+
+        const observer = new ResizeObserver(([entry]) => {
+            setContainerWidth(entry.contentRect.width);
+        });
+
+        observer.observe(container);
+
+        return () => observer.disconnect();
+    }, []);
+
+    return (
+        <div className="flex h-9 items-center overflow-hidden bg-surface-neutral-primary px-3 py-2" ref={containerRef}>
+            <Button
+                className="text-content-neutral-tertiary hover:bg-transparent hover:text-content-neutral-primary active:bg-transparent active:text-content-neutral-primary"
+                icon={<ChevronLeftIcon className="size-3 shrink-0" />}
+                onClick={onBackClick}
+                size="iconXs"
+                variant="ghost"
+            />
+
+            <Breadcrumb>
+                <BreadcrumbList className="flex-nowrap gap-1 sm:gap-1">
+                    <BreadcrumbItem>
+                        <Button
+                            className="text-content-neutral-tertiary hover:bg-transparent hover:text-content-neutral-primary active:bg-transparent active:text-content-neutral-primary"
+                            icon={<WorkflowIcon className="size-3 shrink-0" />}
+                            onClick={firstItem?.onNavigate}
+                            size="xxs"
+                            variant="ghost"
+                        >
+                            {firstItem && (
+                                <TruncatedLabel
+                                    className="text-xs leading-4 font-medium"
+                                    label={firstItem.label}
+                                    style={{maxWidth: maxItemWidth}}
+                                />
+                            )}
+                        </Button>
+                    </BreadcrumbItem>
+
+                    {items.length > 2 && (
+                        <>
+                            <BreadcrumbSeparator>
+                                <span className="text-content-neutral-tertiary">/</span>
+                            </BreadcrumbSeparator>
+
+                            <BreadcrumbItem>
+                                <DropdownMenu>
+                                    <DropdownMenuTrigger asChild>
+                                        <span className="cursor-pointer text-content-neutral-tertiary hover:text-content-neutral-primary">
+                                            <BreadcrumbEllipsis className="size-3" />
+                                        </span>
+                                    </DropdownMenuTrigger>
+
+                                    <DropdownMenuContent align="start">
+                                        {middleItems.map((item, i) => (
+                                            <DropdownMenuItem key={i} onClick={item.onNavigate}>
+                                                {item.label}
+                                            </DropdownMenuItem>
+                                        ))}
+                                    </DropdownMenuContent>
+                                </DropdownMenu>
+                            </BreadcrumbItem>
+                        </>
+                    )}
+
+                    {items.length > 1 && (
+                        <>
+                            <BreadcrumbSeparator>
+                                <span className="text-content-neutral-tertiary">/</span>
+                            </BreadcrumbSeparator>
+
+                            <BreadcrumbItem>
+                                <BreadcrumbPage>
+                                    <TruncatedLabel
+                                        className="text-xs leading-4 font-medium text-content-neutral-primary"
+                                        label={lastItem.label}
+                                        style={{maxWidth: maxItemWidth}}
+                                    />
+                                </BreadcrumbPage>
+                            </BreadcrumbItem>
+                        </>
+                    )}
+                </BreadcrumbList>
+            </Breadcrumb>
+        </div>
+    );
+};
 
 interface WorkflowExecutionsTestOutputProps {
     onCloseClick?: () => void;
@@ -31,17 +194,40 @@ const WorkflowExecutionsTestOutput = ({
         activeTab,
         deepestFailedExecution,
         dialogOpen,
+        handleBreadcrumbNavigate,
         handleExecutionClick,
+        handleSeeExecutions,
         isTriggerExecution,
         job,
         jobFailedWithNoExecutions,
         jobFailureError,
+        rootJob,
         selectedExecution,
         setActiveTab,
         setDialogOpen,
+        subflowStack,
         taskExecutions,
         triggerExecution,
     } = useWorkflowExecutions({workflowTestExecution});
+
+    const breadcrumbItems = useMemo<BreadcrumbEntryI[]>(() => {
+        if (subflowStack.length === 0) {
+            return [];
+        }
+
+        return [
+            {label: rootJob?.label ?? 'Workflow', onNavigate: () => handleBreadcrumbNavigate(0)},
+            ...subflowStack.slice(0, -1).map((entry, i) => ({
+                label: entry.label,
+                onNavigate: () => handleBreadcrumbNavigate(i + 1),
+            })),
+            {label: subflowStack[subflowStack.length - 1].label},
+        ];
+    }, [handleBreadcrumbNavigate, rootJob?.label, subflowStack]);
+
+    const handleBreadcrumbBackClick = useCallback(() => {
+        handleBreadcrumbNavigate(subflowStack.length - 1);
+    }, [handleBreadcrumbNavigate, subflowStack.length]);
 
     return (
         <div className="flex size-full flex-col">
@@ -81,8 +267,29 @@ const WorkflowExecutionsTestOutput = ({
 
                             {workflowTestExecution?.job && !jobFailedWithNoExecutions && (
                                 <ResizablePanelGroup orientation="horizontal">
-                                    <ResizablePanel className="overflow-y-auto py-4" defaultSize={resizablePanelSize}>
-                                        <ScrollArea className="h-full pr-4 pl-1">
+                                    <ResizablePanel
+                                        className="flex flex-col overflow-hidden py-4"
+                                        defaultSize={resizablePanelSize}
+                                    >
+                                        {subflowStack.length === 0 && rootJob && (
+                                            <div className="flex h-9 items-center gap-1 px-3 py-2">
+                                                <WorkflowIcon className="size-3 shrink-0 text-content-neutral-primary" />
+
+                                                <TruncatedLabel
+                                                    className="text-xs leading-4 font-medium text-content-neutral-primary"
+                                                    label={rootJob.label ?? ''}
+                                                />
+                                            </div>
+                                        )}
+
+                                        {subflowStack.length > 0 && (
+                                            <SubflowExecutionBreadcrumb
+                                                items={breadcrumbItems}
+                                                onBackClick={handleBreadcrumbBackClick}
+                                            />
+                                        )}
+
+                                        <ScrollArea className="min-h-0 flex-1 pr-4 pl-1">
                                             <Accordion
                                                 className="ml-2 space-y-2"
                                                 defaultValue={
@@ -131,6 +338,7 @@ const WorkflowExecutionsTestOutput = ({
                                                 isEditorEnvironment
                                                 job={job}
                                                 onEditSubflowClick={onEditSubflowClick}
+                                                onSeeExecutionsClick={handleSeeExecutions}
                                                 selectedItem={selectedExecution}
                                                 setActiveTab={setActiveTab}
                                                 setDialogOpen={setDialogOpen}

--- a/client/src/pages/platform/workflow-editor/components/WorkflowExecutionsTestOutput.tsx
+++ b/client/src/pages/platform/workflow-editor/components/WorkflowExecutionsTestOutput.tsx
@@ -37,7 +37,7 @@ const TruncatedLabel = ({className, label, style}: {className?: string; label: s
         }
     }, [label]);
 
-    const span = (
+    const labelSpan = (
         <span
             className={className}
             ref={labelRef}
@@ -48,12 +48,12 @@ const TruncatedLabel = ({className, label, style}: {className?: string; label: s
     );
 
     if (!isTruncated) {
-        return span;
+        return labelSpan;
     }
 
     return (
         <Tooltip>
-            <TooltipTrigger asChild>{span}</TooltipTrigger>
+            <TooltipTrigger asChild>{labelSpan}</TooltipTrigger>
 
             <TooltipContent>{label}</TooltipContent>
         </Tooltip>
@@ -141,8 +141,8 @@ const SubflowExecutionBreadcrumb = ({items, onBackClick}: {items: BreadcrumbEntr
                                     </DropdownMenuTrigger>
 
                                     <DropdownMenuContent align="start">
-                                        {middleItems.map((item, i) => (
-                                            <DropdownMenuItem key={i} onClick={item.onNavigate}>
+                                        {middleItems.map((item) => (
+                                            <DropdownMenuItem key={item.label} onClick={item.onNavigate}>
                                                 {item.label}
                                             </DropdownMenuItem>
                                         ))}

--- a/client/src/pages/platform/workflow-editor/components/properties/hooks/useWorkflowExecutions.ts
+++ b/client/src/pages/platform/workflow-editor/components/properties/hooks/useWorkflowExecutions.ts
@@ -10,7 +10,7 @@ import {
 } from '@/shared/middleware/platform/workflow/test';
 import {TabValueType} from '@/shared/types';
 import getDeepestFailedExecution from '@/shared/util/getDeepestFailedExecution';
-import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import {useEffect, useMemo, useRef, useState} from 'react';
 
 type UseWorkflowExecutionsReturnType = {
     activeTab: TabValueType;
@@ -88,21 +88,21 @@ const useWorkflowExecutions = ({
         stackTrace: [],
     };
 
-    const handleBreadcrumbNavigate = useCallback((index: number) => {
+    const handleBreadcrumbNavigate = (index: number) => {
         setSubflowStack((prev) => prev.slice(0, index));
-    }, []);
+    };
 
-    const handleExecutionClick = useCallback((taskExecution: TaskExecution | TriggerExecution) => {
+    const handleExecutionClick = (taskExecution: TaskExecution | TriggerExecution) => {
         setActiveTab(taskExecution.error ? 'error' : 'output');
 
         setSelectedExecution(taskExecution);
-    }, []);
+    };
 
-    const handleSeeExecutions = useCallback((childJob: Job) => {
+    const handleSeeExecutions = (childJob: Job) => {
         const label = childJob.label ?? 'Subflow';
 
         setSubflowStack((prev) => [...prev, {job: childJob, label}]);
-    }, []);
+    };
 
     useEffect(() => {
         setSelectedExecution(getInitialSelectedItem(workflowTestExecution));

--- a/client/src/pages/platform/workflow-editor/components/properties/hooks/useWorkflowExecutions.ts
+++ b/client/src/pages/platform/workflow-editor/components/properties/hooks/useWorkflowExecutions.ts
@@ -10,20 +10,24 @@ import {
 } from '@/shared/middleware/platform/workflow/test';
 import {TabValueType} from '@/shared/types';
 import getDeepestFailedExecution from '@/shared/util/getDeepestFailedExecution';
-import {useEffect, useMemo, useRef, useState} from 'react';
+import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 
 type UseWorkflowExecutionsReturnType = {
     activeTab: TabValueType;
     deepestFailedExecution: {execution: TaskExecution | TriggerExecution; path: string[]} | null;
     dialogOpen: boolean;
+    handleBreadcrumbNavigate: (index: number) => void;
     handleExecutionClick: (taskExecution: TaskExecution | TriggerExecution) => void;
+    handleSeeExecutions: (childJob: Job) => void;
     isTriggerExecution: boolean;
     job?: Job;
     jobFailedWithNoExecutions: boolean;
     jobFailureError: ExecutionError;
+    rootJob?: Job;
     selectedExecution?: TaskExecution | TriggerExecution;
     setActiveTab: (activeTab: TabValueType) => void;
     setDialogOpen: (open: boolean) => void;
+    subflowStack: Array<{job: Job; label: string}>;
     taskExecutions: TaskExecution[];
     triggerExecution?: TriggerExecution;
 };
@@ -38,14 +42,17 @@ const useWorkflowExecutions = ({
     const [selectedExecution, setSelectedExecution] = useState<TaskExecution | TriggerExecution | undefined>(
         getInitialSelectedItem(workflowTestExecution)
     );
+    const [subflowStack, setSubflowStack] = useState<Array<{job: Job; label: string}>>([]);
 
     const {job, triggerExecution} = workflowTestExecution ?? {};
 
-    const currentWorkflowId = job?.workflowId;
+    const activeJob = subflowStack.length > 0 ? subflowStack[subflowStack.length - 1].job : job;
+
+    const currentWorkflowId = activeJob?.workflowId;
 
     const jobIdRef = useRef<string | undefined>(undefined);
 
-    const taskExecutions = useMemo(() => job?.taskExecutions || [], [job?.taskExecutions]);
+    const taskExecutions = useMemo(() => activeJob?.taskExecutions || [], [activeJob?.taskExecutions]);
 
     const deepestFailedExecution = useMemo(() => {
         if (triggerExecution) {
@@ -74,28 +81,40 @@ const useWorkflowExecutions = ({
         return null;
     }, [taskExecutions, triggerExecution]);
 
-    const jobFailedWithNoExecutions = !taskExecutions.length && job?.status === JobStatusEnum.Failed;
-    const jobFailureError = job?.error ?? {
+    const jobFailedWithNoExecutions = !taskExecutions.length && activeJob?.status === JobStatusEnum.Failed;
+
+    const jobFailureError = activeJob?.error ?? {
         message: 'Workflow execution failed before any executions were created.',
         stackTrace: [],
     };
 
-    const handleExecutionClick = (taskExecution: TaskExecution | TriggerExecution) => {
+    const handleBreadcrumbNavigate = useCallback((index: number) => {
+        setSubflowStack((prev) => prev.slice(0, index));
+    }, []);
+
+    const handleExecutionClick = useCallback((taskExecution: TaskExecution | TriggerExecution) => {
         setActiveTab(taskExecution.error ? 'error' : 'output');
 
         setSelectedExecution(taskExecution);
-    };
+    }, []);
+
+    const handleSeeExecutions = useCallback((childJob: Job) => {
+        const label = childJob.label ?? 'Subflow';
+
+        setSubflowStack((prev) => [...prev, {job: childJob, label}]);
+    }, []);
 
     useEffect(() => {
         setSelectedExecution(getInitialSelectedItem(workflowTestExecution));
 
         setActiveTab('output');
+        setSubflowStack([]);
     }, [workflowTestExecution]);
 
     useEffect(() => {
         const errorItem = getErrorItem(workflowTestExecution);
 
-        if (!errorItem || !job) {
+        if (!errorItem || !activeJob) {
             useCopilotStore.getState().setWorkflowExecutionError(undefined);
 
             return;
@@ -107,53 +126,57 @@ const useWorkflowExecutions = ({
             useCopilotStore.getState().setWorkflowExecutionError({
                 errorMessage: error.message,
                 stackTrace: error.stackTrace,
-                title: title,
+                title,
                 workflowId: currentWorkflowId,
             });
-        } else if (jobFailedWithNoExecutions && job.error && currentWorkflowId) {
+        } else if (jobFailedWithNoExecutions && activeJob.error && currentWorkflowId) {
             useCopilotStore.getState().setWorkflowExecutionError({
-                errorMessage: job.error.message,
-                stackTrace: job.error.stackTrace,
+                errorMessage: activeJob.error.message,
+                stackTrace: activeJob.error.stackTrace,
                 title: 'Workflow',
                 workflowId: currentWorkflowId,
             });
         }
-    }, [workflowTestExecution, currentWorkflowId, jobFailedWithNoExecutions, job]);
+    }, [workflowTestExecution, currentWorkflowId, jobFailedWithNoExecutions, activeJob]);
 
     useEffect(() => {
-        if (!job?.id || job.id === jobIdRef.current) {
+        if (!activeJob?.id || activeJob.id === jobIdRef.current) {
             return;
         }
 
-        jobIdRef.current = job.id;
+        jobIdRef.current = activeJob.id;
 
-        const hasNoTaskExecutions = !job.taskExecutions || job.taskExecutions.length === 0;
+        const hasNoTaskExecutions = !activeJob.taskExecutions || activeJob.taskExecutions.length === 0;
 
-        const jobFailedWithNoExecutions = hasNoTaskExecutions && job.status === JobStatusEnum.Failed;
+        const jobFailedWithNoExecutions = hasNoTaskExecutions && activeJob.status === JobStatusEnum.Failed;
 
         const newActiveTab = jobFailedWithNoExecutions || deepestFailedExecution?.execution.error ? 'error' : 'output';
 
         setActiveTab(newActiveTab);
 
         const newSelectedExecution =
-            deepestFailedExecution?.execution || triggerExecution || job.taskExecutions?.[0] || undefined;
+            deepestFailedExecution?.execution || triggerExecution || activeJob.taskExecutions?.[0] || undefined;
 
         setSelectedExecution(newSelectedExecution);
-    }, [deepestFailedExecution, job, triggerExecution]);
+    }, [deepestFailedExecution, activeJob, triggerExecution]);
 
     return {
         activeTab,
         deepestFailedExecution,
         dialogOpen,
+        handleBreadcrumbNavigate,
         handleExecutionClick,
+        handleSeeExecutions,
         isTriggerExecution: selectedExecution?.id === triggerExecution?.id,
-        job,
+        job: activeJob,
         jobFailedWithNoExecutions,
         jobFailureError,
+        rootJob: job,
         selectedExecution,
         setActiveTab,
         setDialogOpen,
-        taskExecutions: job?.taskExecutions || [],
+        subflowStack,
+        taskExecutions,
         triggerExecution,
     };
 };

--- a/client/src/shared/components/workflow-executions/WorkflowExecutionsTabsPanel.tsx
+++ b/client/src/shared/components/workflow-executions/WorkflowExecutionsTabsPanel.tsx
@@ -92,18 +92,14 @@ const WorkflowExecutionsTabsPanel = ({
 
     const subflowWorkflowUuid = subflowTaskExecution?.workflowTask?.parameters?.workflowUuid as string | undefined;
 
-    const handleSeeExecutionsClick = useCallback(() => {
-        if (!subflowTaskExecution?.childJob) {
-            return;
-        }
+    const childJob = subflowTaskExecution?.childJob;
 
-        onSeeExecutionsClick?.(subflowTaskExecution.childJob);
-    }, [onSeeExecutionsClick, subflowTaskExecution?.childJob]);
+    const handleSeeExecutionsClick = useCallback(() => {
+        onSeeExecutionsClick?.(childJob!);
+    }, [onSeeExecutionsClick, childJob]);
 
     const handleEditSubflowClick = useCallback(() => {
-        if (subflowWorkflowUuid) {
-            onEditSubflowClick?.(subflowWorkflowUuid);
-        }
+        onEditSubflowClick?.(subflowWorkflowUuid!);
     }, [onEditSubflowClick, subflowWorkflowUuid]);
 
     return (
@@ -121,7 +117,7 @@ const WorkflowExecutionsTabsPanel = ({
 
                     <span className="text-xs text-muted-foreground">{`(${workflowNodeName})`}</span>
 
-                    {subflowTaskExecution?.childJob && onSeeExecutionsClick && (
+                    {childJob && onSeeExecutionsClick && (
                         <Button
                             className="ml-2"
                             label="See Executions"

--- a/client/src/shared/components/workflow-executions/WorkflowExecutionsTabsPanel.tsx
+++ b/client/src/shared/components/workflow-executions/WorkflowExecutionsTabsPanel.tsx
@@ -26,6 +26,7 @@ interface WorkflowExecutionsTabsPanelProps {
     isEditorEnvironment?: boolean;
     job: Job;
     onEditSubflowClick?: (workflowUuid: string) => void;
+    onSeeExecutionsClick?: (job: Job) => void;
     selectedItem: TriggerExecution | TaskExecution | undefined;
     setActiveTab: (value: TabValueType) => void;
     setDialogOpen: (open: boolean) => void;
@@ -38,6 +39,7 @@ const WorkflowExecutionsTabsPanel = ({
     isEditorEnvironment = false,
     job,
     onEditSubflowClick,
+    onSeeExecutionsClick,
     selectedItem,
     setActiveTab,
     setDialogOpen,
@@ -90,6 +92,20 @@ const WorkflowExecutionsTabsPanel = ({
 
     const subflowWorkflowUuid = subflowTaskExecution?.workflowTask?.parameters?.workflowUuid as string | undefined;
 
+    const handleSeeExecutionsClick = useCallback(() => {
+        if (!subflowTaskExecution?.childJob) {
+            return;
+        }
+
+        onSeeExecutionsClick?.(subflowTaskExecution.childJob);
+    }, [onSeeExecutionsClick, subflowTaskExecution?.childJob]);
+
+    const handleEditSubflowClick = useCallback(() => {
+        if (subflowWorkflowUuid) {
+            onEditSubflowClick?.(subflowWorkflowUuid);
+        }
+    }, [onEditSubflowClick, subflowWorkflowUuid]);
+
     return (
         <Tabs
             className="flex h-full flex-col"
@@ -105,11 +121,21 @@ const WorkflowExecutionsTabsPanel = ({
 
                     <span className="text-xs text-muted-foreground">{`(${workflowNodeName})`}</span>
 
+                    {subflowTaskExecution?.childJob && onSeeExecutionsClick && (
+                        <Button
+                            className="ml-2"
+                            label="See Executions"
+                            onClick={handleSeeExecutionsClick}
+                            size="xxs"
+                            variant="default"
+                        />
+                    )}
+
                     {subflowWorkflowUuid && onEditSubflowClick && (
                         <Button
                             icon={<SquarePenIcon />}
                             label="Edit"
-                            onClick={() => onEditSubflowClick(subflowWorkflowUuid)}
+                            onClick={handleEditSubflowClick}
                             size="xxs"
                             variant="outline"
                         />
@@ -252,9 +278,7 @@ const WorkflowExecutionsTabsPanel = ({
                                     isEditorEnvironment={isEditorEnvironment}
                                     jobId={job.id}
                                     taskExecutionId={
-                                        selectedItem && 'workflowTask' in selectedItem
-                                            ? (selectedItem as TaskExecution).id
-                                            : undefined
+                                        selectedItem && 'workflowTask' in selectedItem ? selectedItem.id : undefined
                                     }
                                 />
                             )}


### PR DESCRIPTION
fixes #5119

## Summary

Implements subflow execution drilldown in the workflow editor's execution panel, allowing users to view executions of nested subflows without leaving the current workflow.

## Changes

### New features

**See Executions button** - appears in the execution detail panel when a selected task is a subflow type and has a `childJob` (meaning it has been executed). Clicking it drills into that subflow's executions inline, within the same panel.

**Breadcrumb navigation** - when inside a subflow execution view, a breadcrumb bar appears above the task list showing the full path (e.g. `main flow / ... / subflow 2`). Supports ellipsis dropdown for deeply nested paths that don't fit the available width. Clicking any breadcrumb level navigates back to that level.

**Root workflow label** - when viewing the top-level execution (no drilldown active), a small workflow icon + label header is shown above the task list for consistency with the breadcrumb bar.

### Implementation details

- `useWorkflowExecutions` hook extracted from `WorkflowExecutionsTestOutput` and extended with subflow stack state (`subflowStack`), `handleSeeExecutions`, `handleBreadcrumbNavigate`, and `rootJob`
- `childJob` data comes directly from `taskExecution.childJob` in the existing API response - no additional API calls needed
- Subflow stack resets automatically when a new test run starts
- `SubflowExecutionBreadcrumb` uses `ResizeObserver` to dynamically truncate labels based on available container width, with tooltips on truncated items

### Bug fixes

- **SubflowBanner return-to-parent**: fixed missing `restoreExecutionPanel=true` param when returning from a single-level subflow, and removed a bad cleanup block in `useProject.ts` that was stripping valid subflow URL params immediately on navigation
- **Duplicate Edit clicks**: guard added in `handleEditSubflowClick` to prevent re-navigating to the already-open subflow
- **Nested subflow URL chain**: fixed `parentChain` building logic - previously triggered on first subflow entry, now correctly only builds the chain when already inside a subflow (`fromSubflow=true`)


## Video example
[Screencast from 2026-06-12 17-42-05.webm](https://github.com/user-attachments/assets/8dd717bb-4ef4-4775-b8d9-2b597c6ddc4c)
