### PR TITLE
fix: customize drag image to only show component icon

### DIFF
--- a/client/src/pages/platform/workflow-editor/components/workflow-nodes-tabs/WorkflowNodesTabsItem.test.tsx
+++ b/client/src/pages/platform/workflow-editor/components/workflow-nodes-tabs/WorkflowNodesTabsItem.test.tsx
@@ -1,0 +1,97 @@
+import {ComponentDefinitionBasic} from '@/shared/middleware/platform/configuration';
+import {fireEvent, render, screen} from '@/shared/util/test-utils';
+import {expect, it, vi} from 'vitest';
+
+import WorkflowNodesTabsItem from './WorkflowNodesTabsItem';
+
+const mockNode = {
+    clusterElement: false,
+    description: 'This is a test node description',
+    name: 'testNode',
+    taskDispatcher: false,
+    title: 'Test Node Title',
+    trigger: false,
+} as unknown as ComponentDefinitionBasic & {
+    clusterElement?: boolean;
+    taskDispatcher: boolean;
+    trigger: boolean;
+};
+
+it('renders the workflow node item correctly with title and description', () => {
+    render(<WorkflowNodesTabsItem draggable={true} node={mockNode} />);
+
+    const titleElement = screen.getByText('Test Node Title');
+    const descriptionElement = screen.getByText('This is a test node description');
+
+    expect(titleElement).toBeInTheDocument();
+    expect(descriptionElement).toBeInTheDocument();
+});
+
+it('triggers handleClick when clicked', () => {
+    const handleClick = vi.fn();
+
+    render(<WorkflowNodesTabsItem draggable={true} handleClick={handleClick} node={mockNode} />);
+
+    const listItem = screen.getByRole('listitem');
+
+    fireEvent.click(listItem);
+
+    expect(handleClick).toHaveBeenCalledTimes(1);
+});
+
+it('triggers onDragStart and sets correct drag data and drag image', () => {
+    render(<WorkflowNodesTabsItem draggable={true} node={mockNode} />);
+
+    const setData = vi.fn();
+    const setDragImage = vi.fn();
+    const dataTransfer = {
+        effectAllowed: '',
+        setData,
+        setDragImage,
+    };
+
+    const listItem = screen.getByRole('listitem');
+
+    fireEvent.dragStart(listItem, {
+        dataTransfer,
+    });
+
+    const formatString = 'application/reactflow';
+    const expectedNodeName = 'testNode';
+
+    expect(setData).toHaveBeenCalledWith(formatString, expectedNodeName);
+    expect(dataTransfer.effectAllowed).toBe('move');
+    expect(setDragImage).toHaveBeenCalledTimes(1);
+});
+
+it('maps the trigger node name correctly with suffix --trigger', () => {
+    const triggerNode = {
+        ...mockNode,
+        trigger: true,
+    } as unknown as ComponentDefinitionBasic & {
+        clusterElement?: boolean;
+        taskDispatcher: boolean;
+        trigger: boolean;
+    };
+
+    render(<WorkflowNodesTabsItem draggable={true} node={triggerNode} />);
+
+    const setData = vi.fn();
+    const setDragImage = vi.fn();
+    const dataTransfer = {
+        effectAllowed: '',
+        setData,
+        setDragImage,
+    };
+
+    const listItem = screen.getByRole('listitem');
+
+    fireEvent.dragStart(listItem, {
+        dataTransfer,
+    });
+
+    const formatString = 'application/reactflow';
+    const expectedNodeName = 'testNode--trigger';
+
+    expect(setData).toHaveBeenCalledWith(formatString, expectedNodeName);
+});

--- a/client/src/pages/platform/workflow-editor/components/workflow-nodes-tabs/WorkflowNodesTabsItem.tsx
+++ b/client/src/pages/platform/workflow-editor/components/workflow-nodes-tabs/WorkflowNodesTabsItem.tsx
@@ -44,22 +44,43 @@ const WorkflowNodesTabsItem = ({draggable, handleClick, node, selected}: Workflo
         if (iconRef.current) {
             const nodeContainer = document.createElement('div');
 
-            nodeContainer.className =
-                'flex size-14 items-center justify-center rounded-lg border-2 border-slate-200 bg-white absolute left-[-1000px] top-[-1000px]';
+            nodeContainer.style.position = 'absolute';
+            nodeContainer.style.top = '-9999px';
+            nodeContainer.style.left = '-9999px';
+            nodeContainer.style.width = '56px';
+            nodeContainer.style.height = '56px';
+            nodeContainer.style.display = 'flex';
+            nodeContainer.style.alignItems = 'center';
+            nodeContainer.style.justifyContent = 'center';
+            nodeContainer.style.backgroundColor = '#ffffff';
+            nodeContainer.style.border = '2px solid #e2e8f0';
+            nodeContainer.style.borderRadius = '8px';
+            nodeContainer.style.zIndex = '-9999';
 
             const iconClone = iconRef.current.cloneNode(true) as HTMLElement;
 
-            iconClone.className = 'm-0 size-7';
+            iconClone.style.margin = '0';
+            iconClone.style.width = '28px';
+            iconClone.style.height = '28px';
+            iconClone.style.display = 'flex';
+            iconClone.style.alignItems = 'center';
+            iconClone.style.justifyContent = 'center';
 
             const svgElement = iconClone.querySelector('svg');
 
             if (svgElement) {
-                svgElement.setAttribute('class', 'block size-full');
+                svgElement.style.display = 'block';
+                svgElement.style.width = '100%';
+                svgElement.style.height = '100%';
             }
 
             nodeContainer.appendChild(iconClone);
             document.body.appendChild(nodeContainer);
-            event.dataTransfer.setDragImage(nodeContainer, 28, 28);
+
+            const dragX = nodeContainer.offsetWidth > 0 ? 28 : 28;
+            const dragY = 28;
+
+            event.dataTransfer.setDragImage(nodeContainer, dragX, dragY);
 
             requestAnimationFrame(() => {
                 if (nodeContainer.parentNode) {


### PR DESCRIPTION
Ran command: `git remote add fork https://github.com/OptimumCoder1/bytechef.git`
Ran command: `git push -u fork fix/sidebar-drag-image-icon
`
Viewed WorkflowNodesTabsItem.test.tsx:11-48

Here is the filled-out Pull Request template for your PR on GitHub. You can copy and paste this directly:

***

## Description

When dragging a component card from the node sidebar in the workflow editor, the browser dragged the entire card (including the title and description text). This change modifies the drag image to only display the component's icon, while keeping the entire card surface draggable to initiate the drag.

### Technical Solution
*   Updated `onDragStart` inside `WorkflowNodesTabsItem.tsx` to build the custom drag image element (`nodeContainer`) with inline styling. This ensures the browser layout engine calculates the styles synchronously.
*   Forced a browser layout reflow by checking `nodeContainer.offsetWidth` within the initialization of `dragX` (which gets passed to `setDragImage`). This ensures the browser computes layout/dimensions prior to taking the drag snapshot.
*   Added unit tests in `WorkflowNodesTabsItem.test.tsx` verifying component rendering, click callback triggers, and `onDragStart` payload configuration and drag image setup.

Fixes # (No existing upstream issue, submitted as a direct UX enhancement)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I ran local verification checks in the `client/` directory:

1. **Unit Testing (Vitest):**
   Ran unit tests specifically targeting the item component:
   ```bash
   npx vitest run src/pages/platform/workflow-editor/components/workflow-nodes-tabs/WorkflowNodesTabsItem.test.tsx
   ```
   *Result:* All 4 tests passed.
   
2. **Workspace Verification Checks:**
   Ran full formatting, linting, typechecking, and test validation:
   ```bash
   npm run check
   ```
   *Result:* Completed successfully with no formatting, typescript, or testing errors.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes