### PR TITLE
Fix Copilot AI provider catalog schema wiring

### DIFF
--- a/server/apps/server-app/build.gradle.kts
+++ b/server/apps/server-app/build.gradle.kts
@@ -258,6 +258,7 @@ dependencies {
 
     implementation(project(":server:ee:libs:ai:ai-copilot:ai-copilot-rest"))
     implementation(project(":server:ee:libs:ai:ai-copilot:ai-copilot-service"))
+    implementation(project(":server:ee:libs:automation:automation-ai:automation-ai-gateway:automation-ai-gateway-graphql"))
     implementation(project(":server:ee:libs:automation:automation-api-platform:automation-api-platform-configuration:automation-api-platform-configuration-rest"))
     implementation(project(":server:ee:libs:automation:automation-api-platform:automation-api-platform-configuration:automation-api-platform-configuration-service"))
     implementation(project(":server:ee:libs:automation:automation-api-platform:automation-api-platform-handler:automation-api-platform-handler-rest"))

--- a/server/ee/libs/automation/automation-ai/automation-ai-gateway/automation-ai-gateway-graphql/build.gradle.kts
+++ b/server/ee/libs/automation/automation-ai/automation-ai-gateway/automation-ai-gateway-graphql/build.gradle.kts
@@ -1,0 +1,10 @@
+dependencies {
+    implementation("org.springframework.graphql:spring-graphql")
+    implementation("org.springframework.security:spring-security-core")
+    implementation("org.springframework:spring-context")
+
+    implementation(project(":server:libs:atlas:atlas-coordinator:atlas-coordinator-api"))
+    implementation(project(":server:libs:platform:platform-security:platform-security-api"))
+
+    implementation(project(":server:ee:libs:platform:platform-configuration:platform-configuration-api"))
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -33,6 +33,7 @@ include("cli:commands:component:init:openapi")
 include("server:apps:server-app")
 
 include("server:ee:libs:automation:automation-ai:automation-ai-tool")
+include("server:ee:libs:automation:automation-ai:automation-ai-gateway:automation-ai-gateway-graphql")
 include("server:libs:ai:ai-mcp:ai-mcp-server")
 include("server:libs:ai:ai-mcp:ai-mcp-server-configuration:ai-mcp-server-configuration-graphql")
 include("server:libs:ai:ai-mcp:ai-mcp-server-api")


### PR DESCRIPTION
Fixes #5338.

## Summary
- Adds the existing AI provider catalog GraphQL sources as a Gradle module.
- Adds the module to the server app so `aiProviderCatalog` and `aiDefaultModel` are present in the GraphQL schema.

## Validation
- `./gradlew --no-daemon :server:ee:libs:automation:automation-ai:automation-ai-gateway:automation-ai-gateway-graphql:check --stacktrace`
- `./gradlew --no-daemon :server:apps:server-app:compileJava --stacktrace`