### PR TITLE
5268 - add info item into context-menu

### DIFF
--- a/client/src/pages/platform/workflow-editor/components/WorkflowNodeContextMenu.tsx
+++ b/client/src/pages/platform/workflow-editor/components/WorkflowNodeContextMenu.tsx
@@ -13,6 +13,7 @@ import {
     ArrowLeftRightIcon,
     ClipboardPlusIcon,
     CopyIcon,
+    InfoIcon,
     RefreshCcwIcon,
     ScissorsIcon,
     TextCursorInputIcon,
@@ -30,6 +31,7 @@ interface WorkflowNodeContextMenuProps {
     onCopy?: () => void;
     onCut?: () => void;
     onDelete: () => void;
+    onInfo?: () => void;
     onPaste?: () => void;
     onRename: () => void;
     onResetPosition: () => void;
@@ -37,6 +39,7 @@ interface WorkflowNodeContextMenuProps {
     showCopyAction?: boolean;
     showCutAction?: boolean;
     showDeleteAction?: boolean;
+    showInfoAction?: boolean;
     showRenameAction?: boolean;
     showReplaceAction?: boolean;
 }
@@ -49,6 +52,7 @@ const WorkflowNodeContextMenu = ({
     onCopy,
     onCut,
     onDelete,
+    onInfo,
     onPaste,
     onRename,
     onResetPosition,
@@ -56,6 +60,7 @@ const WorkflowNodeContextMenu = ({
     showCopyAction = false,
     showCutAction = false,
     showDeleteAction = false,
+    showInfoAction = false,
     showRenameAction = false,
     showReplaceAction = false,
 }: WorkflowNodeContextMenuProps) => {
@@ -129,6 +134,13 @@ const WorkflowNodeContextMenu = ({
                                 <TextCursorInputIcon className="size-4 shrink-0" />
                                 Rename
                             </ContextMenuItem>
+
+                            {showInfoAction && (
+                                <ContextMenuItem className="dropdown-menu-item gap-2" onClick={onInfo}>
+                                    <InfoIcon className="size-4 shrink-0" />
+                                    Info
+                                </ContextMenuItem>
+                            )}
                         </>
                     ) : (
                         <>
@@ -156,7 +168,9 @@ const WorkflowNodeContextMenu = ({
                             {showCopyAction && PasteMenuItem}
 
                             {(showCutAction || showReplaceAction || showCopyAction || canPaste) &&
-                                (showRenameAction || hasSavedPosition) && <ContextMenuSeparator className="m-0" />}
+                                (showRenameAction || hasSavedPosition || showInfoAction) && (
+                                    <ContextMenuSeparator className="m-0" />
+                                )}
 
                             {showRenameAction && (
                                 <ContextMenuItem className="dropdown-menu-item gap-2" onClick={onRename}>
@@ -169,6 +183,13 @@ const WorkflowNodeContextMenu = ({
                                 <ContextMenuItem className="dropdown-menu-item gap-2" onClick={onResetPosition}>
                                     <RefreshCcwIcon className="size-4 shrink-0" />
                                     Reset position
+                                </ContextMenuItem>
+                            )}
+
+                            {showInfoAction && (
+                                <ContextMenuItem className="dropdown-menu-item gap-2" onClick={onInfo}>
+                                    <InfoIcon className="size-4 shrink-0" />
+                                    Info
                                 </ContextMenuItem>
                             )}
 

--- a/client/src/pages/platform/workflow-editor/nodes/AiAgentNode.tsx
+++ b/client/src/pages/platform/workflow-editor/nodes/AiAgentNode.tsx
@@ -1,15 +1,14 @@
 import Button from '@/components/Button/Button';
-import {HoverCard, HoverCardContent, HoverCardTrigger} from '@/components/ui/hover-card';
+import {Popover, PopoverContent, PopoverTrigger} from '@/components/ui/popover';
 import {Skeleton} from '@/components/ui/skeleton';
 import {Tooltip, TooltipContent, TooltipTrigger} from '@/components/ui/tooltip';
 import WorkflowNodeContextMenu from '@/pages/platform/workflow-editor/components/WorkflowNodeContextMenu';
 import {useGetWorkflowNodeDescriptionQuery} from '@/shared/queries/platform/workflowNodeDescriptions.queries';
 import {useEnvironmentStore} from '@/shared/stores/useEnvironmentStore';
 import {NodeDataType} from '@/shared/types';
-import {HoverCardPortal} from '@radix-ui/react-hover-card';
 import {useQueryClient} from '@tanstack/react-query';
 import {Handle, Position} from '@xyflow/react';
-import {CheckIcon, ComponentIcon} from 'lucide-react';
+import {CheckIcon, ComponentIcon, PinOffIcon, TrashIcon, XIcon} from 'lucide-react';
 import {ChangeEvent, FocusEvent, KeyboardEvent, memo, useCallback, useMemo, useState} from 'react';
 import InlineSVG from 'react-inlinesvg';
 import sanitize from 'sanitize-html';
@@ -33,7 +32,7 @@ import saveWorkflowDefinition from '../utils/saveWorkflowDefinition';
 import styles from './NodeTypes.module.css';
 
 const AiAgentNode = ({data, id}: {data: NodeDataType; id: string}) => {
-    const [hoveredNodeName, setHoveredNodeName] = useState<string | undefined>();
+    const [infoCardOpen, setInfoCardOpen] = useState(false);
     const [renameValue, setRenameValue] = useState('');
     const layoutDirection = useLayoutDirectionStore((state) => state.layoutDirection);
 
@@ -50,7 +49,6 @@ const AiAgentNode = ({data, id}: {data: NodeDataType; id: string}) => {
             workflow: state.workflow,
         }))
     );
-    const clusterElementsCanvasOpen = useWorkflowEditorStore((state) => state.clusterElementsCanvasOpen);
     const {copiedNode, copiedWorkflowId, renamingNodeName, setCopiedNode, setCopiedWorkflowId, setRenamingNodeName} =
         useWorkflowEditorStore(
             useShallow((state) => ({
@@ -110,9 +108,9 @@ const AiAgentNode = ({data, id}: {data: NodeDataType; id: string}) => {
         {
             environmentId: currentEnvironmentId,
             id: workflow.id!,
-            workflowNodeName: hoveredNodeName!,
+            workflowNodeName: data.workflowNodeName,
         },
-        hoveredNodeName !== undefined
+        infoCardOpen
     );
 
     const handleNodeClick = useNodeClickHandler(data, id);
@@ -289,6 +287,7 @@ const AiAgentNode = ({data, id}: {data: NodeDataType; id: string}) => {
     );
 
     const isRenaming = renamingNodeName === data.name;
+    const suppressHover = isRenaming;
 
     const canPaste = useMemo(
         () => !!copiedNode && copiedWorkflowId === workflow.id,
@@ -305,6 +304,7 @@ const AiAgentNode = ({data, id}: {data: NodeDataType; id: string}) => {
             onCopy={handleCopyNode}
             onCut={handleCutNode}
             onDelete={handleDelete}
+            onInfo={() => setInfoCardOpen(true)}
             onPaste={handlePasteNode}
             onRename={handleStartRename}
             onResetPosition={handleResetPosition}
@@ -312,6 +312,7 @@ const AiAgentNode = ({data, id}: {data: NodeDataType; id: string}) => {
             showCopyAction
             showCutAction
             showDeleteAction
+            showInfoAction
             showRenameAction
         >
             <div
@@ -322,18 +323,41 @@ const AiAgentNode = ({data, id}: {data: NodeDataType; id: string}) => {
                 data-nodetype="clusterRoot"
                 key={id}
             >
-                <HoverCard
-                    key={id}
-                    onOpenChange={(open) => {
-                        if (open) {
-                            setHoveredNodeName(data.name);
-                        } else {
-                            setHoveredNodeName(undefined);
-                        }
-                    }}
-                    open={false}
+                <div
+                    className={twMerge(
+                        'invisible absolute top-0 left-workflow-node-popover-hover pr-4',
+                        !suppressHover && 'group-hover:visible'
+                    )}
                 >
-                    <HoverCardTrigger>
+                    <div className="flex flex-col gap-1">
+                        <Button
+                            className="opacity-100"
+                            icon={<TrashIcon />}
+                            onClick={() => handleDeleteNodeClick(data)}
+                            size="iconSm"
+                            title="Delete a node"
+                            variant="destructiveGhost"
+                        />
+
+                        {hasSavedNodePosition && (
+                            <Button
+                                icon={<PinOffIcon />}
+                                onClick={() => handleRemoveNodePosition(data.name)}
+                                size="iconSm"
+                                title="Remove saved node position"
+                                variant="ghost"
+                            />
+                        )}
+                    </div>
+                </div>
+
+                <Popover
+                    onOpenChange={(open) => {
+                        if (!open) setInfoCardOpen(false);
+                    }}
+                    open={infoCardOpen}
+                >
+                    <PopoverTrigger asChild>
                         <Button
                             className="flex h-auto min-h-18 w-full flex-col items-center justify-center rounded-md border-2 border-stroke-neutral-tertiary bg-surface-neutral-primary p-4 shadow-sm hover:border-stroke-brand-secondary-hover hover:bg-surface-neutral-primary hover:shadow-none focus-visible:ring-stroke-brand-focus active:bg-surface-neutral-primary"
                             onClick={handleNodeClick}
@@ -407,30 +431,46 @@ const AiAgentNode = ({data, id}: {data: NodeDataType; id: string}) => {
                                 </ul>
                             )}
                         </Button>
-                    </HoverCardTrigger>
+                    </PopoverTrigger>
 
-                    {!clusterElementsCanvasOpen && (
-                        <HoverCardPortal>
-                            <HoverCardContent className="w-fit max-w-xl min-w-72 text-sm" side="right">
-                                {workflowNodeDescription?.description && (
-                                    <div
-                                        className="flex"
-                                        dangerouslySetInnerHTML={{
-                                            __html: sanitize(workflowNodeDescription.description, {
-                                                allowedAttributes: {
-                                                    div: ['class'],
-                                                    table: ['class'],
-                                                    td: ['class'],
-                                                    tr: ['class'],
-                                                },
-                                            }),
-                                        }}
-                                    />
-                                )}
-                            </HoverCardContent>
-                        </HoverCardPortal>
-                    )}
-                </HoverCard>
+                    <PopoverContent
+                        className="w-fit max-w-xl min-w-72 text-sm"
+                        onFocusOutside={(event) => event.preventDefault()}
+                        onOpenAutoFocus={(event) => event.preventDefault()}
+                        side="right"
+                    >
+                        <div className="mb-2 flex items-center justify-between gap-2">
+                            <span className="font-semibold">{nodeLabel}</span>
+
+                            <Button
+                                className="hover:bg-transparent active:bg-transparent"
+                                icon={<XIcon />}
+                                onClick={() => setInfoCardOpen(false)}
+                                size="iconXs"
+                                title="Close"
+                                variant="ghost"
+                            />
+                        </div>
+
+                        {workflowNodeDescription?.description ? (
+                            <div
+                                className="flex"
+                                dangerouslySetInnerHTML={{
+                                    __html: sanitize(workflowNodeDescription.description, {
+                                        allowedAttributes: {
+                                            div: ['class'],
+                                            table: ['class'],
+                                            td: ['class'],
+                                            tr: ['class'],
+                                        },
+                                    }),
+                                }}
+                            />
+                        ) : (
+                            <p className="text-xs text-content-neutral-secondary">No description available.</p>
+                        )}
+                    </PopoverContent>
+                </Popover>
 
                 <div
                     className={twMerge(

--- a/client/src/pages/platform/workflow-editor/nodes/WorkflowNode.tsx
+++ b/client/src/pages/platform/workflow-editor/nodes/WorkflowNode.tsx
@@ -224,7 +224,7 @@ const WorkflowNodeContent = forwardRef<HTMLDivElement, WorkflowNodeContentProps>
                         side="right"
                     >
                         <div className="mb-2 flex items-center justify-between gap-2">
-                            <span className="font-semibold">{nodeLabel}</span>
+                            <h3 className="text-lg font-semibold">{nodeLabel}</h3>
 
                             <Button
                                 className="hover:bg-transparent active:bg-transparent"

--- a/client/src/pages/platform/workflow-editor/nodes/WorkflowNode.tsx
+++ b/client/src/pages/platform/workflow-editor/nodes/WorkflowNode.tsx
@@ -1,5 +1,5 @@
 import Button from '@/components/Button/Button';
-import {HoverCardContent, HoverCardTrigger} from '@/components/ui/hover-card';
+import {Popover, PopoverContent, PopoverTrigger} from '@/components/ui/popover';
 import WorkflowNodeContextMenu from '@/pages/platform/workflow-editor/components/WorkflowNodeContextMenu';
 import WorkflowNodesPopoverMenu from '@/pages/platform/workflow-editor/components/WorkflowNodesPopoverMenu';
 import {useWorkflowEditor} from '@/pages/platform/workflow-editor/providers/workflowEditorProvider';
@@ -9,10 +9,9 @@ import {useGetClusterElementDefinitionQuery} from '@/shared/queries/platform/clu
 import {useGetWorkflowNodeDescriptionQuery} from '@/shared/queries/platform/workflowNodeDescriptions.queries';
 import {useEnvironmentStore} from '@/shared/stores/useEnvironmentStore';
 import {ClusterElementsType, NodeDataType} from '@/shared/types';
-import {HoverCard, HoverCardPortal} from '@radix-ui/react-hover-card';
 import {useQueryClient} from '@tanstack/react-query';
 import {Handle, Position} from '@xyflow/react';
-import {CheckIcon, ComponentIcon} from 'lucide-react';
+import {CheckIcon, ComponentIcon, XIcon} from 'lucide-react';
 import {KeyboardEvent, forwardRef, memo, useCallback, useMemo, useState} from 'react';
 import sanitize from 'sanitize-html';
 import {twMerge} from 'tailwind-merge';
@@ -52,6 +51,7 @@ interface WorkflowNodeContentProps extends Omit<React.HTMLAttributes<HTMLDivElem
     handleRenameSubmit: (newLabel: string) => void;
     hasSavedClusterElementPosition: NodePositionType;
     id: string;
+    infoCardOpen: boolean;
     isClusterElement: string | undefined;
     isHorizontal: boolean;
     isMainRootClusterElement: boolean;
@@ -62,7 +62,7 @@ interface WorkflowNodeContentProps extends Omit<React.HTMLAttributes<HTMLDivElem
     nodeDescription: string | undefined;
     nodeLabel: string | undefined;
     nodeWidth: number;
-    onHoveredNodeNameChange: (name: string | undefined) => void;
+    onInfoClose: () => void;
     parentClusterRootId: string | undefined;
     renameValue: string;
     setRenameValue: (value: string) => void;
@@ -83,6 +83,7 @@ const WorkflowNodeContent = forwardRef<HTMLDivElement, WorkflowNodeContentProps>
             handleRenameSubmit,
             hasSavedClusterElementPosition,
             id,
+            infoCardOpen,
             isClusterElement,
             isHorizontal,
             isMainRootClusterElement,
@@ -93,7 +94,7 @@ const WorkflowNodeContent = forwardRef<HTMLDivElement, WorkflowNodeContentProps>
             nodeDescription,
             nodeLabel,
             nodeWidth,
-            onHoveredNodeNameChange,
+            onInfoClose,
             parentClusterRootId,
             renameValue,
             setRenameValue,
@@ -143,14 +144,13 @@ const WorkflowNodeContent = forwardRef<HTMLDivElement, WorkflowNodeContentProps>
                 />
             )}
 
-            <HoverCard
-                key={id}
+            <Popover
                 onOpenChange={(open) => {
-                    onHoveredNodeNameChange(open ? data.name : undefined);
+                    if (!open) onInfoClose();
                 }}
-                open={false}
+                open={infoCardOpen}
             >
-                <HoverCardTrigger>
+                <PopoverTrigger asChild>
                     <Button
                         aria-label={`${data.workflowNodeName} node`}
                         className={twMerge(
@@ -214,30 +214,48 @@ const WorkflowNodeContent = forwardRef<HTMLDivElement, WorkflowNodeContentProps>
                             )}
                         </div>
                     </Button>
-                </HoverCardTrigger>
+                </PopoverTrigger>
 
                 {!isMainRootClusterElement && (
-                    <HoverCardPortal>
-                        <HoverCardContent className="w-fit max-w-xl min-w-72 text-sm" side="right">
-                            {nodeDescription && (
-                                <div
-                                    className="flex"
-                                    dangerouslySetInnerHTML={{
-                                        __html: sanitize(nodeDescription, {
-                                            allowedAttributes: {
-                                                div: ['class'],
-                                                table: ['class'],
-                                                td: ['class'],
-                                                tr: ['class'],
-                                            },
-                                        }),
-                                    }}
-                                />
-                            )}
-                        </HoverCardContent>
-                    </HoverCardPortal>
+                    <PopoverContent
+                        className="w-fit max-w-xl min-w-72 text-sm"
+                        onFocusOutside={(event) => event.preventDefault()}
+                        onOpenAutoFocus={(event) => event.preventDefault()}
+                        side="right"
+                    >
+                        <div className="mb-2 flex items-center justify-between gap-2">
+                            <span className="font-semibold">{nodeLabel}</span>
+
+                            <Button
+                                className="hover:bg-transparent active:bg-transparent"
+                                icon={<XIcon />}
+                                onClick={onInfoClose}
+                                size="iconXs"
+                                title="Close"
+                                variant="ghost"
+                            />
+                        </div>
+
+                        {nodeDescription ? (
+                            <div
+                                className="flex"
+                                dangerouslySetInnerHTML={{
+                                    __html: sanitize(nodeDescription, {
+                                        allowedAttributes: {
+                                            div: ['class'],
+                                            table: ['class'],
+                                            td: ['class'],
+                                            tr: ['class'],
+                                        },
+                                    }),
+                                }}
+                            />
+                        ) : (
+                            <p className="text-xs text-content-neutral-secondary">No description available.</p>
+                        )}
+                    </PopoverContent>
                 )}
-            </HoverCard>
+            </Popover>
 
             {!(isMainRootClusterElement || isNestedClusterRoot) && (
                 <div
@@ -403,7 +421,7 @@ const WorkflowNodeContent = forwardRef<HTMLDivElement, WorkflowNodeContentProps>
 WorkflowNodeContent.displayName = 'WorkflowNodeContent';
 
 const WorkflowNode = ({data, id}: {data: NodeDataType; id: string}) => {
-    const [hoveredNodeName, setHoveredNodeName] = useState<string | undefined>();
+    const [infoCardOpen, setInfoCardOpen] = useState(false);
     const [renameValue, setRenameValue] = useState('');
     const [switchPopoverOpen, setSwitchPopoverOpen] = useState(false);
 
@@ -491,9 +509,9 @@ const WorkflowNode = ({data, id}: {data: NodeDataType; id: string}) => {
         {
             environmentId: currentEnvironmentId,
             id: workflow.id!,
-            workflowNodeName: hoveredNodeName as string,
+            workflowNodeName: data.name,
         },
-        hoveredNodeName !== undefined && !data.clusterElementType
+        infoCardOpen && !data.clusterElementType
     );
 
     const {data: clusterElementDefinitionData} = useGetClusterElementDefinitionQuery(
@@ -502,7 +520,7 @@ const WorkflowNode = ({data, id}: {data: NodeDataType; id: string}) => {
             componentName: data.componentName,
             componentVersion: data.version as number,
         },
-        hoveredNodeName !== undefined && !!data.clusterElementType
+        infoCardOpen && !!data.clusterElementType
     );
 
     const filteredClusterElementTypes = useMemo(() => {
@@ -749,6 +767,7 @@ const WorkflowNode = ({data, id}: {data: NodeDataType; id: string}) => {
         handleRenameSubmit,
         hasSavedClusterElementPosition,
         id,
+        infoCardOpen,
         isClusterElement,
         isHorizontal,
         isMainRootClusterElement,
@@ -759,7 +778,7 @@ const WorkflowNode = ({data, id}: {data: NodeDataType; id: string}) => {
         nodeDescription,
         nodeLabel,
         nodeWidth,
-        onHoveredNodeNameChange: setHoveredNodeName,
+        onInfoClose: () => setInfoCardOpen(false),
         parentClusterRootId,
         renameValue,
         setRenameValue,
@@ -777,6 +796,7 @@ const WorkflowNode = ({data, id}: {data: NodeDataType; id: string}) => {
                 onCopy={handleCopyNode}
                 onCut={handleCutNode}
                 onDelete={handleDelete}
+                onInfo={() => setInfoCardOpen(true)}
                 onPaste={handlePasteNode}
                 onRename={handleStartRename}
                 onResetPosition={handleResetPosition}
@@ -784,6 +804,7 @@ const WorkflowNode = ({data, id}: {data: NodeDataType; id: string}) => {
                 showCopyAction
                 showCutAction
                 showDeleteAction
+                showInfoAction
                 showRenameAction
             >
                 <WorkflowNodeContent {...sharedContentProps} />
@@ -797,10 +818,12 @@ const WorkflowNode = ({data, id}: {data: NodeDataType; id: string}) => {
                 data={data}
                 hasSavedPosition={!!hasSavedClusterElementPosition}
                 onDelete={handleDelete}
+                onInfo={() => setInfoCardOpen(true)}
                 onRename={handleStartRename}
                 onResetPosition={() => handleRemoveSavedClusterElementPosition(data.workflowNodeName)}
                 onSwitch={handleSwitch}
                 showDeleteAction
+                showInfoAction
                 showRenameAction
                 showReplaceAction={!data.multipleClusterElementsNode}
             >


### PR DESCRIPTION
fixes #5268 

feat(workflow-editor): replace hover info card with Info context menu action

[Screencast from 2026-06-23 15-25-27.webm](https://github.com/user-attachments/assets/fa01040c-9a47-4c74-8d96-04b1ccd681da)


- Add "Info" item to node right-click context menu (WorkflowNodeContextMenu),
  positioned after Reset position / Rename
- Replace hover-triggered HoverCard with a controlled Popover in WorkflowNode
  and AiAgentNode, opened via the new context menu action instead of hover
- Remove dead hover-related state and store subscriptions no longer needed
  after the hover trigger was dropped
- Add close (X) button to the info card, aligned with the node name heading,
  sized 12x12px with transparent hover/active background


<img width="607" height="499" alt="image" src="https://github.com/user-attachments/assets/26f3a65a-6634-4a95-92d5-855bfa24ca0d" />
<img width="748" height="366" alt="image" src="https://github.com/user-attachments/assets/d72c1f99-72ad-4bfa-9ea5-9754199462c3" />

