### PR TITLE
5199 client - Fix MCP Add Workflows button silently doing nothing

### DIFF
--- a/client/src/ee/pages/embedded/mcp-servers/components/McpIntegrationInstanceConfigurationWorkflowDialog.test.tsx
+++ b/client/src/ee/pages/embedded/mcp-servers/components/McpIntegrationInstanceConfigurationWorkflowDialog.test.tsx
@@ -1,0 +1,98 @@
+import {McpServer} from '@/shared/middleware/graphql';
+import {render, screen, waitFor} from '@/shared/util/test-utils';
+import userEvent from '@testing-library/user-event';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+
+import McpIntegrationInstanceConfigurationWorkflowDialog from './McpIntegrationInstanceConfigurationWorkflowDialog';
+import {McpIntegrationInstanceConfigurationItemType} from './mcp-integration-instance-configuration-list/hooks/useMcpIntegrationInstanceConfigurationList';
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks (must not reference outer-scope constants — vi.hoisted runs
+// before module initialisation)
+// ---------------------------------------------------------------------------
+
+const hoisted = vi.hoisted(() => ({
+    createMutate: vi.fn(),
+    eligibleResult: {data: undefined} as {data: unknown},
+    updateMutate: vi.fn(),
+}));
+
+vi.mock('@/shared/middleware/graphql', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('@/shared/middleware/graphql')>();
+
+    return {
+        ...actual,
+        useCreateMcpIntegrationInstanceConfigurationMutation: () => ({mutate: hoisted.createMutate, reset: vi.fn()}),
+        useToolEligibleIntegrationInstanceConfigurationWorkflowsQuery: () => hoisted.eligibleResult,
+        useUpdateMcpIntegrationInstanceConfigurationMutation: () => ({mutate: hoisted.updateMutate, reset: vi.fn()}),
+    };
+});
+
+vi.mock('@/ee/shared/queries/embedded/integrationInstanceConfigurations.queries', () => ({
+    useGetIntegrationInstanceConfigurationsQuery: () => ({data: []}),
+}));
+
+const mcpServer = {id: 's1', name: 'Server'} as McpServer;
+
+const makeEditConfig = (workflowLabels: string[]): McpIntegrationInstanceConfigurationItemType =>
+    ({
+        id: 'cfg1',
+        integration: {name: 'Integration'},
+        integrationInstanceConfigurationId: '42',
+        integrationVersion: 1,
+        mcpIntegrationInstanceConfigurationWorkflows: workflowLabels.map((label, index) => ({
+            id: `mw${index}`,
+            workflow: {label},
+        })),
+        mcpServerId: 's1',
+    }) as McpIntegrationInstanceConfigurationItemType;
+
+describe('McpIntegrationInstanceConfigurationWorkflowDialog', () => {
+    beforeEach(() => {
+        hoisted.createMutate.mockReset();
+        hoisted.updateMutate.mockReset();
+        hoisted.eligibleResult.data = undefined;
+
+        Element.prototype.scrollIntoView = vi.fn();
+    });
+
+    it('shows an explanatory message and keeps the submit button disabled when there are no tool-eligible workflows', () => {
+        hoisted.eligibleResult.data = {toolEligibleIntegrationInstanceConfigurationWorkflows: []};
+
+        render(
+            <McpIntegrationInstanceConfigurationWorkflowDialog
+                mcpIntegrationInstanceConfiguration={makeEditConfig([])}
+                mcpServer={mcpServer}
+            />
+        );
+
+        expect(screen.getByText(/No tool-eligible workflows found/i)).toBeInTheDocument();
+        expect(screen.getByRole('button', {name: 'Update'})).toBeDisabled();
+    });
+
+    it('enables the submit button once a tool-eligible workflow is selected', async () => {
+        hoisted.eligibleResult.data = {
+            toolEligibleIntegrationInstanceConfigurationWorkflows: [{id: 'w1', label: 'Workflow One'}],
+        };
+
+        render(
+            <McpIntegrationInstanceConfigurationWorkflowDialog
+                mcpIntegrationInstanceConfiguration={makeEditConfig(['Workflow One'])}
+                mcpServer={mcpServer}
+            />
+        );
+
+        // Edit mode pre-populates the previously-selected workflow once eligible workflows load.
+        await waitFor(() => expect(screen.getByRole('button', {name: 'Update'})).toBeEnabled());
+
+        expect(screen.queryByText(/No tool-eligible workflows found/i)).not.toBeInTheDocument();
+
+        await userEvent.click(screen.getByRole('button', {name: 'Update'}));
+
+        expect(hoisted.updateMutate).toHaveBeenCalledTimes(1);
+        expect(hoisted.updateMutate.mock.calls[0][0]).toMatchObject({
+            id: 'cfg1',
+            input: {selectedWorkflowIds: ['w1']},
+        });
+    });
+});

--- a/client/src/ee/pages/embedded/mcp-servers/components/McpIntegrationInstanceConfigurationWorkflowDialog.tsx
+++ b/client/src/ee/pages/embedded/mcp-servers/components/McpIntegrationInstanceConfigurationWorkflowDialog.tsx
@@ -358,7 +358,7 @@ const McpIntegrationInstanceConfigurationWorkflowDialog = ({
                             </DialogClose>
 
                             <Button
-                                disabled={!selectedWorkflowIds || selectedWorkflowIds.length === 0}
+                                disabled={hasNoEligibleWorkflows || !selectedWorkflowIds || selectedWorkflowIds.length === 0}
                                 label={isEditMode ? 'Update' : 'Add'}
                                 type="submit"
                             />

--- a/client/src/ee/pages/embedded/mcp-servers/components/McpIntegrationInstanceConfigurationWorkflowDialog.tsx
+++ b/client/src/ee/pages/embedded/mcp-servers/components/McpIntegrationInstanceConfigurationWorkflowDialog.tsx
@@ -358,7 +358,9 @@ const McpIntegrationInstanceConfigurationWorkflowDialog = ({
                             </DialogClose>
 
                             <Button
-                                disabled={hasNoEligibleWorkflows || !selectedWorkflowIds || selectedWorkflowIds.length === 0}
+                                disabled={
+                                    hasNoEligibleWorkflows || !selectedWorkflowIds || selectedWorkflowIds.length === 0
+                                }
                                 label={isEditMode ? 'Update' : 'Add'}
                                 type="submit"
                             />

--- a/client/src/ee/pages/embedded/mcp-servers/components/McpIntegrationInstanceConfigurationWorkflowDialog.tsx
+++ b/client/src/ee/pages/embedded/mcp-servers/components/McpIntegrationInstanceConfigurationWorkflowDialog.tsx
@@ -104,6 +104,8 @@ const McpIntegrationInstanceConfigurationWorkflowDialog = ({
 
     const selectedWorkflowIds = form.watch('selectedWorkflowIds');
 
+    const hasNoEligibleWorkflows = !!(currentIntegrationInstanceConfigurationId && eligibleWorkflows?.length === 0);
+
     const queryClient = useQueryClient();
 
     const invalidateAndClose = () => {
@@ -294,6 +296,13 @@ const McpIntegrationInstanceConfigurationWorkflowDialog = ({
                             </>
                         )}
 
+                        {hasNoEligibleWorkflows && (
+                            <p className="text-sm text-content-neutral-secondary">
+                                No tool-eligible workflows found for this integration instance configuration. Only
+                                workflows with a New Workflow Call trigger can be added to an MCP server.
+                            </p>
+                        )}
+
                         {eligibleWorkflows && eligibleWorkflows.length > 0 && (
                             <FormField
                                 control={control}
@@ -348,7 +357,11 @@ const McpIntegrationInstanceConfigurationWorkflowDialog = ({
                                 <Button label="Cancel" type="button" variant="outline" />
                             </DialogClose>
 
-                            <Button label={isEditMode ? 'Update' : 'Add'} type="submit" />
+                            <Button
+                                disabled={!selectedWorkflowIds || selectedWorkflowIds.length === 0}
+                                label={isEditMode ? 'Update' : 'Add'}
+                                type="submit"
+                            />
                         </DialogFooter>
                     </form>
                 </Form>

--- a/client/src/pages/automation/mcp-servers/components/McpProjectWorkflowDialog.test.tsx
+++ b/client/src/pages/automation/mcp-servers/components/McpProjectWorkflowDialog.test.tsx
@@ -1,0 +1,114 @@
+import {McpServer} from '@/shared/middleware/graphql';
+import {render, screen} from '@/shared/util/test-utils';
+import userEvent from '@testing-library/user-event';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+
+import McpProjectWorkflowDialog from './McpProjectWorkflowDialog';
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks (must not reference outer-scope constants — vi.hoisted runs
+// before module initialisation)
+// ---------------------------------------------------------------------------
+
+const hoisted = vi.hoisted(() => ({
+    createMutate: vi.fn(),
+    eligibleResult: {data: undefined} as {data: unknown},
+    updateMutate: vi.fn(),
+}));
+
+vi.mock('@/shared/middleware/graphql', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('@/shared/middleware/graphql')>();
+
+    return {
+        ...actual,
+        useCreateMcpProjectMutation: () => ({mutate: hoisted.createMutate, reset: vi.fn()}),
+        useToolEligibleProjectVersionWorkflowsQuery: () => hoisted.eligibleResult,
+        useUpdateMcpProjectMutation: () => ({mutate: hoisted.updateMutate, reset: vi.fn()}),
+    };
+});
+
+vi.mock('@/shared/queries/automation/projects.queries', () => ({
+    useGetWorkspaceProjectsQuery: () => ({data: []}),
+}));
+
+vi.mock('@/pages/automation/stores/useWorkspaceStore', () => ({
+    useWorkspaceStore: (selector: (state: Record<string, unknown>) => unknown) => selector({currentWorkspaceId: 1}),
+}));
+
+// Replace the project/version selectors with simple buttons that invoke their
+// onChange synchronously, so we can drive the create-mode flow deterministically.
+vi.mock(
+    '@/pages/automation/project-deployments/components/project-deployment-dialog/ProjectDeploymentDialogBasicStepProjectsComboBox',
+    () => ({
+        default: ({onChange}: {onChange: (item: {label: string; name: string; value: number}) => void}) => (
+            <button onClick={() => onChange({label: 'Project', name: 'Project', value: 10})} type="button">
+                pick-project
+            </button>
+        ),
+    })
+);
+
+vi.mock(
+    '@/pages/automation/project-deployments/components/project-deployment-dialog/ProjectDeploymentDialogBasicStepProjectVersionsSelect',
+    () => ({
+        default: ({onChange}: {onChange: (value: number) => void}) => (
+            <button onClick={() => onChange(2)} type="button">
+                pick-version
+            </button>
+        ),
+    })
+);
+
+const mcpServer = {id: 's1', name: 'Server'} as McpServer;
+
+describe('McpProjectWorkflowDialog', () => {
+    beforeEach(() => {
+        hoisted.createMutate.mockReset();
+        hoisted.updateMutate.mockReset();
+        hoisted.eligibleResult.data = undefined;
+
+        Element.prototype.scrollIntoView = vi.fn();
+    });
+
+    it('shows an explanatory message and keeps Add disabled when the selected project version has no tool-eligible workflows', async () => {
+        const user = userEvent.setup();
+
+        hoisted.eligibleResult.data = {toolEligibleProjectVersionWorkflows: []};
+
+        render(<McpProjectWorkflowDialog mcpServer={mcpServer} />);
+
+        await user.click(screen.getByText('pick-project'));
+        await user.click(screen.getByText('pick-version'));
+
+        expect(screen.getByText(/No tool-eligible workflows found/i)).toBeInTheDocument();
+        expect(screen.getByRole('button', {name: 'Add'})).toBeDisabled();
+    });
+
+    it('enables Add and submits once a tool-eligible workflow is selected', async () => {
+        const user = userEvent.setup();
+
+        hoisted.eligibleResult.data = {
+            toolEligibleProjectVersionWorkflows: [{id: 'pw1', workflow: {id: 'w1', label: 'Workflow One'}}],
+        };
+
+        render(<McpProjectWorkflowDialog mcpServer={mcpServer} />);
+
+        await user.click(screen.getByText('pick-project'));
+        await user.click(screen.getByText('pick-version'));
+
+        const addButton = screen.getByRole('button', {name: 'Add'});
+
+        expect(addButton).toBeDisabled();
+
+        await user.click(screen.getByRole('checkbox'));
+
+        expect(addButton).toBeEnabled();
+
+        await user.click(addButton);
+
+        expect(hoisted.createMutate).toHaveBeenCalledTimes(1);
+        expect(hoisted.createMutate.mock.calls[0][0]).toMatchObject({
+            input: {mcpServerId: 's1', selectedWorkflowIds: ['w1']},
+        });
+    });
+});

--- a/client/src/pages/automation/mcp-servers/components/McpProjectWorkflowDialog.test.tsx
+++ b/client/src/pages/automation/mcp-servers/components/McpProjectWorkflowDialog.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
 
 import McpProjectWorkflowDialog from './McpProjectWorkflowDialog';
+import {McpProjectItemType} from './mcp-project-workflow-list/hooks/useMcpProjectList';
 
 // ---------------------------------------------------------------------------
 // Hoisted mocks (must not reference outer-scope constants — vi.hoisted runs
@@ -82,6 +83,23 @@ describe('McpProjectWorkflowDialog', () => {
 
         expect(screen.getByText(/No tool-eligible workflows found/i)).toBeInTheDocument();
         expect(screen.getByRole('button', {name: 'Add'})).toBeDisabled();
+    });
+
+    it('keeps Update disabled in edit mode when the project version no longer has tool-eligible workflows', () => {
+        hoisted.eligibleResult.data = {toolEligibleProjectVersionWorkflows: []};
+
+        const mcpProject = {
+            id: 'mp1',
+            mcpProjectWorkflows: [{id: 'mpw1', workflow: {id: 'w1', label: 'Workflow One'}}],
+            mcpServerId: 's1',
+            project: {id: '10', name: 'Project'},
+            projectVersion: 2,
+        } as unknown as McpProjectItemType;
+
+        render(<McpProjectWorkflowDialog mcpProject={mcpProject} mcpServer={mcpServer} />);
+
+        expect(screen.getByText(/No tool-eligible workflows found/i)).toBeInTheDocument();
+        expect(screen.getByRole('button', {name: 'Update'})).toBeDisabled();
     });
 
     it('enables Add and submits once a tool-eligible workflow is selected', async () => {

--- a/client/src/pages/automation/mcp-servers/components/McpProjectWorkflowDialog.tsx
+++ b/client/src/pages/automation/mcp-servers/components/McpProjectWorkflowDialog.tsx
@@ -374,7 +374,9 @@ const McpProjectWorkflowDialog = ({mcpProject, mcpServer, onClose, triggerNode}:
                             </DialogClose>
 
                             <Button
-                                disabled={hasNoEligibleWorkflows || !selectedWorkflowIds || selectedWorkflowIds.length === 0}
+                                disabled={
+                                    hasNoEligibleWorkflows || !selectedWorkflowIds || selectedWorkflowIds.length === 0
+                                }
                                 label={isEditMode ? 'Update' : 'Add'}
                                 type="submit"
                             />

--- a/client/src/pages/automation/mcp-servers/components/McpProjectWorkflowDialog.tsx
+++ b/client/src/pages/automation/mcp-servers/components/McpProjectWorkflowDialog.tsx
@@ -374,7 +374,7 @@ const McpProjectWorkflowDialog = ({mcpProject, mcpServer, onClose, triggerNode}:
                             </DialogClose>
 
                             <Button
-                                disabled={!selectedWorkflowIds || selectedWorkflowIds.length === 0}
+                                disabled={hasNoEligibleWorkflows || !selectedWorkflowIds || selectedWorkflowIds.length === 0}
                                 label={isEditMode ? 'Update' : 'Add'}
                                 type="submit"
                             />

--- a/client/src/pages/automation/mcp-servers/components/McpProjectWorkflowDialog.tsx
+++ b/client/src/pages/automation/mcp-servers/components/McpProjectWorkflowDialog.tsx
@@ -101,6 +101,10 @@ const McpProjectWorkflowDialog = ({mcpProject, mcpServer, onClose, triggerNode}:
 
     const {control, getValues, handleSubmit, reset, resetField, setValue} = form;
 
+    const selectedWorkflowIds = form.watch('selectedWorkflowIds');
+
+    const hasNoEligibleWorkflows = !!(currentProjectId && currentProjectVersion && eligibleWorkflows?.length === 0);
+
     const queryClient = useQueryClient();
 
     const onCreateSuccess = () => {
@@ -291,6 +295,13 @@ const McpProjectWorkflowDialog = ({mcpProject, mcpServer, onClose, triggerNode}:
                             </>
                         )}
 
+                        {hasNoEligibleWorkflows && (
+                            <p className="text-sm text-content-neutral-secondary">
+                                No tool-eligible workflows found for this project version. Only workflows with a New
+                                Workflow Call trigger can be added to an MCP server.
+                            </p>
+                        )}
+
                         {eligibleWorkflows && eligibleWorkflows.length > 0 && (
                             <FormField
                                 control={control}
@@ -362,7 +373,11 @@ const McpProjectWorkflowDialog = ({mcpProject, mcpServer, onClose, triggerNode}:
                                 <Button label="Cancel" type="button" variant="outline" />
                             </DialogClose>
 
-                            <Button label={isEditMode ? 'Update' : 'Add'} type="submit" />
+                            <Button
+                                disabled={!selectedWorkflowIds || selectedWorkflowIds.length === 0}
+                                label={isEditMode ? 'Update' : 'Add'}
+                                type="submit"
+                            />
                         </DialogFooter>
                     </form>
                 </Form>


### PR DESCRIPTION
The Add button validates the full zod schema, which requires at least one
selected workflow. The workflow checkboxes and their validation message were
both gated behind eligibleWorkflows.length > 0, so when a project/version (or
integration instance configuration) had no tool-eligible workflows, submit was
silently blocked with no feedback.

Show an explanatory message when no tool-eligible workflows exist, and disable
the Add/Update button while no workflow is selected, in both the automation and
embedded MCP dialogs. Adds component tests for both.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

Closes #5199