### PR TITLE
5273 client - Prevent invalid property expression from bricking workflow node

### DIFF
--- a/client/src/pages/platform/workflow-editor/components/datapills/DataPill.tsx
+++ b/client/src/pages/platform/workflow-editor/components/datapills/DataPill.tsx
@@ -1,11 +1,14 @@
 import {Tooltip, TooltipContent, TooltipTrigger} from '@/components/ui/tooltip';
 import useWorkflowNodeDetailsPanelStore from '@/pages/platform/workflow-editor/stores/useWorkflowNodeDetailsPanelStore';
-import {encodePath, transformPathForObjectAccess} from '@/pages/platform/workflow-editor/utils/encodingUtils';
+import {
+    encodePath,
+    safeResolvePath,
+    transformPathForObjectAccess,
+} from '@/pages/platform/workflow-editor/utils/encodingUtils';
 import getNestedObject from '@/pages/platform/workflow-editor/utils/getNestedObject';
 import {TYPE_ICONS} from '@/shared/typeIcons';
 import {ComponentType, DataPillDragPayloadType, PropertyAllType} from '@/shared/types';
 import {Editor} from '@tiptap/react';
-import resolvePath from 'object-resolve-path';
 import {DragEvent, MouseEvent} from 'react';
 import {twMerge} from 'tailwind-merge';
 import {useShallow} from 'zustand/react/shallow';
@@ -42,7 +45,7 @@ export const canInsertMentionForProperty = (
 
     try {
         const resolvedPath = transformPathForObjectAccess(encodePath(path));
-        const existingValue = resolvePath(parameters, resolvedPath);
+        const existingValue = safeResolvePath(parameters, resolvedPath);
 
         return !existingValue || String(existingValue).startsWith('=');
     } catch {

--- a/client/src/pages/platform/workflow-editor/components/properties/hooks/useArrayProperty.ts
+++ b/client/src/pages/platform/workflow-editor/components/properties/hooks/useArrayProperty.ts
@@ -3,11 +3,10 @@ import useWorkflowNodeDetailsPanelStore from '@/pages/platform/workflow-editor/s
 import {VALUE_PROPERTY_CONTROL_TYPES} from '@/shared/constants';
 import {ControlType, ObjectProperty, PropertyType} from '@/shared/middleware/platform/configuration';
 import {ArrayPropertyType, ComponentType, PropertyAllType} from '@/shared/types';
-import resolvePath from 'object-resolve-path';
 import {Dispatch, SetStateAction, useCallback, useEffect, useMemo, useState} from 'react';
 
 import useWorkflowDataStore from '../../../stores/useWorkflowDataStore';
-import {decodePath, encodeParameters, encodePath} from '../../../utils/encodingUtils';
+import {decodePath, encodeParameters, encodePath, safeResolvePath} from '../../../utils/encodingUtils';
 import getParameterItemType from '../../../utils/getParameterItemType';
 import saveProperty from '../../../utils/saveProperty';
 
@@ -186,7 +185,7 @@ export function useArrayProperty({onDeleteClick, parentArrayItems, path, propert
                 return existingItem;
             }
 
-            const savedValue = resolvePath(encodedParameters, `${encodedBasePath}[${existingIndex}]`);
+            const savedValue = safeResolvePath(encodedParameters, `${encodedBasePath}[${existingIndex}]`);
 
             if (savedValue === undefined || savedValue === null) {
                 return existingItem;
@@ -233,7 +232,7 @@ export function useArrayProperty({onDeleteClick, parentArrayItems, path, propert
                 return;
             }
 
-            const clickedItemParameterValue = resolvePath(currentComponent.parameters ?? {}, deletePath);
+            const clickedItemParameterValue = safeResolvePath(currentComponent.parameters ?? {}, deletePath);
 
             if (clickedItemParameterValue !== undefined) {
                 onDeleteClick(deletePath);
@@ -309,7 +308,7 @@ export function useArrayProperty({onDeleteClick, parentArrayItems, path, propert
         const encodedParameters = encodeParameters(currentComponent.parameters);
         const encodedPath = encodePath(path);
 
-        const parameterValue = resolvePath(encodedParameters, encodedPath);
+        const parameterValue = safeResolvePath(encodedParameters, encodedPath);
 
         if (parameterValue === undefined) {
             return;
@@ -548,10 +547,10 @@ export function useArrayPropertyItem({
             const encodedParameters = encodeParameters(currentComponent.parameters);
             const encodedBasePath = encodePath(basePath);
 
-            let resolvedArray = resolvePath(encodedParameters, encodedBasePath);
+            let resolvedArray = safeResolvePath(encodedParameters, encodedBasePath);
 
             if (!Array.isArray(resolvedArray)) {
-                resolvedArray = resolvePath(currentComponent.parameters as Record<string, unknown>, basePath);
+                resolvedArray = safeResolvePath(currentComponent.parameters as Record<string, unknown>, basePath);
             }
 
             if (Array.isArray(resolvedArray)) {

--- a/client/src/pages/platform/workflow-editor/components/properties/hooks/useObjectProperty.ts
+++ b/client/src/pages/platform/workflow-editor/components/properties/hooks/useObjectProperty.ts
@@ -4,11 +4,10 @@ import {VALUE_PROPERTY_CONTROL_TYPES} from '@/shared/constants';
 import {ControlType, PropertyType} from '@/shared/middleware/platform/configuration';
 import {PropertyAllType, SubPropertyType} from '@/shared/types';
 import isObject from 'isobject';
-import resolvePath from 'object-resolve-path';
 import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 
 import useWorkflowDataStore from '../../../stores/useWorkflowDataStore';
-import {decodePath, encodeParameters, encodePath} from '../../../utils/encodingUtils';
+import {decodePath, encodeParameters, encodePath, safeResolvePath} from '../../../utils/encodingUtils';
 import getParameterItemType from '../../../utils/getParameterItemType';
 import saveProperty from '../../../utils/saveProperty';
 
@@ -311,7 +310,7 @@ export const useObjectProperty = ({onDeleteClick, path, property}: UseObjectProp
         const encodedParameters = encodeParameters(currentComponent.parameters);
         const encodedPath = encodePath(path);
 
-        const resolvedParameterObject = resolvePath(encodedParameters, encodedPath);
+        const resolvedParameterObject = safeResolvePath(encodedParameters, encodedPath);
 
         const parameterObject: {[key: string]: unknown} = {};
 
@@ -444,7 +443,7 @@ export const useObjectProperty = ({onDeleteClick, path, property}: UseObjectProp
         const encodedParameters = encodeParameters(currentComponent.parameters ?? {});
         const encodedPath = encodePath(path);
 
-        const existingObject = resolvePath(encodedParameters, encodedPath);
+        const existingObject = safeResolvePath(encodedParameters, encodedPath);
 
         if (existingObject && isObject(existingObject)) {
             return;

--- a/client/src/pages/platform/workflow-editor/components/properties/hooks/useProperty.ts
+++ b/client/src/pages/platform/workflow-editor/components/properties/hooks/useProperty.ts
@@ -6,7 +6,12 @@ import useWorkflowDataStore from '@/pages/platform/workflow-editor/stores/useWor
 import useWorkflowEditorStore from '@/pages/platform/workflow-editor/stores/useWorkflowEditorStore';
 import useWorkflowNodeDetailsPanelStore from '@/pages/platform/workflow-editor/stores/useWorkflowNodeDetailsPanelStore';
 import deleteProperty from '@/pages/platform/workflow-editor/utils/deleteProperty';
-import {decodePath, encodeParameters, encodePath} from '@/pages/platform/workflow-editor/utils/encodingUtils';
+import {
+    decodePath,
+    encodeParameters,
+    encodePath,
+    safeResolvePath,
+} from '@/pages/platform/workflow-editor/utils/encodingUtils';
 import saveProperty from '@/pages/platform/workflow-editor/utils/saveProperty';
 import {ERROR_MESSAGES} from '@/shared/errorMessages';
 import {
@@ -22,7 +27,6 @@ import {ArrayPropertyType, ClusterElementItemType, ComponentType, NodeDataType, 
 import {UseQueryResult} from '@tanstack/react-query';
 import {Editor} from '@tiptap/react';
 import {usePrevious} from '@uidotdev/usehooks';
-import resolvePath from 'object-resolve-path';
 import {
     ChangeEvent,
     Dispatch,
@@ -983,7 +987,10 @@ export const useProperty = ({
             return;
         }
 
-        const parentParameterValue = resolvePath(encodeParameters(currentComponent.parameters ?? {}), encodePath(path));
+        const parentParameterValue = safeResolvePath(
+            encodeParameters(currentComponent.parameters ?? {}),
+            encodePath(path)
+        );
 
         if (mentionInput && !mentionInputValue) {
             return;
@@ -1308,7 +1315,7 @@ export const useProperty = ({
                     return;
                 }
 
-                const valueFromDefinition = resolvePath(encodedParameters, encodedPath);
+                const valueFromDefinition = safeResolvePath(encodedParameters, encodedPath);
 
                 if (valueFromDefinition !== undefined && valueFromDefinition !== null) {
                     setPropertyParameterValue(valueFromDefinition);
@@ -1339,7 +1346,7 @@ export const useProperty = ({
             encodedPath &&
             (objectName === undefined || dynamicPropertySource === objectName) &&
             (updateWorkflowNodeParameterMutation || updateClusterElementParameterMutation) &&
-            resolvePath(encodedParameters, encodedPath) !== defaultValue;
+            safeResolvePath(encodedParameters, encodedPath) !== defaultValue;
 
         if (shouldSaveHiddenProperty) {
             const saveDefaultValue = () => {
@@ -1389,7 +1396,7 @@ export const useProperty = ({
             return;
         }
 
-        const valueFromDefinition = resolvePath(encodedParameters, encodedPath);
+        const valueFromDefinition = safeResolvePath(encodedParameters, encodedPath);
 
         const effectiveValue = parameterValue !== undefined ? parameterValue : valueFromDefinition;
 
@@ -1580,7 +1587,7 @@ export const useProperty = ({
 
         const optionsLookupDependsOnValues: unknown[] = optionsDataSource.optionsLookupDependsOn.map(
             (optionLookupDependency) => {
-                const resolvedValue = resolvePath(
+                const resolvedValue = safeResolvePath(
                     currentComponent.parameters,
                     optionLookupDependency.replace('[index]', `[${arrayIndex}]`)
                 );
@@ -1612,7 +1619,7 @@ export const useProperty = ({
 
         const propertiesLookupDependsOnValues: unknown[] = propertiesDataSource.propertiesLookupDependsOn.map(
             (propertyLookupDependency) => {
-                const resolvedValue = resolvePath(
+                const resolvedValue = safeResolvePath(
                     currentComponent.parameters,
                     propertyLookupDependency.replace('[index]', `[${arrayIndex}]`)
                 );
@@ -1680,7 +1687,7 @@ export const useProperty = ({
 
         const encodedPath = encodePath(path);
 
-        const valueFromWorkflowDefinition = resolvePath(encodedParameters, encodedPath);
+        const valueFromWorkflowDefinition = safeResolvePath(encodedParameters, encodedPath);
 
         const nextParameterValue =
             parameterValueRef.current !== undefined ? parameterValueRef.current : valueFromWorkflowDefinition;

--- a/client/src/pages/platform/workflow-editor/utils/encodingUtils.test.ts
+++ b/client/src/pages/platform/workflow-editor/utils/encodingUtils.test.ts
@@ -1,0 +1,26 @@
+import {describe, expect, it} from 'vitest';
+
+import {safeResolvePath} from './encodingUtils';
+
+describe('safeResolvePath', () => {
+    it('resolves a value at a valid path', () => {
+        expect(safeResolvePath({input: {name: 'value'}}, 'input.name')).toBe('value');
+    });
+
+    it('returns undefined for a valid path that does not exist', () => {
+        expect(safeResolvePath({input: {}}, 'input.missing')).toBeUndefined();
+    });
+
+    it('returns undefined instead of throwing for an invalid object path', () => {
+        // A user typing n8n-style "${httpClient_1}" as an OBJECT property key produces a path
+        // segment containing "{"/"}", which object-resolve-path rejects as invalid and throws on.
+        // The lookup must degrade to undefined so a bad expression never bricks the node.
+        expect(() => safeResolvePath({input: {}}, 'input.${httpClient_1}')).not.toThrow();
+        expect(safeResolvePath({input: {}}, 'input.${httpClient_1}')).toBeUndefined();
+    });
+
+    it('returns undefined instead of throwing when the object is undefined', () => {
+        expect(() => safeResolvePath(undefined, 'input.name')).not.toThrow();
+        expect(safeResolvePath(undefined, 'input.name')).toBeUndefined();
+    });
+});

--- a/client/src/pages/platform/workflow-editor/utils/encodingUtils.ts
+++ b/client/src/pages/platform/workflow-editor/utils/encodingUtils.ts
@@ -10,6 +10,7 @@ import {
     PATH_UNICODE_REPLACEMENT_PREFIX,
 } from '@/shared/constants';
 import isObject from 'isobject';
+import resolvePath from 'object-resolve-path';
 
 interface EncodeParametersGenericProps {
     matchPattern: RegExp;
@@ -201,6 +202,24 @@ export function encodePath(path: string): string {
     encodedPath = encodePathGeneric(encodedPath, /:/g, PATH_COLON_REPLACEMENT);
 
     return encodedPath;
+}
+
+/**
+ * Resolves a value at the given path, returning undefined instead of throwing when the path is
+ * invalid or unresolvable.
+ *
+ * `object-resolve-path` throws "path is not a valid object path" for segments that aren't valid
+ * identifiers (e.g. a user typing "${httpClient_1}" as an OBJECT property key, which leaves "{"/"}"
+ * in the path). These lookups are best-effort "what is the current value here?" reads where a
+ * missing/invalid path simply means "no value", so the throw must degrade to undefined — otherwise
+ * the error escapes to the editor's error boundary and leaves the node permanently broken.
+ */
+export function safeResolvePath(object: object | undefined, path: string): unknown {
+    try {
+        return resolvePath(object, path);
+    } catch {
+        return undefined;
+    }
 }
 
 function encodeNonAsciiCharacters(string: string): string {

--- a/client/src/pages/platform/workflow-editor/utils/encodingUtils.ts
+++ b/client/src/pages/platform/workflow-editor/utils/encodingUtils.ts
@@ -213,8 +213,17 @@ export function encodePath(path: string): string {
  * in the path). These lookups are best-effort "what is the current value here?" reads where a
  * missing/invalid path simply means "no value", so the throw must degrade to undefined — otherwise
  * the error escapes to the editor's error boundary and leaves the node permanently broken.
+ *
+ * "{"/"}" can never appear in a resolvable path (object-resolve-path uses dot and bracket-index
+ * notation), so a fast-path guard short-circuits the motivating case — an expression being typed —
+ * without paying the throw/catch cost on every lookup. The try/catch remains as a backstop for any
+ * other invalid path.
  */
 export function safeResolvePath(object: object | undefined, path: string): unknown {
+    if (object === undefined || path.includes('{') || path.includes('}')) {
+        return undefined;
+    }
+
     try {
         return resolvePath(object, path);
     } catch {


### PR DESCRIPTION
Typing an unresolvable expression (e.g. an n8n-style ${node} as an OBJECT
property key) made object-resolve-path throw "path is not a valid object
path". The throw escaped to the editor ErrorBoundary, which latches and only
recovers via its own button, so clearing the field left the node dead until
deleted and recreated.

These resolvePath calls are best-effort value lookups where an invalid or
missing path should mean "no value". Add a non-throwing safeResolvePath
wrapper and route all property/datapill lookups through it, so a bad
expression degrades to undefined instead of crashing the node.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
