### PR TITLE
5238 client - Reset OAuth Connect button promptly when popup is closed

### DIFF
--- a/client/src/shared/components/connection/oauth2/tests/useOAuth2.test.ts
+++ b/client/src/shared/components/connection/oauth2/tests/useOAuth2.test.ts
@@ -642,6 +642,9 @@ describe('useOAuth2', () => {
 
         const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
+        // Closing the popup returns focus to this window, which is what starts the abandon countdown.
+        const hasFocusSpy = vi.spyOn(document, 'hasFocus').mockReturnValue(true);
+
         const {result} = renderHook(() => useOAuth2(defaultProps));
 
         act(() => {
@@ -656,14 +659,45 @@ describe('useOAuth2', () => {
             vi.advanceTimersByTime(300);
         });
 
-        // Advance past the 120-second grace period so the hook treats the popup as abandoned
+        // Advance past the grace period so the hook treats the popup as abandoned
         act(() => {
-            vi.advanceTimersByTime(121_000);
+            vi.advanceTimersByTime(2_500);
         });
 
         expect(result.current.loading).toBe(false);
         expect(consoleWarnSpy).toHaveBeenCalledWith('Warning: Popup was closed before completing authentication.');
 
+        hasFocusSpy.mockRestore();
+        consoleWarnSpy.mockRestore();
+        vi.useRealTimers();
+    });
+
+    it('should keep loading while the popup is in front even if it reports closed (COOP false positive)', () => {
+        vi.useFakeTimers();
+
+        const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        // While the user authenticates, the popup holds focus, so this window does not.
+        const hasFocusSpy = vi.spyOn(document, 'hasFocus').mockReturnValue(false);
+
+        const {result} = renderHook(() => useOAuth2(defaultProps));
+
+        act(() => {
+            result.current.getAuth();
+        });
+
+        // A COOP provider can make the still-open popup report closed during cross-origin navigation.
+        (mockWindow as unknown as {closed: boolean}).closed = true;
+
+        // Advance well beyond the grace period; without focus the hook must not abandon the flow.
+        act(() => {
+            vi.advanceTimersByTime(60_000);
+        });
+
+        expect(result.current.loading).toBe(true);
+        expect(consoleWarnSpy).not.toHaveBeenCalled();
+
+        hasFocusSpy.mockRestore();
         consoleWarnSpy.mockRestore();
         vi.useRealTimers();
     });

--- a/client/src/shared/components/connection/oauth2/useOAuth2.ts
+++ b/client/src/shared/components/connection/oauth2/useOAuth2.ts
@@ -20,7 +20,7 @@ export interface CodePayloadI {
 const POPUP_HEIGHT = 800;
 const POPUP_WIDTH = 600;
 
-const POPUP_CLOSED_GRACE_PERIOD_MS = 120_000;
+const POPUP_CLOSED_GRACE_PERIOD_MS = 2_000;
 
 // https://medium.com/@dazcyril/generating-cryptographic-random-state-in-javascript-in-the-browser-c538b3daae50
 const generateState = () => {
@@ -299,7 +299,7 @@ const useOAuth2 = ({
                 // Cross-origin access may throw; keep popupAppearsClosed as false
             }
 
-            if (popupAppearsClosed) {
+            if (popupAppearsClosed && document.hasFocus()) {
                 if (!popupClosedAt) {
                     popupClosedAt = Date.now();
                 }


### PR DESCRIPTION
The Connect button stayed in "Connecting…" for up to 2 minutes after the
OAuth popup was closed without completing the flow (e.g. Google
redirect_uri_mismatch error page, or user cancel), because the
popup-closed grace period in useOAuth2 was 120s.

Gate the abandon countdown on document.hasFocus() and shorten the grace
to 2s: while the user authenticates the popup holds focus, so the
countdown never starts even when a COOP provider makes a still-open popup
report closed === true (the case #3978 added the grace for). A genuine
close returns focus to the opener, resetting the button ~2s later.

Closes #5238

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
