### PR TITLE
5197 Create job for non-batch non-collection trigger output

### DIFF
--- a/server/libs/platform/platform-workflow/platform-workflow-coordinator/platform-workflow-coordinator-impl/src/main/java/com/bytechef/platform/workflow/coordinator/trigger/completion/TriggerCompletionHandler.java
+++ b/server/libs/platform/platform-workflow/platform-workflow-coordinator/platform-workflow-coordinator-impl/src/main/java/com/bytechef/platform/workflow/coordinator/trigger/completion/TriggerCompletionHandler.java
@@ -90,38 +90,38 @@ public class TriggerCompletionHandler {
         String workflowId = getWorkflowId(workflowExecutionId);
         Map<String, ?> metadataMap = getMetadataMap(workflowExecutionId);
 
-        if (triggerExecution.getOutput() == null) {
+        Object output = triggerExecution.getOutput() == null
+            ? null
+            : triggerFileStorage.readTriggerExecutionOutput(triggerExecution.getOutput());
+
+        if (output == null) {
             triggerExecution.addJobId(
                 createJob(
                     workflowId,
                     MapUtils.concat(inputMap, Map.of(triggerExecution.getName(), Map.of())),
                     workflowExecutionId.getJobPrincipalId(), metadataMap, workflowExecutionId.getType()));
-        } else {
-            Object output = triggerFileStorage.readTriggerExecutionOutput(triggerExecution.getOutput());
-
-            if (!triggerExecution.isBatch() && output instanceof Collection<?> triggerOutputValues) {
-                for (Object triggerOutputValue : triggerOutputValues) {
-                    triggerExecution.addJobId(
-                        createJob(
-                            workflowId,
-                            MapUtils.concat(inputMap, Map.of(triggerExecution.getName(), triggerOutputValue)),
-                            workflowExecutionId.getJobPrincipalId(), metadataMap, workflowExecutionId.getType()));
-                }
-            } else if (triggerExecution.isBatch()) {
-                if (output instanceof Collection<?> collection && !collection.isEmpty()) {
-                    triggerExecution.addJobId(
-                        createJob(
-                            workflowId,
-                            MapUtils.concat(inputMap, Map.of(triggerExecution.getName(), output)),
-                            workflowExecutionId.getJobPrincipalId(), metadataMap, workflowExecutionId.getType()));
-                }
-            } else {
+        } else if (!triggerExecution.isBatch() && output instanceof Collection<?> triggerOutputValues) {
+            for (Object triggerOutputValue : triggerOutputValues) {
+                triggerExecution.addJobId(
+                    createJob(
+                        workflowId,
+                        MapUtils.concat(inputMap, Map.of(triggerExecution.getName(), triggerOutputValue)),
+                        workflowExecutionId.getJobPrincipalId(), metadataMap, workflowExecutionId.getType()));
+            }
+        } else if (triggerExecution.isBatch()) {
+            if (output instanceof Collection<?> collection && !collection.isEmpty()) {
                 triggerExecution.addJobId(
                     createJob(
                         workflowId,
                         MapUtils.concat(inputMap, Map.of(triggerExecution.getName(), output)),
                         workflowExecutionId.getJobPrincipalId(), metadataMap, workflowExecutionId.getType()));
             }
+        } else {
+            triggerExecution.addJobId(
+                createJob(
+                    workflowId,
+                    MapUtils.concat(inputMap, Map.of(triggerExecution.getName(), output)),
+                    workflowExecutionId.getJobPrincipalId(), metadataMap, workflowExecutionId.getType()));
         }
 
         triggerExecutionService.update(triggerExecution);

--- a/server/libs/platform/platform-workflow/platform-workflow-coordinator/platform-workflow-coordinator-impl/src/main/java/com/bytechef/platform/workflow/coordinator/trigger/completion/TriggerCompletionHandler.java
+++ b/server/libs/platform/platform-workflow/platform-workflow-coordinator/platform-workflow-coordinator-impl/src/main/java/com/bytechef/platform/workflow/coordinator/trigger/completion/TriggerCompletionHandler.java
@@ -107,15 +107,20 @@ public class TriggerCompletionHandler {
                             MapUtils.concat(inputMap, Map.of(triggerExecution.getName(), triggerOutputValue)),
                             workflowExecutionId.getJobPrincipalId(), metadataMap, workflowExecutionId.getType()));
                 }
-            } else {
-                if (triggerExecution.isBatch() && output instanceof Collection<?> collection && !collection.isEmpty()) {
+            } else if (triggerExecution.isBatch()) {
+                if (output instanceof Collection<?> collection && !collection.isEmpty()) {
                     triggerExecution.addJobId(
                         createJob(
                             workflowId,
                             MapUtils.concat(inputMap, Map.of(triggerExecution.getName(), output)),
                             workflowExecutionId.getJobPrincipalId(), metadataMap, workflowExecutionId.getType()));
                 }
-
+            } else {
+                triggerExecution.addJobId(
+                    createJob(
+                        workflowId,
+                        MapUtils.concat(inputMap, Map.of(triggerExecution.getName(), output)),
+                        workflowExecutionId.getJobPrincipalId(), metadataMap, workflowExecutionId.getType()));
             }
         }
 

--- a/server/libs/platform/platform-workflow/platform-workflow-coordinator/platform-workflow-coordinator-impl/src/test/java/com/bytechef/platform/workflow/coordinator/trigger/completion/TriggerCompletionHandlerTest.java
+++ b/server/libs/platform/platform-workflow/platform-workflow-coordinator/platform-workflow-coordinator-impl/src/test/java/com/bytechef/platform/workflow/coordinator/trigger/completion/TriggerCompletionHandlerTest.java
@@ -16,17 +16,200 @@
 
 package com.bytechef.platform.workflow.coordinator.trigger.completion;
 
-import org.junit.jupiter.api.Disabled;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.bytechef.atlas.execution.dto.JobParametersDTO;
+import com.bytechef.file.storage.domain.FileEntry;
+import com.bytechef.platform.constant.PlatformType;
+import com.bytechef.platform.file.storage.TriggerFileStorage;
+import com.bytechef.platform.workflow.WorkflowExecutionId;
+import com.bytechef.platform.workflow.execution.accessor.JobPrincipalAccessor;
+import com.bytechef.platform.workflow.execution.accessor.JobPrincipalAccessorRegistry;
+import com.bytechef.platform.workflow.execution.domain.TriggerExecution;
+import com.bytechef.platform.workflow.execution.facade.PrincipalJobFacade;
+import com.bytechef.platform.workflow.execution.service.TriggerExecutionService;
+import com.bytechef.platform.workflow.execution.service.TriggerStateService;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
  * @author Ivica Cardic
  */
-public class TriggerCompletionHandlerTest {
+@ExtendWith(MockitoExtension.class)
+class TriggerCompletionHandlerTest {
 
-    @Disabled
+    private static final String TRIGGER_NAME = "trigger1";
+    private static final WorkflowExecutionId WORKFLOW_EXECUTION_ID =
+        WorkflowExecutionId.of(PlatformType.AUTOMATION, 1L, "workflow-uuid", TRIGGER_NAME);
+
+    @Mock
+    private FileEntry fileEntry;
+
+    @Mock
+    private JobPrincipalAccessor jobPrincipalAccessor;
+
+    @Mock
+    private JobPrincipalAccessorRegistry jobPrincipalAccessorRegistry;
+
+    @Mock
+    private PrincipalJobFacade principalJobFacade;
+
+    @Mock
+    private TriggerExecution triggerExecution;
+
+    @Mock
+    private TriggerExecutionService triggerExecutionService;
+
+    @Mock
+    private TriggerFileStorage triggerFileStorage;
+
+    @Mock
+    private TriggerStateService triggerStateService;
+
+    private TriggerCompletionHandler triggerCompletionHandler;
+
+    @BeforeEach
+    void setUp() {
+        triggerCompletionHandler = new TriggerCompletionHandler(
+            jobPrincipalAccessorRegistry, principalJobFacade, triggerExecutionService, triggerFileStorage,
+            triggerStateService);
+
+        when(triggerExecution.getId()).thenReturn(1L);
+        when(triggerExecution.getWorkflowExecutionId()).thenReturn(WORKFLOW_EXECUTION_ID);
+
+        when(jobPrincipalAccessorRegistry.getJobPrincipalAccessor(PlatformType.AUTOMATION))
+            .thenReturn(jobPrincipalAccessor);
+        doReturn(Map.of("existingKey", "existingValue"))
+            .when(jobPrincipalAccessor)
+            .getInputMap(1L, "workflow-uuid");
+        when(jobPrincipalAccessor.getWorkflowId(1L, "workflow-uuid"))
+            .thenReturn("workflow-id");
+        doReturn(Map.of("metaKey", "metaValue"))
+            .when(jobPrincipalAccessor)
+            .getMetadataMap(1L);
+    }
+
     @Test
-    public void testHandle() {
-        // TODO
+    void testHandleNullOutputCreatesSingleJobWithEmptyMap() {
+        stubName();
+        when(triggerExecution.getOutput()).thenReturn(null);
+        stubCreateJob();
+
+        triggerCompletionHandler.handle(triggerExecution);
+
+        List<JobParametersDTO> jobParametersDTOs = captureCreatedJobs(1);
+
+        assertEquals(Map.of(), jobParametersDTOs.get(0)
+            .getInputs()
+            .get(TRIGGER_NAME));
+    }
+
+    @Test
+    void testHandleNonBatchCollectionFansOutJobPerElement() {
+        stubName();
+        stubOutput(List.of("first", "second"));
+        when(triggerExecution.isBatch()).thenReturn(false);
+        stubCreateJob();
+
+        triggerCompletionHandler.handle(triggerExecution);
+
+        List<JobParametersDTO> jobParametersDTOs = captureCreatedJobs(2);
+
+        assertEquals("first", triggerValue(jobParametersDTOs.get(0)));
+        assertEquals("second", triggerValue(jobParametersDTOs.get(1)));
+    }
+
+    @Test
+    void testHandleNonBatchNonCollectionCreatesSingleJob() {
+        stubName();
+        stubOutput("singleValue");
+        when(triggerExecution.isBatch()).thenReturn(false);
+        stubCreateJob();
+
+        triggerCompletionHandler.handle(triggerExecution);
+
+        List<JobParametersDTO> jobParametersDTOs = captureCreatedJobs(1);
+
+        assertEquals("singleValue", triggerValue(jobParametersDTOs.get(0)));
+        assertEquals("existingValue", jobParametersDTOs.get(0)
+            .getInputs()
+            .get("existingKey"));
+    }
+
+    @Test
+    void testHandleBatchCollectionCreatesSingleJobWithWholeCollection() {
+        List<String> output = List.of("first", "second");
+
+        stubName();
+        stubOutput(output);
+        when(triggerExecution.isBatch()).thenReturn(true);
+        stubCreateJob();
+
+        triggerCompletionHandler.handle(triggerExecution);
+
+        List<JobParametersDTO> jobParametersDTOs = captureCreatedJobs(1);
+
+        assertEquals(output, triggerValue(jobParametersDTOs.get(0)));
+    }
+
+    @Test
+    void testHandleBatchEmptyCollectionCreatesNoJob() {
+        stubOutput(List.of());
+        when(triggerExecution.isBatch()).thenReturn(true);
+
+        triggerCompletionHandler.handle(triggerExecution);
+
+        verify(principalJobFacade, never()).createJob(any(), eq(1L), eq(PlatformType.AUTOMATION));
+    }
+
+    @Test
+    void testHandleBatchNonCollectionCreatesNoJob() {
+        stubOutput("singleValue");
+        when(triggerExecution.isBatch()).thenReturn(true);
+
+        triggerCompletionHandler.handle(triggerExecution);
+
+        verify(principalJobFacade, never()).createJob(any(), eq(1L), eq(PlatformType.AUTOMATION));
+    }
+
+    private List<JobParametersDTO> captureCreatedJobs(int expectedCount) {
+        ArgumentCaptor<JobParametersDTO> captor = ArgumentCaptor.forClass(JobParametersDTO.class);
+
+        verify(principalJobFacade, times(expectedCount))
+            .createJob(captor.capture(), eq(1L), eq(PlatformType.AUTOMATION));
+
+        return captor.getAllValues();
+    }
+
+    private void stubCreateJob() {
+        when(principalJobFacade.createJob(any(), eq(1L), eq(PlatformType.AUTOMATION)))
+            .thenReturn(5L);
+    }
+
+    private void stubName() {
+        when(triggerExecution.getName()).thenReturn(TRIGGER_NAME);
+    }
+
+    private void stubOutput(Object output) {
+        when(triggerExecution.getOutput()).thenReturn(fileEntry);
+        when(triggerFileStorage.readTriggerExecutionOutput(fileEntry)).thenReturn(output);
+    }
+
+    private static Object triggerValue(JobParametersDTO jobParametersDTO) {
+        return jobParametersDTO.getInputs()
+            .get(TRIGGER_NAME);
     }
 }

--- a/server/libs/platform/platform-workflow/platform-workflow-coordinator/platform-workflow-coordinator-impl/src/test/java/com/bytechef/platform/workflow/coordinator/trigger/completion/TriggerCompletionHandlerTest.java
+++ b/server/libs/platform/platform-workflow/platform-workflow-coordinator/platform-workflow-coordinator-impl/src/test/java/com/bytechef/platform/workflow/coordinator/trigger/completion/TriggerCompletionHandlerTest.java
@@ -118,6 +118,21 @@ class TriggerCompletionHandlerTest {
     }
 
     @Test
+    void testHandleDeserializedNullOutputCreatesSingleJobWithEmptyMap() {
+        stubName();
+        stubOutput(null);
+        stubCreateJob();
+
+        triggerCompletionHandler.handle(triggerExecution);
+
+        List<JobParametersDTO> jobParametersDTOs = captureCreatedJobs(1);
+
+        assertEquals(Map.of(), jobParametersDTOs.get(0)
+            .getInputs()
+            .get(TRIGGER_NAME));
+    }
+
+    @Test
     void testHandleNonBatchCollectionFansOutJobPerElement() {
         stubName();
         stubOutput(List.of("first", "second"));


### PR DESCRIPTION
A non-batch trigger producing a single, non-Collection output previously
fell through TriggerCompletionHandler without creating any job, so the
trigger fired but nothing downstream ran. Add an else branch to create a
single job carrying the scalar output.

Replace the disabled test stub with one unit test per dispatch path:
null output, non-batch collection (fan-out), non-batch scalar, batch
collection, batch empty collection, and batch scalar.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
