### PR TITLE
5061 & 5221 - Add the ability to Cut a node in the Workflow Editor, Remove icons when hovering a node

### DIFF
--- a/client/src/pages/platform/workflow-editor/components/WorkflowNodeContextMenu.tsx
+++ b/client/src/pages/platform/workflow-editor/components/WorkflowNodeContextMenu.tsx
@@ -19,6 +19,7 @@ import {
     Trash2Icon,
 } from 'lucide-react';
 import {ReactNode, useCallback, useMemo, useState} from 'react';
+import {twMerge} from 'tailwind-merge';
 import {useShallow} from 'zustand/react/shallow';
 
 interface WorkflowNodeContextMenuProps {
@@ -59,12 +60,22 @@ const WorkflowNodeContextMenu = ({
     showReplaceAction = false,
 }: WorkflowNodeContextMenuProps) => {
     const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+    const [menuReady, setMenuReady] = useState(false);
 
     const copiedNode = useWorkflowEditorStore(useShallow((state) => state.copiedNode));
 
     const handleDeleteClick = useCallback(() => setDeleteDialogOpen(true), []);
 
     const handleDeleteCancel = useCallback(() => setDeleteDialogOpen(false), []);
+
+    const handleOpenChange = useCallback((open: boolean) => {
+        if (open) {
+            setMenuReady(false);
+            setTimeout(() => setMenuReady(true), 200);
+        } else {
+            setMenuReady(false);
+        }
+    }, []);
 
     const PasteMenuItem = useMemo(() => {
         if (!canPaste || !copiedNode) {
@@ -101,10 +112,10 @@ const WorkflowNodeContextMenu = ({
 
     return (
         <>
-            <ContextMenu>
+            <ContextMenu onOpenChange={handleOpenChange}>
                 <ContextMenuTrigger asChild>{children}</ContextMenuTrigger>
 
-                <ContextMenuContent className="w-workflow-node-context-menu-width p-0">
+                <ContextMenuContent className={twMerge('w-workflow-node-context-menu-width p-0', !menuReady && 'pointer-events-none')}>
                     {data.trigger ? (
                         <>
                             <ContextMenuItem className="dropdown-menu-item gap-2" onClick={onSwitch}>

--- a/client/src/pages/platform/workflow-editor/components/WorkflowNodeContextMenu.tsx
+++ b/client/src/pages/platform/workflow-editor/components/WorkflowNodeContextMenu.tsx
@@ -68,14 +68,14 @@ const WorkflowNodeContextMenu = ({
 
     const handleDeleteCancel = useCallback(() => setDeleteDialogOpen(false), []);
 
-    const handleOpenChange = useCallback((open: boolean) => {
+    const handleOpenChange = (open: boolean) => {
         if (open) {
             setMenuReady(false);
             setTimeout(() => setMenuReady(true), 200);
         } else {
             setMenuReady(false);
         }
-    }, []);
+    };
 
     const PasteMenuItem = useMemo(() => {
         if (!canPaste || !copiedNode) {

--- a/client/src/pages/platform/workflow-editor/components/WorkflowNodeContextMenu.tsx
+++ b/client/src/pages/platform/workflow-editor/components/WorkflowNodeContextMenu.tsx
@@ -14,6 +14,7 @@ import {
     ClipboardPlusIcon,
     CopyIcon,
     RefreshCcwIcon,
+    ScissorsIcon,
     TextCursorInputIcon,
     Trash2Icon,
 } from 'lucide-react';
@@ -26,12 +27,14 @@ interface WorkflowNodeContextMenuProps {
     data: NodeDataType;
     hasSavedPosition: boolean;
     onCopy?: () => void;
+    onCut?: () => void;
     onDelete: () => void;
     onPaste?: () => void;
     onRename: () => void;
     onResetPosition: () => void;
     onSwitch: () => void;
     showCopyAction?: boolean;
+    showCutAction?: boolean;
     showDeleteAction?: boolean;
     showRenameAction?: boolean;
     showReplaceAction?: boolean;
@@ -43,12 +46,14 @@ const WorkflowNodeContextMenu = ({
     data,
     hasSavedPosition,
     onCopy,
+    onCut,
     onDelete,
     onPaste,
     onRename,
     onResetPosition,
     onSwitch,
     showCopyAction = false,
+    showCutAction = false,
     showDeleteAction = false,
     showRenameAction = false,
     showReplaceAction = false,
@@ -114,6 +119,13 @@ const WorkflowNodeContextMenu = ({
                         </>
                     ) : (
                         <>
+                            {showCutAction && (
+                                <ContextMenuItem className="dropdown-menu-item gap-2" onClick={onCut}>
+                                    <ScissorsIcon className="size-4 shrink-0" />
+                                    Cut
+                                </ContextMenuItem>
+                            )}
+
                             {showReplaceAction && (
                                 <ContextMenuItem className="dropdown-menu-item gap-2" onClick={onSwitch}>
                                     <ArrowLeftRightIcon className="size-4 shrink-0" />
@@ -130,7 +142,7 @@ const WorkflowNodeContextMenu = ({
 
                             {showCopyAction && PasteMenuItem}
 
-                            {(showReplaceAction || showCopyAction || canPaste) &&
+                            {(showCutAction || showReplaceAction || showCopyAction || canPaste) &&
                                 (showRenameAction || hasSavedPosition) && <ContextMenuSeparator className="m-0" />}
 
                             {showRenameAction && (

--- a/client/src/pages/platform/workflow-editor/components/WorkflowNodeContextMenu.tsx
+++ b/client/src/pages/platform/workflow-editor/components/WorkflowNodeContextMenu.tsx
@@ -115,7 +115,9 @@ const WorkflowNodeContextMenu = ({
             <ContextMenu onOpenChange={handleOpenChange}>
                 <ContextMenuTrigger asChild>{children}</ContextMenuTrigger>
 
-                <ContextMenuContent className={twMerge('w-workflow-node-context-menu-width p-0', !menuReady && 'pointer-events-none')}>
+                <ContextMenuContent
+                    className={twMerge('w-workflow-node-context-menu-width p-0', !menuReady && 'pointer-events-none')}
+                >
                     {data.trigger ? (
                         <>
                             <ContextMenuItem className="dropdown-menu-item gap-2" onClick={onSwitch}>

--- a/client/src/pages/platform/workflow-editor/components/WorkflowNodesPopoverMenu.tsx
+++ b/client/src/pages/platform/workflow-editor/components/WorkflowNodesPopoverMenu.tsx
@@ -1,4 +1,4 @@
-import {Popover, PopoverContent, PopoverTrigger} from '@/components/ui/popover';
+import {Popover, PopoverAnchor, PopoverContent, PopoverTrigger} from '@/components/ui/popover';
 import {ComponentDefinition, ComponentDefinitionApi} from '@/shared/middleware/platform/configuration';
 import {ComponentDefinitionKeys} from '@/shared/queries/platform/componentDefinitions.queries';
 import {ClickedDefinitionType} from '@/shared/types';
@@ -162,9 +162,13 @@ const WorkflowNodesPopoverMenu = ({
             onOpenChange={handlePopoverOpenChange}
             open={popoverOpen}
         >
-            <PopoverTrigger asChild onClick={handleStopPropagation}>
-                {children}
-            </PopoverTrigger>
+            {children ? (
+                <PopoverTrigger asChild onClick={handleStopPropagation}>
+                    {children}
+                </PopoverTrigger>
+            ) : (
+                <PopoverAnchor />
+            )}
 
             <PopoverContent
                 align="start"

--- a/client/src/pages/platform/workflow-editor/edges/WorkflowEdge.tsx
+++ b/client/src/pages/platform/workflow-editor/edges/WorkflowEdge.tsx
@@ -184,14 +184,14 @@ export default function WorkflowEdge({
 
     const handleClick = (event: MouseEvent) => event.stopPropagation();
 
-    const handleOpenChange = useCallback((open: boolean) => {
+    const handleOpenChange = (open: boolean) => {
         if (open) {
             setMenuReady(false);
             setTimeout(() => setMenuReady(true), 200);
         } else {
             setMenuReady(false);
         }
-    }, []);
+    };
 
     useEffect(() => {
         const handleGlobalDragEnd = () => {

--- a/client/src/pages/platform/workflow-editor/edges/WorkflowEdge.tsx
+++ b/client/src/pages/platform/workflow-editor/edges/WorkflowEdge.tsx
@@ -31,6 +31,7 @@ export default function WorkflowEdge({
     targetY,
 }: EdgeProps) {
     const [isDropzoneActive, setDropzoneActive] = useState<boolean>(false);
+    const [menuReady, setMenuReady] = useState<boolean>(false);
 
     const {edges, nodes, workflow} = useWorkflowDataStore(
         useShallow((state) => ({
@@ -183,6 +184,15 @@ export default function WorkflowEdge({
 
     const handleClick = (event: MouseEvent) => event.stopPropagation();
 
+    const handleOpenChange = useCallback((open: boolean) => {
+        if (open) {
+            setMenuReady(false);
+            setTimeout(() => setMenuReady(true), 200);
+        } else {
+            setMenuReady(false);
+        }
+    }, []);
+
     useEffect(() => {
         const handleGlobalDragEnd = () => {
             setDropzoneActive(false);
@@ -236,7 +246,7 @@ export default function WorkflowEdge({
                         zIndex: isDropzoneActive ? 40 : 'auto',
                     }}
                 >
-                    <ContextMenu>
+                    <ContextMenu onOpenChange={handleOpenChange}>
                         <ContextMenuTrigger asChild disabled={!canPaste}>
                             <div>
                                 <WorkflowNodesPopoverMenu
@@ -268,7 +278,7 @@ export default function WorkflowEdge({
                             </div>
                         </ContextMenuTrigger>
 
-                        <ContextMenuContent className="w-workflow-node-context-menu-width p-0">
+                        <ContextMenuContent className={twMerge('w-workflow-node-context-menu-width p-0', !menuReady && 'pointer-events-none')}>
                             <ContextMenuItem
                                 className="dropdown-menu-item flex w-full flex-col items-start gap-1"
                                 disabled={!canPaste}

--- a/client/src/pages/platform/workflow-editor/edges/WorkflowEdge.tsx
+++ b/client/src/pages/platform/workflow-editor/edges/WorkflowEdge.tsx
@@ -278,7 +278,12 @@ export default function WorkflowEdge({
                             </div>
                         </ContextMenuTrigger>
 
-                        <ContextMenuContent className={twMerge('w-workflow-node-context-menu-width p-0', !menuReady && 'pointer-events-none')}>
+                        <ContextMenuContent
+                            className={twMerge(
+                                'w-workflow-node-context-menu-width p-0',
+                                !menuReady && 'pointer-events-none'
+                            )}
+                        >
                             <ContextMenuItem
                                 className="dropdown-menu-item flex w-full flex-col items-start gap-1"
                                 disabled={!canPaste}

--- a/client/src/pages/platform/workflow-editor/nodes/AiAgentNode.tsx
+++ b/client/src/pages/platform/workflow-editor/nodes/AiAgentNode.tsx
@@ -161,12 +161,19 @@ const AiAgentNode = ({data, id}: {data: NodeDataType; id: string}) => {
         [incrementLayoutResetCounter, invalidateWorkflowQueries, updateWorkflowMutation]
     );
 
-    const handleCopyNode = useCallback(() => {
-        setTimeout(() => {
-            setCopiedNode({...data, label: nodeLabel ?? data.label});
-            setCopiedWorkflowId(workflow.id);
-        }, 200);
+    const saveNodeToClipboard = useCallback(() => {
+        setCopiedNode({...data, label: nodeLabel ?? data.label});
+        setCopiedWorkflowId(workflow.id);
     }, [data, nodeLabel, setCopiedNode, setCopiedWorkflowId, workflow.id]);
+
+    const handleCopyNode = useCallback(() => {
+        setTimeout(saveNodeToClipboard, 200);
+    }, [saveNodeToClipboard]);
+
+    const handleCutNode = useCallback(() => {
+        setTimeout(saveNodeToClipboard, 200);
+        handleDeleteNodeClick(data);
+    }, [handleDeleteNodeClick, saveNodeToClipboard, data]);
 
     const handleDelete = useCallback(() => handleDeleteNodeClick(data), [data, handleDeleteNodeClick]);
 
@@ -297,12 +304,14 @@ const AiAgentNode = ({data, id}: {data: NodeDataType; id: string}) => {
             data={data}
             hasSavedPosition={!!hasSavedNodePosition}
             onCopy={handleCopyNode}
+            onCut={handleCutNode}
             onDelete={handleDelete}
             onPaste={handlePasteNode}
             onRename={handleStartRename}
             onResetPosition={handleResetPosition}
             onSwitch={handleSwitch}
             showCopyAction
+            showCutAction
             showDeleteAction
             showRenameAction
         >

--- a/client/src/pages/platform/workflow-editor/nodes/AiAgentNode.tsx
+++ b/client/src/pages/platform/workflow-editor/nodes/AiAgentNode.tsx
@@ -9,7 +9,7 @@ import {NodeDataType} from '@/shared/types';
 import {HoverCardPortal} from '@radix-ui/react-hover-card';
 import {useQueryClient} from '@tanstack/react-query';
 import {Handle, Position} from '@xyflow/react';
-import {CheckIcon, ComponentIcon, PinOffIcon, TrashIcon} from 'lucide-react';
+import {CheckIcon, ComponentIcon} from 'lucide-react';
 import {ChangeEvent, FocusEvent, KeyboardEvent, memo, useCallback, useMemo, useState} from 'react';
 import InlineSVG from 'react-inlinesvg';
 import sanitize from 'sanitize-html';
@@ -295,7 +295,6 @@ const AiAgentNode = ({data, id}: {data: NodeDataType; id: string}) => {
         [copiedNode, copiedWorkflowId, workflow.id]
     );
 
-    const suppressHover = isRenaming;
     const isHorizontal = layoutDirection === 'LR';
 
     return (
@@ -323,34 +322,6 @@ const AiAgentNode = ({data, id}: {data: NodeDataType; id: string}) => {
                 data-nodetype="clusterRoot"
                 key={id}
             >
-                <div
-                    className={twMerge(
-                        'invisible absolute top-0 left-workflow-node-popover-hover pr-4',
-                        !suppressHover && 'group-hover:visible'
-                    )}
-                >
-                    <div className="flex flex-col gap-1">
-                        <Button
-                            className="opacity-100"
-                            icon={<TrashIcon />}
-                            onClick={() => handleDeleteNodeClick(data)}
-                            size="iconSm"
-                            title="Delete a node"
-                            variant="destructiveGhost"
-                        />
-
-                        {hasSavedNodePosition && (
-                            <Button
-                                icon={<PinOffIcon />}
-                                onClick={() => handleRemoveNodePosition(data.name)}
-                                size="iconSm"
-                                title="Remove saved node position"
-                                variant="ghost"
-                            />
-                        )}
-                    </div>
-                </div>
-
                 <HoverCard
                     key={id}
                     onOpenChange={(open) => {

--- a/client/src/pages/platform/workflow-editor/nodes/PlaceholderNode.tsx
+++ b/client/src/pages/platform/workflow-editor/nodes/PlaceholderNode.tsx
@@ -73,14 +73,14 @@ const PlaceholderNode = ({data, id}: {data: NodeDataType; id: string}) => {
         pasteNode({nodeIndex, taskDispatcherContext, updateWorkflowMutation});
     }, [id, nodeIndex, nodes, updateWorkflowMutation]);
 
-    const handleOpenChange = useCallback((open: boolean) => {
+    const handleOpenChange = (open: boolean) => {
         if (open) {
             setMenuReady(false);
             setTimeout(() => setMenuReady(true), 200);
         } else {
             setMenuReady(false);
         }
-    }, []);
+    };
 
     const handleDragEnter = () => setDropzoneActive(true);
 

--- a/client/src/pages/platform/workflow-editor/nodes/PlaceholderNode.tsx
+++ b/client/src/pages/platform/workflow-editor/nodes/PlaceholderNode.tsx
@@ -138,7 +138,9 @@ const PlaceholderNode = ({data, id}: {data: NodeDataType; id: string}) => {
                 </div>
             </ContextMenuTrigger>
 
-            <ContextMenuContent className={twMerge('w-workflow-node-context-menu-width p-0', !menuReady && 'pointer-events-none')}>
+            <ContextMenuContent
+                className={twMerge('w-workflow-node-context-menu-width p-0', !menuReady && 'pointer-events-none')}
+            >
                 <ContextMenuItem
                     className="dropdown-menu-item flex w-full flex-col items-start gap-1"
                     disabled={!canPaste}

--- a/client/src/pages/platform/workflow-editor/nodes/PlaceholderNode.tsx
+++ b/client/src/pages/platform/workflow-editor/nodes/PlaceholderNode.tsx
@@ -19,6 +19,7 @@ import styles from './NodeTypes.module.css';
 
 const PlaceholderNode = ({data, id}: {data: NodeDataType; id: string}) => {
     const [isDropzoneActive, setDropzoneActive] = useState(false);
+    const [menuReady, setMenuReady] = useState(false);
 
     const layoutDirection = useLayoutDirectionStore((state) => state.layoutDirection);
 
@@ -72,6 +73,15 @@ const PlaceholderNode = ({data, id}: {data: NodeDataType; id: string}) => {
         pasteNode({nodeIndex, taskDispatcherContext, updateWorkflowMutation});
     }, [id, nodeIndex, nodes, updateWorkflowMutation]);
 
+    const handleOpenChange = useCallback((open: boolean) => {
+        if (open) {
+            setMenuReady(false);
+            setTimeout(() => setMenuReady(true), 200);
+        } else {
+            setMenuReady(false);
+        }
+    }, []);
+
     const handleDragEnter = () => setDropzoneActive(true);
 
     const handleDragLeave = () => setDropzoneActive(false);
@@ -81,7 +91,7 @@ const PlaceholderNode = ({data, id}: {data: NodeDataType; id: string}) => {
     const handleDrop = () => setDropzoneActive(false);
 
     return (
-        <ContextMenu>
+        <ContextMenu onOpenChange={handleOpenChange}>
             <ContextMenuTrigger asChild disabled={!canPaste || isClusterElement}>
                 <div>
                     <WorkflowNodesPopoverMenu
@@ -128,7 +138,7 @@ const PlaceholderNode = ({data, id}: {data: NodeDataType; id: string}) => {
                 </div>
             </ContextMenuTrigger>
 
-            <ContextMenuContent className="w-workflow-node-context-menu-width p-0">
+            <ContextMenuContent className={twMerge('w-workflow-node-context-menu-width p-0', !menuReady && 'pointer-events-none')}>
                 <ContextMenuItem
                     className="dropdown-menu-item flex w-full flex-col items-start gap-1"
                     disabled={!canPaste}

--- a/client/src/pages/platform/workflow-editor/nodes/WorkflowNode.tsx
+++ b/client/src/pages/platform/workflow-editor/nodes/WorkflowNode.tsx
@@ -126,9 +126,7 @@ const WorkflowNodeContent = forwardRef<HTMLDivElement, WorkflowNodeContentProps>
                     onOpenChange={setSwitchPopoverOpen}
                     open={switchPopoverOpen}
                     sourceNodeId={id}
-                >
-                    <div />
-                </WorkflowNodesPopoverMenu>
+                />
             )}
 
             {isClusterElement && !data.multipleClusterElementsNode && (
@@ -142,9 +140,7 @@ const WorkflowNodeContent = forwardRef<HTMLDivElement, WorkflowNodeContentProps>
                     open={switchPopoverOpen}
                     sourceNodeId={data.clusterElementType && parentClusterRootId ? parentClusterRootId : id}
                     sourceNodeName={data.workflowNodeName}
-                >
-                    <div />
-                </WorkflowNodesPopoverMenu>
+                />
             )}
 
             <HoverCard

--- a/client/src/pages/platform/workflow-editor/nodes/WorkflowNode.tsx
+++ b/client/src/pages/platform/workflow-editor/nodes/WorkflowNode.tsx
@@ -12,7 +12,7 @@ import {ClusterElementsType, NodeDataType} from '@/shared/types';
 import {HoverCard, HoverCardPortal} from '@radix-ui/react-hover-card';
 import {useQueryClient} from '@tanstack/react-query';
 import {Handle, Position} from '@xyflow/react';
-import {ArrowLeftRightIcon, CheckIcon, ComponentIcon, PinOffIcon, Trash2Icon} from 'lucide-react';
+import {CheckIcon, ComponentIcon} from 'lucide-react';
 import {KeyboardEvent, forwardRef, memo, useCallback, useMemo, useState} from 'react';
 import sanitize from 'sanitize-html';
 import {twMerge} from 'tailwind-merge';
@@ -47,14 +47,10 @@ interface WorkflowNodeContentProps extends Omit<React.HTMLAttributes<HTMLDivElem
     data: NodeDataType;
     effectiveDirection: EffectiveDirectionType;
     filteredClusterElementTypes: ReturnType<typeof getFilteredClusterElementTypes>;
-    handleDeleteNodeClick: (data: NodeDataType) => void;
     handleNodeClick: () => void;
-    handleRemoveNodePosition: (nodeName: string) => void;
-    handleRemoveSavedClusterElementPosition: (clickedNodeName: string) => void;
     handleRenameKeyDown: (event: KeyboardEvent<HTMLInputElement>) => void;
     handleRenameSubmit: (newLabel: string) => void;
     hasSavedClusterElementPosition: NodePositionType;
-    hasSavedNodePosition: false | NodePositionType;
     id: string;
     isClusterElement: string | undefined;
     isHorizontal: boolean;
@@ -71,7 +67,6 @@ interface WorkflowNodeContentProps extends Omit<React.HTMLAttributes<HTMLDivElem
     renameValue: string;
     setRenameValue: (value: string) => void;
     setSwitchPopoverOpen: (open: boolean) => void;
-    suppressHover: boolean;
     switchPopoverOpen: boolean;
     workflowNodeDetailsPanelOpen: boolean;
 }
@@ -83,14 +78,10 @@ const WorkflowNodeContent = forwardRef<HTMLDivElement, WorkflowNodeContentProps>
             data,
             effectiveDirection,
             filteredClusterElementTypes,
-            handleDeleteNodeClick,
             handleNodeClick,
-            handleRemoveNodePosition,
-            handleRemoveSavedClusterElementPosition,
             handleRenameKeyDown,
             handleRenameSubmit,
             hasSavedClusterElementPosition,
-            hasSavedNodePosition,
             id,
             isClusterElement,
             isHorizontal,
@@ -107,7 +98,6 @@ const WorkflowNodeContent = forwardRef<HTMLDivElement, WorkflowNodeContentProps>
             renameValue,
             setRenameValue,
             setSwitchPopoverOpen,
-            suppressHover,
             switchPopoverOpen,
             workflowNodeDetailsPanelOpen,
             ...rest
@@ -119,7 +109,6 @@ const WorkflowNodeContent = forwardRef<HTMLDivElement, WorkflowNodeContentProps>
             {...rest}
             className={twMerge(
                 'relative flex min-w-60 cursor-pointer justify-center',
-                !suppressHover && 'group',
                 !data.taskDispatcher && 'items-center',
                 (data.trigger || isMainRootClusterElement) && 'nodrag',
                 isClusterElement && !isNestedClusterRoot && 'w-[72px] min-w-[72px] flex-col items-center gap-1',
@@ -129,103 +118,33 @@ const WorkflowNodeContent = forwardRef<HTMLDivElement, WorkflowNodeContentProps>
             data-nodetype={data.trigger ? 'trigger' : 'task'}
             key={id}
         >
-            {!isMainRootClusterElement && !isClusterElement && (
-                <div className="invisible absolute top-0 left-workflow-node-popover-hover pr-4 group-hover:visible">
-                    {data.trigger ? (
-                        <WorkflowNodesPopoverMenu
-                            hideActionComponents
-                            hideClusterElementComponents
-                            hideTaskDispatchers
-                            onOpenChange={setSwitchPopoverOpen}
-                            open={switchPopoverOpen}
-                            sourceNodeId={id}
-                        >
-                            <Button
-                                icon={<ArrowLeftRightIcon />}
-                                size="iconSm"
-                                title="Change trigger component"
-                                variant="outline"
-                            />
-                        </WorkflowNodesPopoverMenu>
-                    ) : (
-                        <div className="flex flex-col gap-1">
-                            <Button
-                                className="opacity-100"
-                                icon={<Trash2Icon />}
-                                onClick={() => handleDeleteNodeClick(data)}
-                                size="iconSm"
-                                title="Delete a node"
-                                variant="destructiveGhost"
-                            />
-
-                            {hasSavedNodePosition && (
-                                <Button
-                                    icon={<PinOffIcon />}
-                                    onClick={() => handleRemoveNodePosition(data.name)}
-                                    size="iconSm"
-                                    title="Remove saved node position"
-                                    variant="ghost"
-                                />
-                            )}
-                        </div>
-                    )}
-                </div>
+            {!isMainRootClusterElement && !isClusterElement && data.trigger && (
+                <WorkflowNodesPopoverMenu
+                    hideActionComponents
+                    hideClusterElementComponents
+                    hideTaskDispatchers
+                    onOpenChange={setSwitchPopoverOpen}
+                    open={switchPopoverOpen}
+                    sourceNodeId={id}
+                >
+                    <div />
+                </WorkflowNodesPopoverMenu>
             )}
 
-            {isClusterElement && (
-                <div
-                    className={twMerge(
-                        'invisible absolute left-[-80px] z-50 flex gap-1 pr-8 group-hover:visible',
-                        data.multipleClusterElementsNode &&
-                            !hasSavedClusterElementPosition &&
-                            'left-workflow-node-popover-hover'
-                    )}
+            {isClusterElement && !data.multipleClusterElementsNode && (
+                <WorkflowNodesPopoverMenu
+                    clusterElementType={data.clusterElementType}
+                    hideActionComponents={!!data.clusterElementType}
+                    hideClusterElementComponents={!data.clusterElementType}
+                    hideTaskDispatchers={!!data.clusterElementType}
+                    hideTriggerComponents
+                    onOpenChange={setSwitchPopoverOpen}
+                    open={switchPopoverOpen}
+                    sourceNodeId={data.clusterElementType && parentClusterRootId ? parentClusterRootId : id}
+                    sourceNodeName={data.workflowNodeName}
                 >
-                    <Button
-                        className={twMerge(
-                            'opacity-100',
-                            !data.multipleClusterElementsNode && hasSavedClusterElementPosition && 'self-center'
-                        )}
-                        icon={<Trash2Icon />}
-                        onClick={() => handleDeleteNodeClick(data)}
-                        size="iconSm"
-                        title="Delete a node"
-                        variant="destructiveGhost"
-                    />
-
-                    <div className="flex flex-col gap-1">
-                        {!data.multipleClusterElementsNode && (
-                            <WorkflowNodesPopoverMenu
-                                clusterElementType={data.clusterElementType}
-                                hideActionComponents={!!data.clusterElementType}
-                                hideClusterElementComponents={!data.clusterElementType}
-                                hideTaskDispatchers={!!data.clusterElementType}
-                                hideTriggerComponents
-                                onOpenChange={setSwitchPopoverOpen}
-                                open={switchPopoverOpen}
-                                sourceNodeId={data.clusterElementType && parentClusterRootId ? parentClusterRootId : id}
-                                sourceNodeName={data.workflowNodeName}
-                            >
-                                <Button
-                                    icon={<ArrowLeftRightIcon />}
-                                    size="iconSm"
-                                    title={`Change ${data.clusterElementType} component`}
-                                    variant="outline"
-                                />
-                            </WorkflowNodesPopoverMenu>
-                        )}
-
-                        {hasSavedClusterElementPosition && (
-                            <Button
-                                icon={<PinOffIcon />}
-                                onClick={() => handleRemoveSavedClusterElementPosition(data.workflowNodeName)}
-                                size="iconSm"
-                                title="Remove saved node position"
-                                variant="ghost"
-                            />
-                        )}
-                    </div>
-                </div>
+                    <div />
+                </WorkflowNodesPopoverMenu>
             )}
 
             <HoverCard
@@ -813,8 +732,6 @@ const WorkflowNode = ({data, id}: {data: NodeDataType; id: string}) => {
 
     const isRenaming = renamingNodeName === data.name;
 
-    const suppressHover = isRenaming || switchPopoverOpen;
-
     const canPaste = !!copiedNode && copiedWorkflowId === workflow.id;
 
     const nodeDescription =
@@ -831,14 +748,10 @@ const WorkflowNode = ({data, id}: {data: NodeDataType; id: string}) => {
         data,
         effectiveDirection,
         filteredClusterElementTypes,
-        handleDeleteNodeClick,
         handleNodeClick,
-        handleRemoveNodePosition,
-        handleRemoveSavedClusterElementPosition,
         handleRenameKeyDown,
         handleRenameSubmit,
         hasSavedClusterElementPosition,
-        hasSavedNodePosition,
         id,
         isClusterElement,
         isHorizontal,
@@ -855,7 +768,6 @@ const WorkflowNode = ({data, id}: {data: NodeDataType; id: string}) => {
         renameValue,
         setRenameValue,
         setSwitchPopoverOpen,
-        suppressHover,
         switchPopoverOpen,
         workflowNodeDetailsPanelOpen,
     } satisfies WorkflowNodeContentProps;

--- a/client/src/pages/platform/workflow-editor/nodes/WorkflowNode.tsx
+++ b/client/src/pages/platform/workflow-editor/nodes/WorkflowNode.tsx
@@ -777,12 +777,19 @@ const WorkflowNode = ({data, id}: {data: NodeDataType; id: string}) => {
         setRenamingNodeName(data.name);
     }, [data.name, nodeLabel, setRenameValue, setRenamingNodeName]);
 
-    const handleCopyNode = useCallback(() => {
-        setTimeout(() => {
-            setCopiedNode({...data, label: nodeLabel ?? data.label});
-            setCopiedWorkflowId(workflow.id);
-        }, 200);
+    const saveNodeToClipboard = useCallback(() => {
+        setCopiedNode({...data, label: nodeLabel ?? data.label});
+        setCopiedWorkflowId(workflow.id);
     }, [data, nodeLabel, setCopiedNode, setCopiedWorkflowId, workflow.id]);
+
+    const handleCopyNode = useCallback(() => {
+        setTimeout(saveNodeToClipboard, 200);
+    }, [saveNodeToClipboard]);
+
+    const handleCutNode = useCallback(() => {
+        setTimeout(saveNodeToClipboard, 200);
+        handleDeleteNodeClick(data);
+    }, [handleDeleteNodeClick, saveNodeToClipboard, data]);
 
     const handlePasteNode = useCallback(() => {
         const taskDispatcherContext = data.taskDispatcher ? undefined : getContextFromTaskNodeData(data, 1);
@@ -860,12 +867,14 @@ const WorkflowNode = ({data, id}: {data: NodeDataType; id: string}) => {
                 data={data}
                 hasSavedPosition={!!hasSavedNodePosition}
                 onCopy={handleCopyNode}
+                onCut={handleCutNode}
                 onDelete={handleDelete}
                 onPaste={handlePasteNode}
                 onRename={handleStartRename}
                 onResetPosition={handleResetPosition}
                 onSwitch={handleSwitch}
                 showCopyAction
+                showCutAction
                 showDeleteAction
                 showRenameAction
             >

--- a/client/src/pages/platform/workflow-editor/utils/pasteNode.ts
+++ b/client/src/pages/platform/workflow-editor/utils/pasteNode.ts
@@ -310,7 +310,9 @@ export default function pasteNode({
 
     const existingLabels = nodes.map((node) => node.data?.label).filter((label): label is string => !!label);
 
-    const finalLabel = getNextAvailableName(copiedNode.label ?? '', existingLabels);
+    const finalLabel = existingLabels.includes(copiedNode.label ?? '')
+        ? getNextAvailableName(copiedNode.label ?? '', existingLabels)
+        : (copiedNode.label ?? '');
 
     let cleanedMetadata = undefined;
 


### PR DESCRIPTION
fixes #5061 & #5221

- remove icons when hovering a node
- Adds Cut action to the workflow node context menu for regular nodes and AI agent nodes.

<img width="740" height="574" alt="image" src="https://github.com/user-attachments/assets/b036a237-50e8-46d5-8c5a-36bfecd21be7" />

## How

- Added `ScissorsIcon` Cut menu item at the top of the context menu (`WorkflowNodeContextMenu.tsx`)
- Added `showCutAction` and `onCut` props to `WorkflowNodeContextMenu`
- Extracted shared copy logic into `saveNodeToClipboard` callback (used by both copy and cut)
- `handleCutNode` saves the node to clipboard then immediately deletes it from the workflow
- Fixed separator condition to account for `showCutAction`
- Fixed paste-after-cut label: reuses original label if it's no longer taken, appends `(1)` only if it is


[Screencast from 2026-06-16 17-26-04.webm](https://github.com/user-attachments/assets/b662cfe3-f4dc-4188-b320-ffda074f420c)
