### PR TITLE
5279 Set MDC tenantId per tenant during multi-tenant changelog upgrade

### DIFF
--- a/server/ee/libs/core/tenant/tenant-multi-service/src/main/java/com/bytechef/ee/tenant/service/MultiTenantService.java
+++ b/server/ee/libs/core/tenant/tenant-multi-service/src/main/java/com/bytechef/ee/tenant/service/MultiTenantService.java
@@ -19,6 +19,7 @@ package com.bytechef.ee.tenant.service;
 import com.bytechef.ee.tenant.repository.TenantRepository;
 import com.bytechef.ee.tenant.util.TenantUtils;
 import com.bytechef.platform.annotation.ConditionalOnEEVersion;
+import com.bytechef.tenant.TenantContext;
 import com.bytechef.tenant.annotation.ConditionalOnMultiTenant;
 import com.bytechef.tenant.constant.Tenancy;
 import com.bytechef.tenant.domain.Tenant;
@@ -31,7 +32,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.concurrent.locks.ReentrantLock;
-import java.util.stream.Collectors;
 import javax.sql.DataSource;
 import liquibase.integration.spring.MultiTenantSpringLiquibase;
 import org.slf4j.Logger;
@@ -157,29 +157,24 @@ public class MultiTenantService implements TenantService, ResourceLoaderAware {
 
     @Override
     public void loadChangelog(List<String> tenantIds, Tenancy tenancy) {
+        for (String tenantId : tenantIds) {
+            TenantContext.runWithTenantId(tenantId, () -> loadChangelog(tenantId, tenancy));
+        }
+    }
+
+    void loadChangelog(String tenantId, Tenancy tenancy) throws Exception {
         MultiTenantSpringLiquibase multiTenantSpringLiquibase = new MultiTenantSpringLiquibase();
 
         multiTenantSpringLiquibase.setContexts(getRuntimeContext(tenancy));
         multiTenantSpringLiquibase.setDataSource(dataSource);
         multiTenantSpringLiquibase.setResourceLoader(resourceLoader);
-
-        List<String> schemas =
-            tenantIds
-                .stream()
-                .map(TenantUtils::getDatabaseSchema)
-                .collect(Collectors.toList());
-
-        multiTenantSpringLiquibase.setSchemas(schemas);
+        multiTenantSpringLiquibase.setSchemas(List.of(TenantUtils.getDatabaseSchema(tenantId)));
         multiTenantSpringLiquibase.setChangeLog("classpath:config/liquibase/master.xml");
         multiTenantSpringLiquibase.setDefaultSchema(liquibaseProperties.getDefaultSchema());
         multiTenantSpringLiquibase.setDropFirst(liquibaseProperties.isDropFirst());
         multiTenantSpringLiquibase.setParameters(liquibaseProperties.getParameters());
 
-        try {
-            multiTenantSpringLiquibase.afterPropertiesSet();
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+        multiTenantSpringLiquibase.afterPropertiesSet();
     }
 
     @Override

--- a/server/ee/libs/core/tenant/tenant-multi-service/src/test/java/com/bytechef/ee/tenant/service/MultiTenantServiceTest.java
+++ b/server/ee/libs/core/tenant/tenant-multi-service/src/test/java/com/bytechef/ee/tenant/service/MultiTenantServiceTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025 ByteChef
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.bytechef.ee.tenant.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import com.bytechef.ee.tenant.repository.TenantRepository;
+import com.bytechef.tenant.TenantContext;
+import com.bytechef.tenant.constant.Tenancy;
+import java.util.ArrayList;
+import java.util.List;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
+import org.springframework.boot.liquibase.autoconfigure.LiquibaseProperties;
+import org.springframework.context.ApplicationEventPublisher;
+
+/**
+ * @author Ivica Cardic
+ */
+class MultiTenantServiceTest {
+
+    @AfterEach
+    void tearDown() {
+        TenantContext.resetCurrentTenantId();
+    }
+
+    @Test
+    void testLoadChangelogRunsEachTenantWithinItsTenantContext() {
+        List<String> capturedTenantIds = new ArrayList<>();
+
+        MultiTenantService multiTenantService = new MultiTenantService(
+            mock(DataSource.class), mock(ApplicationEventPublisher.class), mock(LiquibaseProperties.class),
+            mock(TenantRepository.class)) {
+
+            @Override
+            void loadChangelog(String tenantId, Tenancy tenancy) {
+                capturedTenantIds.add(MDC.get("tenantId"));
+            }
+        };
+
+        multiTenantService.loadChangelog(List.of("000001", "000002"), Tenancy.MULTITENANT);
+
+        // The MDC tenantId observed while each tenant's changelog runs must match the tenant being upgraded,
+        // not the default "public" value (see GitHub issue bytechef-cloud#119).
+
+        assertThat(capturedTenantIds).containsExactly("000001", "000002");
+    }
+
+    @Test
+    void testLoadChangelogRestoresPreviousTenantId() {
+        MultiTenantService multiTenantService = new MultiTenantService(
+            mock(DataSource.class), mock(ApplicationEventPublisher.class), mock(LiquibaseProperties.class),
+            mock(TenantRepository.class)) {
+
+            @Override
+            void loadChangelog(String tenantId, Tenancy tenancy) {
+                // No-op: skip the real Liquibase run.
+                assertThat(tenantId).isNotBlank();
+            }
+        };
+
+        TenantContext.setCurrentTenantId("000099");
+
+        multiTenantService.loadChangelog(List.of("000001"), Tenancy.MULTITENANT);
+
+        // The tenant ID active before the upgrade must be restored afterward, not reset to the default "public".
+        assertThat(TenantContext.getCurrentTenantId()).isEqualTo("000099");
+    }
+}


### PR DESCRIPTION
Each tenant's Liquibase changelog now runs inside its own TenantContext so
the structured-log tenantId reflects the tenant being upgraded instead of
the default "public". The previous code handed all schemas to
MultiTenantSpringLiquibase at once, whose internal per-schema loop never
updated the MDC.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
