### PR TITLE
5296 client - Render connection rows with stale/removed components instead of erroring

### DIFF
--- a/client/src/pages/automation/connections/components/connection-list/ConnectionListItem.tsx
+++ b/client/src/pages/automation/connections/components/connection-list/ConnectionListItem.tsx
@@ -30,13 +30,10 @@ import {
     useUpdateConnectionMutation,
 } from '@/shared/mutations/automation/connections.mutations';
 import {ConnectionKeys, useGetConnectionTagsQuery} from '@/shared/queries/automation/connections.queries';
-import {
-    ComponentDefinitionKeys,
-    useGetConnectionComponentDefinitionQuery,
-} from '@/shared/queries/platform/componentDefinitions.queries';
+import {ComponentDefinitionKeys} from '@/shared/queries/platform/componentDefinitions.queries';
 import {useQueryClient} from '@tanstack/react-query';
 import {ComponentIcon, EditIcon, EllipsisVerticalIcon, Link2OffIcon, Trash2Icon} from 'lucide-react';
-import {memo, useState} from 'react';
+import {memo, useMemo, useState} from 'react';
 import {toast} from 'sonner';
 
 import TagList from '../../../../../shared/components/TagList';
@@ -51,11 +48,6 @@ const ConnectionListItem = memo(({componentDefinitions, connection, remainingTag
     const [showEditDialog, setShowEditDialog] = useState(false);
     const [showDeleteDialog, setShowDeleteDialog] = useState(false);
     const [showDisconnectDialog, setShowDisconnectDialog] = useState(false);
-
-    const {data: componentDefinition} = useGetConnectionComponentDefinitionQuery({
-        componentName: connection.componentName,
-        connectionVersion: connection.connectionVersion,
-    });
 
     const queryClient = useQueryClient();
 
@@ -109,6 +101,11 @@ const ConnectionListItem = memo(({componentDefinitions, connection, remainingTag
         },
     });
 
+    const componentDefinition = useMemo(
+        () => componentDefinitions.find((definition) => definition.name === connection.componentName),
+        [componentDefinitions, connection.componentName]
+    );
+
     const handleAlertDeleteDialogClick = () => {
         if (connection.id) {
             deleteConnectionMutation.mutate(connection.id);
@@ -121,10 +118,6 @@ const ConnectionListItem = memo(({componentDefinitions, connection, remainingTag
         }
     };
 
-    if (!componentDefinition) {
-        return <></>;
-    }
-
     return (
         <li key={connection.id}>
             <>
@@ -133,11 +126,15 @@ const ConnectionListItem = memo(({componentDefinitions, connection, remainingTag
                         <div className="flex-1">
                             <div className="flex items-center justify-between">
                                 <div className="relative flex items-center gap-2">
-                                    <LazyLoadSVG
-                                        className="size-5 flex-none"
-                                        preloader={<ComponentIcon />}
-                                        src={componentDefinition.icon!}
-                                    />
+                                    {componentDefinition?.icon ? (
+                                        <LazyLoadSVG
+                                            className="size-5 flex-none"
+                                            preloader={<ComponentIcon />}
+                                            src={componentDefinition.icon}
+                                        />
+                                    ) : (
+                                        <ComponentIcon className="size-5 flex-none" />
+                                    )}
 
                                     <span className="text-base font-semibold">{connection.name}</span>
                                 </div>

--- a/client/src/pages/automation/connections/components/connection-list/ConnectionListItem.tsx
+++ b/client/src/pages/automation/connections/components/connection-list/ConnectionListItem.tsx
@@ -101,10 +101,19 @@ const ConnectionListItem = memo(({componentDefinitions, connection, remainingTag
         },
     });
 
-    const componentDefinition = useMemo(
-        () => componentDefinitions.find((definition) => definition.name === connection.componentName),
-        [componentDefinitions, connection.componentName]
-    );
+    const componentDefinition = useMemo(() => {
+        const matchingComponentDefinitions = componentDefinitions.filter(
+            (definition) => definition.name === connection.componentName
+        );
+
+        // The list normally holds a single entry per component, but if several
+        // versions are present resolve to the latest so the icon is picked
+        // deterministically instead of depending on array order.
+        return matchingComponentDefinitions.reduce<ComponentDefinitionBasic | undefined>(
+            (latest, definition) => (!latest || definition.version > latest.version ? definition : latest),
+            undefined
+        );
+    }, [componentDefinitions, connection.componentName]);
 
     const handleAlertDeleteDialogClick = () => {
         if (connection.id) {


### PR DESCRIPTION
Resolve each connection's component from the already-loaded registry prop
rather than a dedicated per-row getConnectionComponentDefinition fetch. A
connection can reference a component that no longer exists (e.g. a removed
custom component); the per-row request 400'd on those stale rows, surfaced a
"Bad Request" toast, and the failed query hid the row entirely. Looking it up
locally yields undefined for stale rows so the row still renders with a
fallback icon and no request is made.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
