### PR TITLE
5283 Skip polling trigger poll cycle on provider 429 rate limit

### DIFF
--- a/sdks/backend/java/component-api/src/main/java/com/bytechef/component/exception/ProviderException.java
+++ b/sdks/backend/java/component-api/src/main/java/com/bytechef/component/exception/ProviderException.java
@@ -16,6 +16,10 @@
 
 package com.bytechef.component.exception;
 
+import com.bytechef.component.definition.HttpStatus;
+import java.util.List;
+import java.util.Map;
+
 /**
  * @author Igor Beslic
  * @author Ivica Cardic
@@ -23,6 +27,7 @@ package com.bytechef.component.exception;
 public class ProviderException extends RuntimeException {
 
     private Integer statusCode;
+    private String retryAfter;
 
     /**
      *
@@ -74,6 +79,56 @@ public class ProviderException extends RuntimeException {
      */
     public Integer getStatusCode() {
         return statusCode;
+    }
+
+    /**
+     * Returns the raw {@code Retry-After} header value the provider sent with this error, if any.
+     *
+     * @return the {@code Retry-After} value (delay-seconds or an HTTP-date), or {@code null} when absent
+     */
+    public String getRetryAfter() {
+        return retryAfter;
+    }
+
+    /**
+     * Whether this provider error is transient and worth retrying later rather than surfacing as a hard failure: an
+     * explicit rate limit (HTTP 429), a temporary unavailability (HTTP 503), or any response carrying a
+     * {@code Retry-After} header.
+     *
+     * @return true if the error is transient/retryable
+     */
+    public boolean isRetryable() {
+        if (retryAfter != null) {
+            return true;
+        }
+
+        if (statusCode == null) {
+            return false;
+        }
+
+        return statusCode == HttpStatus.TOO_MANY_REQUESTS.getValue() ||
+            statusCode == HttpStatus.SERVICE_UNAVAILABLE.getValue();
+    }
+
+    /**
+     * Walks the cause chain of the given throwable and reports whether any {@link ProviderException} in it is
+     * {@link #isRetryable() retryable}.
+     *
+     * @param throwable the throwable to inspect (may be {@code null})
+     * @return true if a retryable provider error is present anywhere in the cause chain
+     */
+    public static boolean isRetryable(Throwable throwable) {
+        Throwable current = throwable;
+
+        while (current != null) {
+            if (current instanceof ProviderException providerException && providerException.isRetryable()) {
+                return true;
+            }
+
+            current = current.getCause();
+        }
+
+        return false;
     }
 
     /**
@@ -145,5 +200,33 @@ public class ProviderException extends RuntimeException {
             case 404 -> new ProviderException.NotFoundException(message);
             default -> new ProviderException(statusCode, message);
         };
+    }
+
+    public static ProviderException getProviderException(
+        int statusCode, Object body, Map<String, List<String>> headers) {
+
+        ProviderException providerException = getProviderException(statusCode, body);
+
+        providerException.retryAfter = getRetryAfter(headers);
+
+        return providerException;
+    }
+
+    private static String getRetryAfter(Map<String, List<String>> headers) {
+        if (headers == null) {
+            return null;
+        }
+
+        for (Map.Entry<String, List<String>> entry : headers.entrySet()) {
+            if ("retry-after".equalsIgnoreCase(entry.getKey())) {
+                List<String> values = entry.getValue();
+
+                if (values != null && !values.isEmpty()) {
+                    return values.getFirst();
+                }
+            }
+        }
+
+        return null;
     }
 }

--- a/sdks/backend/java/component-api/src/test/java/com/bytechef/component/exception/ProviderExceptionTest.java
+++ b/sdks/backend/java/component-api/src/test/java/com/bytechef/component/exception/ProviderExceptionTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2025 ByteChef
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.bytechef.component.exception;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Ivica Cardic
+ */
+class ProviderExceptionTest {
+
+    @Test
+    void testIsRetryableForTooManyRequests() {
+        assertTrue(new ProviderException(429, "Quota exceeded").isRetryable());
+    }
+
+    @Test
+    void testIsRetryableForServiceUnavailable() {
+        assertTrue(new ProviderException(503, "Service unavailable").isRetryable());
+    }
+
+    @Test
+    void testIsNotRetryableForOtherStatusCodes() {
+        assertFalse(new ProviderException(400, "Bad request").isRetryable());
+        assertFalse(new ProviderException(401, "Unauthorized").isRetryable());
+        assertFalse(new ProviderException("No status code").isRetryable());
+    }
+
+    @Test
+    void testIsRetryableWhenRetryAfterPresentRegardlessOfStatus() {
+        // 409 is not retryable by status, but a Retry-After header makes it so.
+        ProviderException providerException = ProviderException.getProviderException(
+            409, "Conflict", Map.of("Retry-After", List.of("120")));
+
+        assertTrue(providerException.isRetryable());
+    }
+
+    @Test
+    void testGetProviderExceptionCapturesRetryAfterHeaderCaseInsensitively() {
+        ProviderException providerException = ProviderException.getProviderException(
+            503, "unavailable", Map.of("Retry-After", List.of("30")));
+
+        assertEquals("30", providerException.getRetryAfter());
+        assertTrue(providerException.isRetryable());
+
+        ProviderException lowerCaseHeader = ProviderException.getProviderException(
+            429, "quota", Map.of("retry-after", List.of("7")));
+
+        assertEquals("7", lowerCaseHeader.getRetryAfter());
+    }
+
+    @Test
+    void testGetProviderExceptionWithoutRetryAfterHeader() {
+        ProviderException providerException = ProviderException.getProviderException(
+            500, "error", Map.of("Content-Type", List.of("application/json")));
+
+        assertNull(providerException.getRetryAfter());
+        assertFalse(providerException.isRetryable());
+    }
+
+    @Test
+    void testGetProviderExceptionWithNullHeaders() {
+        ProviderException providerException = ProviderException.getProviderException(500, "error", null);
+
+        assertNull(providerException.getRetryAfter());
+        assertFalse(providerException.isRetryable());
+    }
+
+    @Test
+    void testGetProviderExceptionIgnoresEmptyRetryAfterValue() {
+        ProviderException providerException = ProviderException.getProviderException(
+            500, "error", Map.of("Retry-After", List.of()));
+
+        assertNull(providerException.getRetryAfter());
+        assertFalse(providerException.isRetryable());
+    }
+
+    @Test
+    void testGetProviderExceptionPreservesSubtypeForMappedStatus() {
+        ProviderException providerException = ProviderException.getProviderException(
+            404, "missing", Map.of("Retry-After", List.of("5")));
+
+        assertInstanceOf(ProviderException.NotFoundException.class, providerException);
+        assertEquals("5", providerException.getRetryAfter());
+        assertTrue(providerException.isRetryable());
+    }
+
+    @Test
+    void testStaticIsRetryableWalksCauseChain() {
+        Exception wrapped = new RuntimeException("outer", new ProviderException(429, "Quota exceeded"));
+
+        assertTrue(ProviderException.isRetryable(wrapped));
+        assertFalse(ProviderException.isRetryable(new RuntimeException("plain")));
+        assertFalse(ProviderException.isRetryable(null));
+    }
+}

--- a/server/libs/platform/platform-component/platform-component-service/src/main/java/com/bytechef/platform/component/aspect/TokenRefreshAspect.java
+++ b/server/libs/platform/platform-component/platform-component-service/src/main/java/com/bytechef/platform/component/aspect/TokenRefreshAspect.java
@@ -17,6 +17,7 @@
 package com.bytechef.platform.component.aspect;
 
 import com.bytechef.component.definition.Context;
+import com.bytechef.component.definition.HttpStatus;
 import com.bytechef.component.exception.ProviderException;
 import com.bytechef.exception.ConfigurationException;
 import com.bytechef.exception.ErrorType;
@@ -100,6 +101,10 @@ public class TokenRefreshAspect {
         ComponentConnection componentConnection = findConnectionArgument(parameters, args);
 
         if (componentConnection == null || componentConnection.authorizationType() == null) {
+            throw exception;
+        }
+
+        if (isRateLimitException(exception)) {
             throw exception;
         }
 
@@ -236,6 +241,24 @@ public class TokenRefreshAspect {
 
     private Context createContext(String componentName, ComponentConnection componentConnection) {
         return contextFactory.createContext(componentName, componentConnection);
+    }
+
+    private static boolean isRateLimitException(Throwable throwable) {
+        Throwable current = throwable;
+
+        while (current != null) {
+            if (current instanceof ProviderException providerException) {
+                Integer statusCode = providerException.getStatusCode();
+
+                if (statusCode != null && statusCode == HttpStatus.TOO_MANY_REQUESTS.getValue()) {
+                    return true;
+                }
+            }
+
+            current = current.getCause();
+        }
+
+        return false;
     }
 
     private Exception wrapException(Exception exception, WithTokenRefresh withTokenRefresh) {

--- a/server/libs/platform/platform-component/platform-component-service/src/main/java/com/bytechef/platform/component/aspect/TokenRefreshAspect.java
+++ b/server/libs/platform/platform-component/platform-component-service/src/main/java/com/bytechef/platform/component/aspect/TokenRefreshAspect.java
@@ -17,7 +17,6 @@
 package com.bytechef.platform.component.aspect;
 
 import com.bytechef.component.definition.Context;
-import com.bytechef.component.definition.HttpStatus;
 import com.bytechef.component.exception.ProviderException;
 import com.bytechef.exception.ConfigurationException;
 import com.bytechef.exception.ErrorType;
@@ -104,7 +103,7 @@ public class TokenRefreshAspect {
             throw exception;
         }
 
-        if (isRateLimitException(exception)) {
+        if (ProviderException.isRetryable(exception)) {
             throw exception;
         }
 
@@ -241,24 +240,6 @@ public class TokenRefreshAspect {
 
     private Context createContext(String componentName, ComponentConnection componentConnection) {
         return contextFactory.createContext(componentName, componentConnection);
-    }
-
-    private static boolean isRateLimitException(Throwable throwable) {
-        Throwable current = throwable;
-
-        while (current != null) {
-            if (current instanceof ProviderException providerException) {
-                Integer statusCode = providerException.getStatusCode();
-
-                if (statusCode != null && statusCode == HttpStatus.TOO_MANY_REQUESTS.getValue()) {
-                    return true;
-                }
-            }
-
-            current = current.getCause();
-        }
-
-        return false;
     }
 
     private Exception wrapException(Exception exception, WithTokenRefresh withTokenRefresh) {

--- a/server/libs/platform/platform-component/platform-component-service/src/main/java/com/bytechef/platform/component/service/ActionDefinitionServiceImpl.java
+++ b/server/libs/platform/platform-component/platform-component-service/src/main/java/com/bytechef/platform/component/service/ActionDefinitionServiceImpl.java
@@ -283,7 +283,7 @@ public class ActionDefinitionServiceImpl implements ActionDefinitionService {
         try {
             return actionDefinition.getProcessErrorResponse()
                 .orElseGet(() -> (statusCode1, body1, headers1, context1) -> ProviderException.getProviderException(
-                    statusCode1, body1))
+                    statusCode1, body1, headers1))
                 .apply(statusCode, body, headers, actionContext);
         } catch (Exception e) {
             throw new ExecutionException(e, ActionDefinitionErrorType.EXECUTE_PROCESS_ERROR_RESPONSE);

--- a/server/libs/platform/platform-component/platform-component-service/src/main/java/com/bytechef/platform/component/service/TriggerDefinitionServiceImpl.java
+++ b/server/libs/platform/platform-component/platform-component-service/src/main/java/com/bytechef/platform/component/service/TriggerDefinitionServiceImpl.java
@@ -239,7 +239,7 @@ public class TriggerDefinitionServiceImpl implements TriggerDefinitionService {
         try {
             return triggerDefinition.getProcessErrorResponse()
                 .orElseGet(() -> (statusCode1, body1, headers1, context1) -> ProviderException.getProviderException(
-                    statusCode1, body1))
+                    statusCode1, body1, headers1))
                 .apply(statusCode, body, headers, triggerContext);
         } catch (Exception e) {
             throw new ExecutionException(e, ActionDefinitionErrorType.EXECUTE_PROCESS_ERROR_RESPONSE);
@@ -493,14 +493,19 @@ public class TriggerDefinitionServiceImpl implements TriggerDefinitionService {
                 log.warn("Polling trigger '{}.{}' configured to poll immediately", componentName, triggerName);
             }
         } catch (ProviderException providerException) {
-            if (!isRateLimitException(providerException)) {
+            if (!providerException.isRetryable()) {
                 throw providerException;
             }
 
+            // A transient provider error (HTTP 429 quota / 503 unavailable / Retry-After) is not a configuration
+            // error: skip this poll cycle, keep the records already collected and the last good cursor, and let the
+            // next scheduled poll retry. Logged at WARN instead of surfaced as a failed trigger execution so quota
+            // spikes don't flood error reporting.
             log.warn(
-                "Polling trigger '{}.{}' skipped: provider rate limit/quota reached (HTTP {}). State preserved; the " +
-                    "next scheduled poll will retry. Provider message: {}",
-                componentName, triggerName, providerException.getStatusCode(), providerException.getMessage());
+                "Polling trigger '{}.{}' skipped: provider signalled a transient error (HTTP {}, Retry-After {}). " +
+                    "State preserved; the next scheduled poll will retry. Provider message: {}",
+                componentName, triggerName, providerException.getStatusCode(), providerException.getRetryAfter(),
+                providerException.getMessage());
         }
 
         Optional<Boolean> triggerDefinitionBatch = triggerDefinition.getBatch();
@@ -772,12 +777,6 @@ public class TriggerDefinitionServiceImpl implements TriggerDefinitionService {
 
         return triggerDefinition.getListenerEnable()
             .orElseThrow(() -> new IllegalArgumentException("Listener enable function is not defined."));
-    }
-
-    private static boolean isRateLimitException(ProviderException providerException) {
-        Integer statusCode = providerException.getStatusCode();
-
-        return statusCode != null && statusCode == HttpStatus.TOO_MANY_REQUESTS.getValue();
     }
 
     private Map<String, ?> toWebhookEnabledOutputParameters(@Nullable Object triggerState) {

--- a/server/libs/platform/platform-component/platform-component-service/src/main/java/com/bytechef/platform/component/service/TriggerDefinitionServiceImpl.java
+++ b/server/libs/platform/platform-component/platform-component-service/src/main/java/com/bytechef/platform/component/service/TriggerDefinitionServiceImpl.java
@@ -499,10 +499,6 @@ public class TriggerDefinitionServiceImpl implements TriggerDefinitionService {
                 throw providerException;
             }
 
-            // A transient provider error (HTTP 429 quota / 503 unavailable / Retry-After) is not a configuration
-            // error: skip this poll cycle, keep the records already collected and the last good cursor, and let the
-            // next scheduled poll retry. Logged at WARN instead of surfaced as a failed trigger execution so quota
-            // spikes don't flood error reporting.
             log.warn(
                 "Polling trigger '{}.{}' skipped: provider signalled a transient error (HTTP {}, Retry-After {}). " +
                     "State preserved; the next scheduled poll will retry. Provider message: {}",

--- a/server/libs/platform/platform-component/platform-component-service/src/main/java/com/bytechef/platform/component/service/TriggerDefinitionServiceImpl.java
+++ b/server/libs/platform/platform-component/platform-component-service/src/main/java/com/bytechef/platform/component/service/TriggerDefinitionServiceImpl.java
@@ -462,7 +462,9 @@ public class TriggerDefinitionServiceImpl implements TriggerDefinitionService {
             int pollFunctionApplyCount = 1;
 
             while (!polledRecords.isEmpty() || pollFunctionApplyCount >= MAX_POLLING_TRIGGER_ITERATIONS) {
-                records.addAll(polledRecords.subList(0, Math.min(MAX_POLLING_TRIGGER_RECORDS, polledRecords.size())));
+                int remainingCapacity = MAX_POLLING_TRIGGER_RECORDS - records.size();
+
+                records.addAll(polledRecords.subList(0, Math.min(remainingCapacity, polledRecords.size())));
 
                 if (pollOutput.pollImmediately() || records.size() >= MAX_POLLING_TRIGGER_RECORDS
                     || pollFunctionApplyCount >= MAX_POLLING_TRIGGER_ITERATIONS) {

--- a/server/libs/platform/platform-component/platform-component-service/src/main/java/com/bytechef/platform/component/service/TriggerDefinitionServiceImpl.java
+++ b/server/libs/platform/platform-component/platform-component-service/src/main/java/com/bytechef/platform/component/service/TriggerDefinitionServiceImpl.java
@@ -447,45 +447,65 @@ public class TriggerDefinitionServiceImpl implements TriggerDefinitionService {
         Parameters inputParameters = ParametersFactory.create(inputParameterMap);
         Parameters connectionParameters = ParametersFactory.create(componentConnection);
 
-        PollOutput pollOutput = pollFunctionApply(
-            pollFunction, inputParameters, connectionParameters, ParametersFactory.create(closureParameterMap),
-            triggerContext);
-
-        List<?> polledRecords = pollOutput.records();
         List<Object> records = new ArrayList<>();
-        int pollFunctionApplyCount = 1;
 
-        while (!polledRecords.isEmpty() || pollFunctionApplyCount >= MAX_POLLING_TRIGGER_ITERATIONS) {
-            records.addAll(polledRecords.subList(0, Math.min(MAX_POLLING_TRIGGER_RECORDS, polledRecords.size())));
+        Object closureParameters = closureParameterMap;
 
-            if (pollOutput.pollImmediately() || records.size() >= MAX_POLLING_TRIGGER_RECORDS
-                || pollFunctionApplyCount >= MAX_POLLING_TRIGGER_ITERATIONS) {
-                break;
+        try {
+            PollOutput pollOutput = pollFunctionApply(
+                pollFunction, inputParameters, connectionParameters, ParametersFactory.create(closureParameterMap),
+                triggerContext);
+
+            closureParameters = pollOutput.closureParameters();
+
+            List<?> polledRecords = pollOutput.records();
+            int pollFunctionApplyCount = 1;
+
+            while (!polledRecords.isEmpty() || pollFunctionApplyCount >= MAX_POLLING_TRIGGER_ITERATIONS) {
+                records.addAll(polledRecords.subList(0, Math.min(MAX_POLLING_TRIGGER_RECORDS, polledRecords.size())));
+
+                if (pollOutput.pollImmediately() || records.size() >= MAX_POLLING_TRIGGER_RECORDS
+                    || pollFunctionApplyCount >= MAX_POLLING_TRIGGER_ITERATIONS) {
+                    break;
+                }
+
+                pollOutput = pollFunctionApply(
+                    pollFunction, inputParameters, connectionParameters,
+                    ParametersFactory.create(pollOutput.closureParameters()), triggerContext);
+
+                closureParameters = pollOutput.closureParameters();
+                polledRecords = pollOutput.records();
+
+                pollFunctionApplyCount++;
             }
 
-            pollOutput = pollFunctionApply(
-                pollFunction, inputParameters, connectionParameters,
-                ParametersFactory.create(pollOutput.closureParameters()), triggerContext);
+            if (pollFunctionApplyCount >= MAX_POLLING_TRIGGER_ITERATIONS
+                || records.size() >= MAX_POLLING_TRIGGER_RECORDS) {
 
-            polledRecords = pollOutput.records();
+                log.warn(
+                    "Polling trigger '{}.{}' hit safety limit (iterations={}, records={}); next scheduled poll will " +
+                        "resume. Likely cause: component keeps requesting immediate re-poll without completing " +
+                        "pagination.",
+                    componentName, triggerName, pollFunctionApplyCount, records.size());
+            }
 
-            pollFunctionApplyCount++;
-        }
+            if (pollOutput.pollImmediately()) {
+                log.warn("Polling trigger '{}.{}' configured to poll immediately", componentName, triggerName);
+            }
+        } catch (ProviderException providerException) {
+            if (!isRateLimitException(providerException)) {
+                throw providerException;
+            }
 
-        if (pollFunctionApplyCount >= MAX_POLLING_TRIGGER_ITERATIONS || records.size() >= MAX_POLLING_TRIGGER_RECORDS) {
             log.warn(
-                "Polling trigger '{}.{}' hit safety limit (iterations={}, records={}); next scheduled poll will " +
-                    "resume. Likely cause: component keeps requesting immediate re-poll without completing pagination.",
-                componentName, triggerName, pollFunctionApplyCount, records.size());
-        }
-
-        if (pollOutput.pollImmediately()) {
-            log.warn("Polling trigger '{}.{}' configured to poll immediately", componentName, triggerName);
+                "Polling trigger '{}.{}' skipped: provider rate limit/quota reached (HTTP {}). State preserved; the " +
+                    "next scheduled poll will retry. Provider message: {}",
+                componentName, triggerName, providerException.getStatusCode(), providerException.getMessage());
         }
 
         Optional<Boolean> triggerDefinitionBatch = triggerDefinition.getBatch();
 
-        return new TriggerOutput(records, pollOutput.closureParameters(), triggerDefinitionBatch.orElse(false));
+        return new TriggerOutput(records, closureParameters, triggerDefinitionBatch.orElse(false));
     }
 
     @SuppressWarnings("unchecked")
@@ -752,6 +772,12 @@ public class TriggerDefinitionServiceImpl implements TriggerDefinitionService {
 
         return triggerDefinition.getListenerEnable()
             .orElseThrow(() -> new IllegalArgumentException("Listener enable function is not defined."));
+    }
+
+    private static boolean isRateLimitException(ProviderException providerException) {
+        Integer statusCode = providerException.getStatusCode();
+
+        return statusCode != null && statusCode == HttpStatus.TOO_MANY_REQUESTS.getValue();
     }
 
     private Map<String, ?> toWebhookEnabledOutputParameters(@Nullable Object triggerState) {

--- a/server/libs/platform/platform-component/platform-component-service/src/test/java/com/bytechef/platform/component/aspect/TokenRefreshAspectIntTest.java
+++ b/server/libs/platform/platform-component/platform-component-service/src/test/java/com/bytechef/platform/component/aspect/TokenRefreshAspectIntTest.java
@@ -242,19 +242,39 @@ class TokenRefreshAspectIntTest {
 
     @Test
     void testExecute429RateLimitPropagatedWithoutRefresh() {
+        assertTransientErrorPropagatedWithoutRefresh(
+            new ProviderException(429, "Quota exceeded for quota metric 'Expensive Reads'"), "Quota exceeded");
+    }
+
+    @Test
+    void testExecute503ServiceUnavailablePropagatedWithoutRefresh() {
+        assertTransientErrorPropagatedWithoutRefresh(
+            new ProviderException(503, "Service Unavailable"), "Service Unavailable");
+    }
+
+    @Test
+    void testExecuteRetryAfterHeaderPropagatedWithoutRefresh() {
+        assertTransientErrorPropagatedWithoutRefresh(
+            ProviderException.getProviderException(409, "Conflict", Map.of("Retry-After", List.of("30"))),
+            "Conflict");
+    }
+
+    private void assertTransientErrorPropagatedWithoutRefresh(
+        ProviderException providerException, String expectedMessageFragment) {
+
         ComponentConnection connection = createOAuth2Connection();
 
-        // Even with a refresh policy configured for 401, a transient 429 (quota / rate limit) must not trigger a
-        // token refresh and must not be relabeled as a ConfigurationException — it propagates unchanged.
+        // Even with a refresh policy configured for 401, a transient provider error (429 / 503 / Retry-After) must not
+        // trigger a token refresh and must not be relabeled as a ConfigurationException — it propagates unchanged.
         setupRefreshOn401();
 
         tokenRefreshTestService.setBehavior(() -> {
-            throw new ProviderException(429, "Quota exceeded for quota metric 'Expensive Reads'");
+            throw providerException;
         });
 
         assertThatThrownBy(() -> tokenRefreshTestService.executeWithConnection("testComponent", 1, connection))
             .isInstanceOf(ProviderException.class)
-            .hasMessageContaining("Quota exceeded");
+            .hasMessageContaining(expectedMessageFragment);
 
         assertThat(tokenRefreshTestService.getCallCount()).isEqualTo(1);
 

--- a/server/libs/platform/platform-component/platform-component-service/src/test/java/com/bytechef/platform/component/aspect/TokenRefreshAspectIntTest.java
+++ b/server/libs/platform/platform-component/platform-component-service/src/test/java/com/bytechef/platform/component/aspect/TokenRefreshAspectIntTest.java
@@ -241,6 +241,28 @@ class TokenRefreshAspectIntTest {
     }
 
     @Test
+    void testExecute429RateLimitPropagatedWithoutRefresh() {
+        ComponentConnection connection = createOAuth2Connection();
+
+        // Even with a refresh policy configured for 401, a transient 429 (quota / rate limit) must not trigger a
+        // token refresh and must not be relabeled as a ConfigurationException — it propagates unchanged.
+        setupRefreshOn401();
+
+        tokenRefreshTestService.setBehavior(() -> {
+            throw new ProviderException(429, "Quota exceeded for quota metric 'Expensive Reads'");
+        });
+
+        assertThatThrownBy(() -> tokenRefreshTestService.executeWithConnection("testComponent", 1, connection))
+            .isInstanceOf(ProviderException.class)
+            .hasMessageContaining("Quota exceeded");
+
+        assertThat(tokenRefreshTestService.getCallCount()).isEqualTo(1);
+
+        verify(connectionDefinitionService, never()).executeRefresh(
+            anyString(), anyInt(), any(), any(), any());
+    }
+
+    @Test
     void testExecuteCustomAuthAcquireNewCredentials() {
         ComponentConnection connection = createCustomConnection();
 

--- a/server/libs/platform/platform-component/platform-component-service/src/test/java/com/bytechef/platform/component/service/TriggerDefinitionServiceTest.java
+++ b/server/libs/platform/platform-component/platform-component-service/src/test/java/com/bytechef/platform/component/service/TriggerDefinitionServiceTest.java
@@ -150,16 +150,32 @@ public class TriggerDefinitionServiceTest {
 
     @Test
     public void testExecutePollingTriggerSkipsOnRateLimit() {
+        // The provider has hit its per-minute quota: poll() fails with HTTP 429.
+        assertPollingTriggerSkipsOnTransientError(new ProviderException(
+            429, "Quota exceeded for quota metric 'Expensive Reads'"));
+    }
+
+    @Test
+    public void testExecutePollingTriggerSkipsOnServiceUnavailable() {
+        // The provider is temporarily down: poll() fails with HTTP 503.
+        assertPollingTriggerSkipsOnTransientError(new ProviderException(503, "Service Unavailable"));
+    }
+
+    @Test
+    public void testExecutePollingTriggerSkipsOnRetryAfterHeader() {
+        // A Retry-After header marks the error transient even when the status code is not itself retryable (409).
+        assertPollingTriggerSkipsOnTransientError(
+            ProviderException.getProviderException(409, "Conflict", Map.of("Retry-After", List.of("120"))));
+    }
+
+    private void assertPollingTriggerSkipsOnTransientError(ProviderException providerException) {
         TriggerDefinition mockTriggerDefinition = mock(TriggerDefinition.class);
 
         when(mockTriggerDefinition.getType()).thenReturn(TriggerType.POLLING);
         when(mockTriggerDefinition.getBatch()).thenReturn(Optional.of(false));
 
-        // A provider that has hit its per-minute quota: poll() fails with HTTP 429. The poll cycle must be skipped
-        // (no records, no exception) and the prior closure state preserved so the next scheduled poll resumes.
-        ProviderException providerException = new ProviderException(
-            429, "Quota exceeded for quota metric 'Expensive Reads'");
-
+        // A transient provider failure must skip the cycle (no records, no exception) while preserving the prior
+        // closure state so the next scheduled poll resumes from the same cursor.
         PollFunction mockPollFunction = (inputParameters, connectionParameters, closureParameters, context) -> {
             throw providerException;
         };
@@ -188,7 +204,7 @@ public class TriggerDefinitionServiceTest {
 
         assertNotNull(output, "TriggerOutput should not be null");
         assertInstanceOf(List.class, output.value(), "Output should be a List");
-        assertTrue(((List<?>) output.value()).isEmpty(), "A rate-limited poll should yield no records");
+        assertTrue(((List<?>) output.value()).isEmpty(), "A skipped poll should yield no records");
         assertEquals(priorState, output.state(), "Closure state must be preserved across a skipped poll cycle");
 
         boolean warningLogged = logAppender.list.stream()
@@ -199,7 +215,47 @@ public class TriggerDefinitionServiceTest {
                     && formattedMessage.contains("testTrigger");
             });
 
-        assertTrue(warningLogged, "A WARN naming the rate-limited trigger should be emitted instead of an error");
+        assertTrue(warningLogged, "A WARN naming the skipped trigger should be emitted instead of an error");
+    }
+
+    @Test
+    public void testExecutePollingTriggerSkipsMidPaginationKeepingPartialRecordsAndCursor() {
+        TriggerDefinition mockTriggerDefinition = mock(TriggerDefinition.class);
+
+        when(mockTriggerDefinition.getType()).thenReturn(TriggerType.POLLING);
+        when(mockTriggerDefinition.getBatch()).thenReturn(Optional.of(false));
+
+        AtomicInteger pollCount = new AtomicInteger();
+
+        // The first page succeeds and advances the cursor without asking to stop; the second page hits a 429. The
+        // records already collected and the cursor advanced by the first page must be retained so the next scheduled
+        // poll resumes from there rather than discarding partial progress.
+        PollFunction mockPollFunction = (inputParameters, connectionParameters, closureParameters, context) -> {
+            if (pollCount.incrementAndGet() == 1) {
+                return new PollOutput(List.of("record-page-1"), Map.of("cursor", "page-2"), false);
+            }
+
+            throw new ProviderException(429, "Quota exceeded");
+        };
+
+        when(mockTriggerDefinition.getPoll()).thenReturn(Optional.of(mockPollFunction));
+
+        when(componentDefinitionRegistry.getTriggerDefinition("testComponent", 1, "testTrigger"))
+            .thenReturn(mockTriggerDefinition);
+
+        TriggerDefinitionServiceImpl triggerDefinitionService = new TriggerDefinitionServiceImpl(
+            componentDefinitionRegistry, contextFactory, eventPublisher, List.of());
+
+        TriggerOutput output = triggerDefinitionService.executeTrigger(
+            "testComponent", 1, "testTrigger", null, null, Collections.emptyMap(), Map.of("cursor", "page-1"), null,
+            null, null, PlatformType.AUTOMATION, false);
+
+        assertNotNull(output, "TriggerOutput should not be null");
+        assertEquals(
+            List.of("record-page-1"), output.value(), "Records collected before the transient error must be kept");
+        assertEquals(
+            Map.of("cursor", "page-2"), output.state(), "Cursor must reflect the last successfully polled page");
+        assertEquals(2, pollCount.get(), "The second page should have been attempted before the skip");
     }
 
     @Test

--- a/server/libs/platform/platform-component/platform-component-service/src/test/java/com/bytechef/platform/component/service/TriggerDefinitionServiceTest.java
+++ b/server/libs/platform/platform-component/platform-component-service/src/test/java/com/bytechef/platform/component/service/TriggerDefinitionServiceTest.java
@@ -186,7 +186,7 @@ public class TriggerDefinitionServiceTest {
             .thenReturn(mockTriggerDefinition);
 
         TriggerDefinitionServiceImpl triggerDefinitionService = new TriggerDefinitionServiceImpl(
-            componentDefinitionRegistry, contextFactory, eventPublisher, List.of());
+            componentDefinitionRegistry, contextFactory, eventPublisher);
 
         Map<String, Object> priorState = Map.of("cursor", "page-1");
 
@@ -244,7 +244,7 @@ public class TriggerDefinitionServiceTest {
             .thenReturn(mockTriggerDefinition);
 
         TriggerDefinitionServiceImpl triggerDefinitionService = new TriggerDefinitionServiceImpl(
-            componentDefinitionRegistry, contextFactory, eventPublisher, List.of());
+            componentDefinitionRegistry, contextFactory, eventPublisher);
 
         TriggerOutput output = triggerDefinitionService.executeTrigger(
             "testComponent", 1, "testTrigger", null, null, Collections.emptyMap(), Map.of("cursor", "page-1"), null,

--- a/server/libs/platform/platform-component/platform-component-service/src/test/java/com/bytechef/platform/component/service/TriggerDefinitionServiceTest.java
+++ b/server/libs/platform/platform-component/platform-component-service/src/test/java/com/bytechef/platform/component/service/TriggerDefinitionServiceTest.java
@@ -16,6 +16,7 @@
 
 package com.bytechef.platform.component.service;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -145,6 +146,60 @@ public class TriggerDefinitionServiceTest {
         assertSame(
             providerException, thrownException,
             "The thrown exception should be the same instance as the original ProviderException");
+    }
+
+    @Test
+    public void testExecutePollingTriggerSkipsOnRateLimit() {
+        TriggerDefinition mockTriggerDefinition = mock(TriggerDefinition.class);
+
+        when(mockTriggerDefinition.getType()).thenReturn(TriggerType.POLLING);
+        when(mockTriggerDefinition.getBatch()).thenReturn(Optional.of(false));
+
+        // A provider that has hit its per-minute quota: poll() fails with HTTP 429. The poll cycle must be skipped
+        // (no records, no exception) and the prior closure state preserved so the next scheduled poll resumes.
+        ProviderException providerException = new ProviderException(
+            429, "Quota exceeded for quota metric 'Expensive Reads'");
+
+        PollFunction mockPollFunction = (inputParameters, connectionParameters, closureParameters, context) -> {
+            throw providerException;
+        };
+
+        when(mockTriggerDefinition.getPoll()).thenReturn(Optional.of(mockPollFunction));
+
+        when(componentDefinitionRegistry.getTriggerDefinition("testComponent", 1, "testTrigger"))
+            .thenReturn(mockTriggerDefinition);
+
+        TriggerDefinitionServiceImpl triggerDefinitionService = new TriggerDefinitionServiceImpl(
+            componentDefinitionRegistry, contextFactory, eventPublisher, List.of());
+
+        Map<String, Object> priorState = Map.of("cursor", "page-1");
+
+        ListAppender<ILoggingEvent> logAppender = attachLogAppender();
+
+        TriggerOutput output;
+
+        try {
+            output = triggerDefinitionService.executeTrigger(
+                "testComponent", 1, "testTrigger", null, null, Collections.emptyMap(), priorState, null, null, null,
+                PlatformType.AUTOMATION, false);
+        } finally {
+            detachLogAppender(logAppender);
+        }
+
+        assertNotNull(output, "TriggerOutput should not be null");
+        assertInstanceOf(List.class, output.value(), "Output should be a List");
+        assertTrue(((List<?>) output.value()).isEmpty(), "A rate-limited poll should yield no records");
+        assertEquals(priorState, output.state(), "Closure state must be preserved across a skipped poll cycle");
+
+        boolean warningLogged = logAppender.list.stream()
+            .anyMatch(event -> {
+                String formattedMessage = event.getFormattedMessage();
+
+                return event.getLevel() == Level.WARN && formattedMessage.contains("testComponent")
+                    && formattedMessage.contains("testTrigger");
+            });
+
+        assertTrue(warningLogged, "A WARN naming the rate-limited trigger should be emitted instead of an error");
     }
 
     @Test


### PR DESCRIPTION
- **5283 Skip polling trigger poll cycle on provider 429 rate limit**
- **5283 Do not relabel transient 429 rate limit as ConfigurationException in TokenRefreshAspect**
- **5283 Widen transient provider-error handling to HTTP 503 and Retry-After**
