### PR TITLE
5348 client - Fix AI skill chat message ordering across turns

### DIFF
--- a/client/src/shared/components/copilot/stores/useCopilotStore.test.ts
+++ b/client/src/shared/components/copilot/stores/useCopilotStore.test.ts
@@ -1,0 +1,91 @@
+import {ThreadMessageLike} from '@assistant-ui/react';
+import {afterEach, describe, expect, it} from 'vitest';
+
+import {useCopilotStore} from './useCopilotStore';
+
+function resetStore() {
+    useCopilotStore.getState().resetMessages();
+}
+
+function contentOf(message: ThreadMessageLike | undefined): string {
+    return typeof message?.content === 'string' ? message.content : '';
+}
+
+describe('useCopilotStore', () => {
+    afterEach(resetStore);
+
+    describe('appendToLastAssistantMessage', () => {
+        it('should create a new assistant message when the turn has none yet', () => {
+            const store = useCopilotStore.getState();
+
+            store.addMessage({content: 'u1', role: 'user'});
+            store.appendToLastAssistantMessage('a1');
+
+            const {messages} = useCopilotStore.getState();
+
+            expect(messages).toHaveLength(2);
+            expect(messages[1]?.role).toBe('assistant');
+            expect(contentOf(messages[1])).toBe('a1');
+        });
+
+        it('should replace the current turn assistant message while streaming', () => {
+            const store = useCopilotStore.getState();
+
+            store.addMessage({content: 'u1', role: 'user'});
+            store.appendToLastAssistantMessage('a');
+            store.appendToLastAssistantMessage('ab');
+            store.appendToLastAssistantMessage('abc');
+
+            const {messages} = useCopilotStore.getState();
+
+            expect(messages).toHaveLength(2);
+            expect(contentOf(messages[1])).toBe('abc');
+        });
+
+        it('should keep messages in back-and-forth order across multiple turns (#5348)', () => {
+            const store = useCopilotStore.getState();
+
+            // Turn 1
+            store.addMessage({content: 'u1', role: 'user'});
+            store.appendToLastAssistantMessage('a1');
+
+            // Turn 2
+            store.addMessage({content: 'u2', role: 'user'});
+            store.appendToLastAssistantMessage('a2');
+
+            // Turn 3
+            store.addMessage({content: 'u3', role: 'user'});
+            store.appendToLastAssistantMessage('a3');
+
+            const {messages} = useCopilotStore.getState();
+
+            expect(messages.map((message) => message.role)).toEqual([
+                'user',
+                'assistant',
+                'user',
+                'assistant',
+                'user',
+                'assistant',
+            ]);
+            expect(messages.map(contentOf)).toEqual(['u1', 'a1', 'u2', 'a2', 'u3', 'a3']);
+        });
+
+        it('should not overwrite a previous turn assistant message that carries array content', () => {
+            const store = useCopilotStore.getState();
+
+            // Turn 1 produced a tool-result style assistant message (array content).
+            store.addMessage({content: 'u1', role: 'user'});
+            store.addMessage({content: [{data: {message: 'done'}, type: 'data-run-error'}], role: 'assistant'});
+
+            // Turn 2 streams plain text — it must land in a fresh assistant message, not the array one.
+            store.addMessage({content: 'u2', role: 'user'});
+            store.appendToLastAssistantMessage('a2');
+
+            const {messages} = useCopilotStore.getState();
+
+            expect(messages).toHaveLength(4);
+            expect(messages.map((message) => message.role)).toEqual(['user', 'assistant', 'user', 'assistant']);
+            expect(contentOf(messages[3])).toBe('a2');
+        });
+    });
+});

--- a/client/src/shared/components/copilot/stores/useCopilotStore.ts
+++ b/client/src/shared/components/copilot/stores/useCopilotStore.ts
@@ -115,9 +115,14 @@ export const useCopilotStore = create<CopilotStateI>()(
             set((state) => {
                 const messages = [...state.messages];
 
-                // find last assistant message
+                // Scan back from the end for this turn's streaming assistant message, stopping at the latest user
+                // message so we never reach into a previous turn and overwrite its reply (issue #5348).
                 for (let i = messages.length - 1; i >= 0; i--) {
                     const message = messages[i] as ThreadMessageLike;
+
+                    if (message.role === 'user') {
+                        break;
+                    }
 
                     if (message.role === 'assistant' && typeof message.content === 'string') {
                         messages[i] = {...message, content: text} as ThreadMessageLike;
@@ -126,7 +131,7 @@ export const useCopilotStore = create<CopilotStateI>()(
                     }
                 }
 
-                // no assistant message yet; create one
+                // No assistant message for the current turn yet; create one.
                 messages.push({role: 'assistant', content: text} as ThreadMessageLike);
 
                 return {...state, messages};


### PR DESCRIPTION
appendToLastAssistantMessage scanned the entire history for the last
string-content assistant message and overwrote it. From turn 2 onward the
scan reached back into a previous turn's reply and rewrote it in place,
leaving user messages to pile up at the tail (A -> U -> A -> UUU).

Stop the backward scan at the latest user message so a fresh assistant
message is appended per turn instead of clobbering a prior one.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
