### PR TITLE
5338 copilot ai provider catalog

### DIFF
--- a/client/src/ee/pages/automation/api-platform/api-collections/components/ApiCollectionEndpointList.tsx
+++ b/client/src/ee/pages/automation/api-platform/api-collections/components/ApiCollectionEndpointList.tsx
@@ -42,7 +42,7 @@ const ApiCollectionEndpointList = ({
                     <ul className="divide-y divide-gray-100">
                         {apiCollectionEndpoints?.map((apiCollectionEndpoint) => (
                             <li
-                                className="flex items-center justify-between rounded-md p-2 px-3 hover:bg-gray-50"
+                                className="flex items-center justify-between rounded-md p-2 px-3 hover:bg-destructive-foreground"
                                 key={apiCollectionEndpoint.id}
                             >
                                 {apiCollectionEndpoint &&

--- a/client/src/ee/pages/embedded/automation-workflows/components/automation-workflow-project-list/AutomationWorkflowProjectListItem.tsx
+++ b/client/src/ee/pages/embedded/automation-workflows/components/automation-workflow-project-list/AutomationWorkflowProjectListItem.tsx
@@ -92,10 +92,10 @@ const AutomationWorkflowProjectListItem = ({
         <>
             <div
                 aria-label={`${project.name}_container`}
-                className="flex w-full cursor-pointer items-center justify-between rounded-md px-2 hover:bg-destructive-foreground"
+                className="flex w-full cursor-pointer items-center justify-between rounded-md px-3 hover:bg-destructive-foreground"
                 onClick={(event) => handleProjectListItemClick(event)}
             >
-                <div className="flex flex-1 items-center py-5 group-data-[state='open']:border-none">
+                <div className="flex flex-1 items-center py-3 group-data-[state='open']:border-none">
                     <div aria-label={project.name} className="flex-1" data-testid="project-item">
                         <div className="flex items-center gap-2">
                             <button

--- a/client/src/ee/pages/embedded/automation-workflows/components/automation-workflow-project-list/AutomationWorkflowProjectWorkflowList.tsx
+++ b/client/src/ee/pages/embedded/automation-workflows/components/automation-workflow-project-list/AutomationWorkflowProjectWorkflowList.tsx
@@ -31,10 +31,10 @@ const AutomationWorkflowProjectWorkflowList = ({
     );
 
     return (
-        <div className="p-3">
+        <div className="pt-3">
             {workflows.length > 0 ? (
                 <>
-                    <h3 className="flex justify-start pl-2 text-sm heading-tertiary">Workflows</h3>
+                    <h3 className="flex justify-start pl-3 text-sm heading-tertiary">Workflows</h3>
 
                     <ul className="divide-y divide-gray-100">
                         {workflows.map((workflow) => (

--- a/client/src/ee/pages/embedded/automation-workflows/components/automation-workflow-project-list/AutomationWorkflowProjectWorkflowListItem.tsx
+++ b/client/src/ee/pages/embedded/automation-workflows/components/automation-workflow-project-list/AutomationWorkflowProjectWorkflowListItem.tsx
@@ -28,7 +28,7 @@ const AutomationWorkflowProjectWorkflowListItem = ({
         : undefined;
 
     return (
-        <li className="flex items-center justify-between rounded-md px-2 py-1 hover:bg-destructive-foreground">
+        <li className="flex items-center justify-between rounded-md px-3 py-1 hover:bg-destructive-foreground">
             <div
                 className="flex flex-1 cursor-pointer items-center gap-2"
                 onClick={() => onSelectWorkflow(workflow.workflowUuid)}

--- a/client/src/ee/pages/embedded/connected-users/components/connected-user-sheet/ConnectedUserSheetPanel.tsx
+++ b/client/src/ee/pages/embedded/connected-users/components/connected-user-sheet/ConnectedUserSheetPanel.tsx
@@ -16,7 +16,7 @@ interface ConnectedUserSheetPanelProps {
 
 const ConnectedUserSheetPanel = ({connectedUser}: ConnectedUserSheetPanelProps) => {
     return (
-        <div className="flex size-full flex-col space-y-10 pt-4">
+        <div className="flex min-h-full w-full shrink-0 flex-col space-y-10 rounded-lg bg-background p-3">
             <div className="w-full space-y-2">
                 <div className="text-base font-semibold">Profile</div>
 

--- a/client/src/ee/pages/embedded/connected-users/components/connected-user-sheet/ConnectedUserSheetPanelIntegrationList.tsx
+++ b/client/src/ee/pages/embedded/connected-users/components/connected-user-sheet/ConnectedUserSheetPanelIntegrationList.tsx
@@ -17,7 +17,7 @@ const ConnectedUserSheetPanelIntegrationList = ({
     });
 
     return connectedUserIntegrationInstances.length > 0 ? (
-        <div className="divide-y">
+        <div>
             {connectedUserIntegrationInstances.map((connectedUserIntegrationInstance) => {
                 const componentDefinition = componentDefinitions?.find(
                     (componentDefinition) => componentDefinition.name === connectedUserIntegrationInstance.componentName

--- a/client/src/ee/pages/embedded/connected-users/components/connected-user-sheet/ConnectedUserSheetPanelIntegrationListItem.tsx
+++ b/client/src/ee/pages/embedded/connected-users/components/connected-user-sheet/ConnectedUserSheetPanelIntegrationListItem.tsx
@@ -75,9 +75,9 @@ const ConnectedUserSheetPanelIntegrationListItem = ({
     });
 
     return (
-        <Collapsible key={connectedUserIntegrationInstance.id}>
+        <Collapsible className="mb-2 rounded border border-border/50" key={connectedUserIntegrationInstance.id}>
             {componentDefinition && (
-                <div className="flex w-full items-center justify-between px-2 hover:bg-muted/50">
+                <div className="flex items-center justify-between rounded-md px-3 py-1 hover:bg-destructive-foreground">
                     <CollapsibleTrigger className="flex-1 py-3">
                         <div className="flex flex-col items-start justify-center gap-y-2">
                             <div className="flex flex-1 items-center gap-1">

--- a/client/src/ee/pages/embedded/connected-users/components/connected-user-sheet/ConnectedUserSheetPanelIntegrationWorkflowList.tsx
+++ b/client/src/ee/pages/embedded/connected-users/components/connected-user-sheet/ConnectedUserSheetPanelIntegrationWorkflowList.tsx
@@ -18,11 +18,11 @@ const ConnectedUserSheetPanelIntegrationWorkflowList = ({
     workflows: Workflow[];
 }) => {
     return (
-        <div className="flex w-full flex-col gap-y-3 py-3 pl-4">
-            <h3 className="flex justify-start px-2 text-sm font-semibold text-muted-foreground uppercase">Workflows</h3>
+        <div className="flex w-full flex-col gap-y-1 pt-3">
+            <h3 className="flex justify-start px-3 text-sm font-semibold text-muted-foreground uppercase">Workflows</h3>
 
             {workflows.length > 0 ? (
-                <ul>
+                <ul className="divide-y divide-gray-100">
                     {workflows.map((workflow) => {
                         const integrationInstanceWorkflow = integrationInstance?.integrationInstanceWorkflows?.find(
                             (integrationInstanceWorkflow) => integrationInstanceWorkflow.workflowId === workflow.id

--- a/client/src/ee/pages/embedded/connected-users/components/connected-user-sheet/ConnectedUserSheetPanelIntegrationWorkflowListItem.tsx
+++ b/client/src/ee/pages/embedded/connected-users/components/connected-user-sheet/ConnectedUserSheetPanelIntegrationWorkflowListItem.tsx
@@ -47,7 +47,10 @@ const ConnectedUserSheetPanelIntegrationWorkflowListItem = ({
     });
 
     return (
-        <li className="flex items-center justify-between rounded-md p-2 py-1 hover:bg-gray-50" key={workflow.id}>
+        <li
+            className="flex h-12 items-center justify-between rounded-md px-3 py-1 hover:bg-destructive-foreground"
+            key={workflow.id}
+        >
             <div className="text-sm font-semibold">{workflow.label}</div>
 
             <div className="flex items-center space-x-1">

--- a/client/src/ee/pages/embedded/connected-users/components/connected-user-sheet/connected-user-mcp-server-list/ConnectedUserMcpServerListItem.tsx
+++ b/client/src/ee/pages/embedded/connected-users/components/connected-user-sheet/connected-user-mcp-server-list/ConnectedUserMcpServerListItem.tsx
@@ -48,7 +48,7 @@ const ConnectedUserMcpServerListItem = ({
     return (
         <>
             <Collapsible key={mcpServer.id}>
-                <div className="flex w-full items-center justify-between px-2 hover:bg-muted/50">
+                <div className="mb-2 flex items-center justify-between rounded border border-border/50 p-3">
                     <CollapsibleTrigger className="flex-1 py-3">
                         <div className="flex flex-col items-start justify-center gap-y-2">
                             <div

--- a/client/src/ee/pages/embedded/connected-users/components/connected-user-sheet/connected-user-project-workflow-list/ConnectedUserProjectWorkflowList.tsx
+++ b/client/src/ee/pages/embedded/connected-users/components/connected-user-sheet/connected-user-project-workflow-list/ConnectedUserProjectWorkflowList.tsx
@@ -7,7 +7,7 @@ const ConnectedUserProjectWorkflowList = ({
     connectedUserProjectWorkflows: ConnectedUserProjectWorkflow[];
 }) => {
     return (
-        <ul className="divide-y">
+        <ul>
             {connectedUserProjectWorkflows.map((connectedUserProjectWorkflow) => (
                 <ConnectedUserProjectWorkflowListItem
                     connectedUserProjectWorkflow={connectedUserProjectWorkflow}

--- a/client/src/ee/pages/embedded/connected-users/components/connected-user-sheet/connected-user-project-workflow-list/ConnectedUserProjectWorkflowListItem.tsx
+++ b/client/src/ee/pages/embedded/connected-users/components/connected-user-sheet/connected-user-project-workflow-list/ConnectedUserProjectWorkflowListItem.tsx
@@ -45,7 +45,7 @@ const ConnectedUserProjectWorkflowListItem = ({
 
     return (
         <>
-            <li className="flex items-center justify-between rounded-md px-2 py-3.5 hover:bg-gray-50">
+            <li className="mb-2 flex items-center justify-between rounded border border-border/50 p-3 hover:bg-destructive-foreground">
                 <div className="flex min-w-0 flex-1 items-center">
                     <span className="truncate text-sm font-semibold">
                         {connectedUserProjectWorkflow.workflow.label}

--- a/client/src/ee/pages/embedded/connections/components/connection-list/ConnectionListItem.tsx
+++ b/client/src/ee/pages/embedded/connections/components/connection-list/ConnectionListItem.tsx
@@ -95,7 +95,7 @@ const ConnectionListItem = ({componentDefinitions, connection, remainingTags}: C
     return (
         <li className="mb-2 rounded border border-border/50" key={connection.id}>
             <>
-                <div className="group flex items-center rounded-md bg-white px-3 hover:bg-gray-50">
+                <div className="group flex items-center rounded-md bg-white px-3 hover:bg-destructive-foreground">
                     <div className="flex flex-1 items-center py-3">
                         <div className="flex-1">
                             <div className="flex items-center justify-between">

--- a/client/src/ee/pages/embedded/integrations/components/integration-workflow-list/IntegrationWorkflowListItem.tsx
+++ b/client/src/ee/pages/embedded/integrations/components/integration-workflow-list/IntegrationWorkflowListItem.tsx
@@ -74,7 +74,10 @@ const IntegrationWorkflowListItem = ({
     });
 
     return (
-        <li className="flex items-center justify-between rounded-md px-3 py-1 hover:bg-gray-50" key={workflow.id}>
+        <li
+            className="flex items-center justify-between rounded-md px-3 py-1 hover:bg-destructive-foreground"
+            key={workflow.id}
+        >
             <Link
                 className="flex flex-1 items-center"
                 to={`/embedded/integrations/${integration.id}/integration-workflows/${workflow.integrationWorkflowId}?${searchParams}`}

--- a/client/src/pages/automation/ai/skills/components/AiSkillListItem.tsx
+++ b/client/src/pages/automation/ai/skills/components/AiSkillListItem.tsx
@@ -36,7 +36,7 @@ const AiSkillListItem = ({deleteSkill, onDownload, onUpdate, skill}: AiSkillList
     return (
         <>
             <div
-                className="flex cursor-pointer items-center justify-between gap-6 rounded-md px-2 py-4 hover:bg-gray-50"
+                className="mb-2 flex cursor-pointer items-center justify-between gap-6 rounded border border-border/50 px-2 py-4 hover:bg-destructive-foreground"
                 onClick={handleClick}
             >
                 <div className="flex min-w-0 flex-1 items-center gap-3">

--- a/client/src/pages/automation/ai/skills/components/AiSkillsList.tsx
+++ b/client/src/pages/automation/ai/skills/components/AiSkillsList.tsx
@@ -11,7 +11,7 @@ const AiSkillsList = ({skills}: AiSkillsListProps) => {
 
     return (
         <div className="flex flex-1 flex-col">
-            <div className="flex-1 divide-y divide-border/50">
+            <div className="flex-1">
                 {filteredSkills.length > 0 ? (
                     filteredSkills.map((skill) => (
                         <AiSkillListItem

--- a/client/src/pages/automation/connections/components/connection-list/ConnectionListItem.tsx
+++ b/client/src/pages/automation/connections/components/connection-list/ConnectionListItem.tsx
@@ -130,7 +130,7 @@ const ConnectionListItem = memo(({componentDefinitions, connection, remainingTag
     return (
         <li className="mb-2 rounded border border-border/50" key={connection.id}>
             <>
-                <div className="group flex items-center rounded-md bg-white px-3 hover:bg-gray-50">
+                <div className="group flex items-center rounded-md bg-white px-3 hover:bg-destructive-foreground">
                     <div className="flex flex-1 items-center py-3">
                         <div className="flex-1">
                             <div className="flex items-center justify-between">

--- a/docs/content/docs/self-hosting/configuration/environment-variables.md
+++ b/docs/content/docs/self-hosting/configuration/environment-variables.md
@@ -10,6 +10,7 @@ ByteChef can be configured using environment variables. This page documents all 
 | Environment Variable | Description | Default Value |
 |---|---|---|
 | `BYTECHEF_AI_COPILOT_ENABLED` | Enable or disable the AI copilot feature | `false` |
+| `BYTECHEF_AI_COPILOT_PROVIDER` | Explicit CE chat-model provider key (e.g. `openai`) to use for Copilot, overriding auto-detection from the configured provider API keys/endpoints. Ignored when the EE AI Providers catalog is active. | - |
 | `BYTECHEF_AI_COPILOT_DOCS_EMBEDDING_PROVIDER` | Embedding provider for the Copilot documentation index (OLLAMA, OPENAI) | - |
 | `BYTECHEF_AI_COPILOT_DOCS_EMBEDDING_APIKEY` | API key for the Copilot documentation embedding provider — OpenAI only; Ollama runs locally and needs none (sensitive) | - |
 
@@ -54,6 +55,7 @@ ByteChef can be configured using environment variables. This page documents all 
 |---------------------------------------------|---|---|
 | `BYTECHEF_AI_PROVIDER_ANTHROPIC_APIKEY`     | Anthropic API key (sensitive) | - |
 | `BYTECHEF_AI_PROVIDER_AZURE_OPENAI_APIKEY`  | Azure OpenAI API key (sensitive) | - |
+| `BYTECHEF_AI_PROVIDER_AZURE_OPENAI_ENDPOINT` | Azure OpenAI resource endpoint, e.g. `https://my-resource.openai.azure.com` | - |
 | `BYTECHEF_AI_PROVIDER_DEEP_SEEK_APIKEY`     | DeepSeek API key (sensitive) | - |
 | `BYTECHEF_AI_PROVIDER_GROQ_APIKEY`          | Groq API key (sensitive) | - |
 | `BYTECHEF_AI_PROVIDER_MISTRAL_APIKEY`       | Mistral API key (sensitive) | - |
@@ -71,15 +73,24 @@ ByteChef can be configured using environment variables. This page documents all 
 |---|---|---|
 | `BYTECHEF_AI_PROVIDER_CHAT_ANTHROPIC_OPTIONS_MODEL` | Anthropic chat model name | `claude-sonnet-4-6` |
 | `BYTECHEF_AI_PROVIDER_CHAT_ANTHROPIC_OPTIONS_TEMPERATURE` | Anthropic chat temperature (0.0-1.0) | `0.5` |
+| `BYTECHEF_AI_PROVIDER_CHAT_AZURE_OPENAI_OPTIONS_MODEL` | Azure OpenAI chat model name (e.g., `gpt-4o`) | - |
+| `BYTECHEF_AI_PROVIDER_CHAT_DEEP_SEEK_OPTIONS_MODEL` | DeepSeek chat model name (e.g., `deepseek-chat`) | - |
+| `BYTECHEF_AI_PROVIDER_CHAT_GROQ_OPTIONS_MODEL` | Groq chat model name (e.g., `llama-3.3-70b-versatile`) | - |
+| `BYTECHEF_AI_PROVIDER_CHAT_MISTRAL_OPTIONS_MODEL` | Mistral chat model name (e.g., `mistral-large-latest`) | - |
+| `BYTECHEF_AI_PROVIDER_CHAT_NVIDIA_OPTIONS_MODEL` | NVIDIA chat model name (e.g., `meta/llama-3.1-70b-instruct`) | - |
+| `BYTECHEF_AI_PROVIDER_CHAT_OLLAMA_OPTIONS_MODEL` | Ollama chat model name (e.g., `llama3.1`) | - |
 | `BYTECHEF_AI_PROVIDER_CHAT_OPENAI_OPTIONS_MODEL` | OpenAI chat model name | `gpt-5.1` |
 | `BYTECHEF_AI_PROVIDER_CHAT_OPENAI_OPTIONS_TEMPERATURE` | OpenAI chat temperature (0.0-2.0) | `1` |
 | `BYTECHEF_AI_PROVIDER_CHAT_OPENAI_OPTIONS_REASONINGEFFECT` | OpenAI reasoning effect (NONE, LOW, MEDIUM, HIGH) | `MEDIUM` |
 | `BYTECHEF_AI_PROVIDER_CHAT_OPENAI_OPTIONS_VERBOSITY` | OpenAI response verbosity (NONE, LOW, MEDIUM, HIGH) | `LOW` |
+| `BYTECHEF_AI_PROVIDER_CHAT_PERPLEXITY_OPTIONS_MODEL` | Perplexity chat model name (e.g., `sonar`) | - |
+| `BYTECHEF_AI_PROVIDER_CHAT_VERTEX_GEMINI_OPTIONS_MODEL` | Vertex Gemini chat model name (e.g., `gemini-1.5-pro`) | - |
 
 ## AI Embedding Model Configuration
 
 | Environment Variable | Description | Default Value |
 |---|---|---|
+| `BYTECHEF_AI_PROVIDER_EMBEDDING_MISTRAL_OPTIONS_MODEL` | Mistral embedding model name (e.g., `mistral-embed`) | - |
 | `BYTECHEF_AI_PROVIDER_EMBEDDING_OLLAMA_OPTIONS_MODEL` | Ollama embedding model name | `qwen3-embedding:8b` |
 | `BYTECHEF_AI_PROVIDER_EMBEDDING_OPENAI_OPTIONS_MODEL` | OpenAI embedding model name | `text-embedding-3-small` |
 

--- a/docs/content/docs/self-hosting/configuration/environment-variables.md
+++ b/docs/content/docs/self-hosting/configuration/environment-variables.md
@@ -10,7 +10,7 @@ ByteChef can be configured using environment variables. This page documents all 
 | Environment Variable | Description | Default Value |
 |---|---|---|
 | `BYTECHEF_AI_COPILOT_ENABLED` | Enable or disable the AI copilot feature | `false` |
-| `BYTECHEF_AI_COPILOT_PROVIDER` | Explicit CE chat-model provider key (e.g. `openai`) to use for Copilot, overriding auto-detection from the configured provider API keys/endpoints. Ignored when the EE AI Providers catalog is active. | - |
+| `BYTECHEF_AI_COPILOT_PROVIDER` | Chat-model provider key (e.g. `anthropic`, `openAi`) to prefer for Copilot. In CE it overrides auto-detection from the configured provider API keys/endpoints. In EE it is used as the environment default provider when set, provided that provider is enabled and has a configured chat model (`BYTECHEF_AI_PROVIDER_CHAT_<PROVIDER>_OPTIONS_MODEL`); otherwise Copilot falls back to the first enabled chat provider. A per-turn model picked in the Copilot toolbar always overrides this. | - |
 | `BYTECHEF_AI_COPILOT_DOCS_EMBEDDING_PROVIDER` | Embedding provider for the Copilot documentation index (OLLAMA, OPENAI) | - |
 | `BYTECHEF_AI_COPILOT_DOCS_EMBEDDING_APIKEY` | API key for the Copilot documentation embedding provider — OpenAI only; Ollama runs locally and needs none (sensitive) | - |
 

--- a/server/ee/libs/ai/ai-copilot/ai-copilot-service/src/main/java/com/bytechef/ee/ai/copilot/agent/CopilotChatClientResolver.java
+++ b/server/ee/libs/ai/ai-copilot/ai-copilot-service/src/main/java/com/bytechef/ee/ai/copilot/agent/CopilotChatClientResolver.java
@@ -26,6 +26,7 @@ import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
@@ -46,10 +47,15 @@ public class CopilotChatClientResolver implements OverrideChatClientResolver {
     private static final Logger log = LoggerFactory.getLogger(CopilotChatClientResolver.class);
 
     private final CatalogChatClientResolver catalogChatClientResolver;
+    private final String defaultProvider;
 
     @SuppressFBWarnings("EI")
-    public CopilotChatClientResolver(CatalogChatClientResolver catalogChatClientResolver) {
+    public CopilotChatClientResolver(
+        CatalogChatClientResolver catalogChatClientResolver,
+        @Value("${bytechef.ai.copilot.provider:}") String defaultProvider) {
+
         this.catalogChatClientResolver = catalogChatClientResolver;
+        this.defaultProvider = defaultProvider;
     }
 
     @Override
@@ -75,6 +81,20 @@ public class CopilotChatClientResolver implements OverrideChatClientResolver {
             log.warn(
                 "Copilot user-selected LLM half-set (provider={}, model={}); using the environment default",
                 llmProvider, llmModel);
+        }
+
+        if (defaultProvider != null && !defaultProvider.isBlank()) {
+            ChatClient preferred =
+                catalogChatClientResolver.resolvePreferred(defaultProvider, environmentId.intValue());
+
+            if (preferred != null) {
+                return preferred;
+            }
+
+            log.warn(
+                "Copilot default provider '{}' (bytechef.ai.copilot.provider) is not usable in environment {} "
+                    + "(disabled or no configured chat model); falling back to the first enabled chat provider",
+                defaultProvider, environmentId);
         }
 
         return catalogChatClientResolver.resolveDefault(environmentId.intValue());

--- a/server/ee/libs/ai/ai-copilot/ai-copilot-service/src/test/java/com/bytechef/ee/ai/copilot/agent/CopilotChatClientResolverCatalogTest.java
+++ b/server/ee/libs/ai/ai-copilot/ai-copilot-service/src/test/java/com/bytechef/ee/ai/copilot/agent/CopilotChatClientResolverCatalogTest.java
@@ -34,7 +34,7 @@ class CopilotChatClientResolverCatalogTest {
 
         when(catalogChatClientResolver.resolve("ai.provider.openAi", "gpt-4o", 3)).thenReturn(catalogChatClient);
 
-        CopilotChatClientResolver resolver = new CopilotChatClientResolver(catalogChatClientResolver);
+        CopilotChatClientResolver resolver = new CopilotChatClientResolver(catalogChatClientResolver, "");
 
         State state = new State();
 

--- a/server/ee/libs/ai/ai-copilot/ai-copilot-service/src/test/java/com/bytechef/ee/ai/copilot/agent/CopilotChatClientResolverTest.java
+++ b/server/ee/libs/ai/ai-copilot/ai-copilot-service/src/test/java/com/bytechef/ee/ai/copilot/agent/CopilotChatClientResolverTest.java
@@ -41,7 +41,7 @@ class CopilotChatClientResolverTest {
     void setUp() {
         catalogChatClientResolver = mock(CatalogChatClientResolver.class);
 
-        resolver = new CopilotChatClientResolver(catalogChatClientResolver);
+        resolver = new CopilotChatClientResolver(catalogChatClientResolver, "");
     }
 
     @Test
@@ -91,5 +91,60 @@ class CopilotChatClientResolverTest {
     @Test
     void testNullStateReturnsNull() {
         assertNull(resolver.resolve(null));
+    }
+
+    @Test
+    void testDefaultProviderPreferredWhenNoUserSelection() {
+        // bytechef.ai.copilot.provider is set and resolvable → Copilot uses it as the environment default instead of
+        // the first-enabled-provider pick.
+        ChatClient preferredChatClient = mock(ChatClient.class);
+
+        when(catalogChatClientResolver.resolvePreferred("anthropic", 3)).thenReturn(preferredChatClient);
+
+        CopilotChatClientResolver preferringResolver =
+            new CopilotChatClientResolver(catalogChatClientResolver, "anthropic");
+
+        State state = new State();
+
+        state.set(CopilotConstants.STATE_ENVIRONMENT_ID, "3");
+
+        assertSame(preferredChatClient, preferringResolver.resolve(state));
+
+        verify(catalogChatClientResolver, never()).resolveDefault(anyInt());
+    }
+
+    @Test
+    void testDefaultProviderFallsBackWhenNotResolvable() {
+        // bytechef.ai.copilot.provider names a provider that is disabled or has no configured model in this
+        // environment → Copilot falls back to the first enabled chat provider.
+        ChatClient defaultChatClient = mock(ChatClient.class);
+
+        when(catalogChatClientResolver.resolvePreferred("anthropic", 3)).thenReturn(null);
+        when(catalogChatClientResolver.resolveDefault(3)).thenReturn(defaultChatClient);
+
+        CopilotChatClientResolver preferringResolver =
+            new CopilotChatClientResolver(catalogChatClientResolver, "anthropic");
+
+        State state = new State();
+
+        state.set(CopilotConstants.STATE_ENVIRONMENT_ID, "3");
+
+        assertSame(defaultChatClient, preferringResolver.resolve(state));
+    }
+
+    @Test
+    void testNoDefaultProviderUsesEnvironmentDefault() {
+        // bytechef.ai.copilot.provider is blank → keep the existing first-enabled-provider behavior.
+        ChatClient defaultChatClient = mock(ChatClient.class);
+
+        when(catalogChatClientResolver.resolveDefault(3)).thenReturn(defaultChatClient);
+
+        State state = new State();
+
+        state.set(CopilotConstants.STATE_ENVIRONMENT_ID, "3");
+
+        assertSame(defaultChatClient, resolver.resolve(state));
+
+        verify(catalogChatClientResolver, never()).resolvePreferred(anyString(), anyInt());
     }
 }

--- a/server/ee/libs/automation/automation-configuration/automation-configuration-api/src/main/java/com/bytechef/ee/automation/configuration/security/PermissionScopeProvider.java
+++ b/server/ee/libs/automation/automation-configuration/automation-configuration-api/src/main/java/com/bytechef/ee/automation/configuration/security/PermissionScopeProvider.java
@@ -7,6 +7,7 @@
 
 package com.bytechef.ee.automation.configuration.security;
 
+import com.bytechef.automation.configuration.security.constant.PermissionScopeType;
 import com.bytechef.ee.automation.configuration.security.constant.WorkspaceRole;
 import java.util.Set;
 
@@ -23,16 +24,16 @@ import java.util.Set;
 public interface PermissionScopeProvider {
 
     /**
-     * The scopes this module owns. Must be unique across all providers; a name declared by two providers (or twice with
-     * different {@link ScopeDefinition#minimumRole()}) is a registration error.
+     * The scopes this module owns. Must be unique across all providers; a scope declared by two providers (or twice
+     * with different {@link ScopeDefinition#minimumRole()}) is a registration error.
      */
     Set<ScopeDefinition> scopeDefinitions();
 
     /**
-     * A single scope: its persisted name and the lowest built-in {@link WorkspaceRole} that is granted it. Higher-
-     * privilege roles inherit it by rank (VIEWER-min &rArr; VIEWER/EDITOR/ADMIN; EDITOR-min &rArr; EDITOR/ADMIN;
+     * A single scope: its {@link PermissionScopeType} and the lowest built-in {@link WorkspaceRole} that is granted it.
+     * Higher-privilege roles inherit it by rank (VIEWER-min &rArr; VIEWER/EDITOR/ADMIN; EDITOR-min &rArr; EDITOR/ADMIN;
      * ADMIN-min &rArr; ADMIN only), which keeps the VIEWER &sub; EDITOR &sub; ADMIN invariant by construction.
      */
-    record ScopeDefinition(String name, WorkspaceRole minimumRole) {
+    record ScopeDefinition(PermissionScopeType scopeType, WorkspaceRole minimumRole) {
     }
 }

--- a/server/ee/libs/automation/automation-configuration/automation-configuration-service/src/main/java/com/bytechef/ee/automation/configuration/service/PermissionScopeRegistry.java
+++ b/server/ee/libs/automation/automation-configuration/automation-configuration-service/src/main/java/com/bytechef/ee/automation/configuration/service/PermissionScopeRegistry.java
@@ -7,6 +7,7 @@
 
 package com.bytechef.ee.automation.configuration.service;
 
+import com.bytechef.automation.configuration.security.constant.PermissionScopeType;
 import com.bytechef.ee.automation.configuration.security.PermissionScopeProvider;
 import com.bytechef.ee.automation.configuration.security.PermissionScopeProvider.ScopeDefinition;
 import com.bytechef.ee.automation.configuration.security.constant.WorkspaceRole;
@@ -49,12 +50,14 @@ public class PermissionScopeRegistry {
 
         for (PermissionScopeProvider permissionScopeProvider : permissionScopeProviders) {
             for (ScopeDefinition scopeDefinition : permissionScopeProvider.scopeDefinitions()) {
+                PermissionScopeType permissionScopeType = scopeDefinition.scopeType();
+
                 WorkspaceRole existing = minimumRoleByScope.putIfAbsent(
-                    scopeDefinition.name(), scopeDefinition.minimumRole());
+                    permissionScopeType.name(), scopeDefinition.minimumRole());
 
                 if (existing != null && existing != scopeDefinition.minimumRole()) {
                     throw new IllegalStateException(
-                        "Permission scope '" + scopeDefinition.name() +
+                        "Permission scope '" + permissionScopeType.name() +
                             "' declared with conflicting minimum roles " + existing + " and " +
                             scopeDefinition.minimumRole());
                 }

--- a/server/ee/libs/automation/automation-configuration/automation-configuration-service/src/test/java/com/bytechef/ee/automation/configuration/service/PermissionScopeRegistryTest.java
+++ b/server/ee/libs/automation/automation-configuration/automation-configuration-service/src/test/java/com/bytechef/ee/automation/configuration/service/PermissionScopeRegistryTest.java
@@ -10,6 +10,7 @@ package com.bytechef.ee.automation.configuration.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.bytechef.automation.configuration.security.constant.PermissionScopeType;
 import com.bytechef.ee.automation.configuration.security.PermissionScopeProvider;
 import com.bytechef.ee.automation.configuration.security.PermissionScopeProvider.ScopeDefinition;
 import com.bytechef.ee.automation.configuration.security.constant.WorkspaceRole;
@@ -38,12 +39,12 @@ class PermissionScopeRegistryTest {
     private final PermissionScopeRegistry permissionScopeRegistry = new PermissionScopeRegistry(
         List.<PermissionScopeProvider>of(
             () -> Set.of(
-                new ScopeDefinition("ALPHA_VIEW", WorkspaceRole.VIEWER),
-                new ScopeDefinition("ALPHA_EDIT", WorkspaceRole.EDITOR),
-                new ScopeDefinition("ALPHA_MANAGE", WorkspaceRole.ADMIN)),
+                new ScopeDefinition(TestPermissionScope.ALPHA_VIEW, WorkspaceRole.VIEWER),
+                new ScopeDefinition(TestPermissionScope.ALPHA_EDIT, WorkspaceRole.EDITOR),
+                new ScopeDefinition(TestPermissionScope.ALPHA_MANAGE, WorkspaceRole.ADMIN)),
             () -> Set.of(
-                new ScopeDefinition("BETA_VIEW", WorkspaceRole.VIEWER),
-                new ScopeDefinition("BETA_DELETE", WorkspaceRole.EDITOR))));
+                new ScopeDefinition(TestPermissionScope.BETA_VIEW, WorkspaceRole.VIEWER),
+                new ScopeDefinition(TestPermissionScope.BETA_DELETE, WorkspaceRole.EDITOR))));
 
     @Test
     void testBuiltInRoleTiers() {
@@ -79,8 +80,10 @@ class PermissionScopeRegistryTest {
 
     @Test
     void testConflictingMinimumRoleFailsFast() {
-        PermissionScopeProvider first = () -> Set.of(new ScopeDefinition("X_SCOPE", WorkspaceRole.VIEWER));
-        PermissionScopeProvider second = () -> Set.of(new ScopeDefinition("X_SCOPE", WorkspaceRole.ADMIN));
+        PermissionScopeProvider first =
+            () -> Set.of(new ScopeDefinition(TestPermissionScope.X_SCOPE, WorkspaceRole.VIEWER));
+        PermissionScopeProvider second =
+            () -> Set.of(new ScopeDefinition(TestPermissionScope.X_SCOPE, WorkspaceRole.ADMIN));
 
         assertThatThrownBy(() -> new PermissionScopeRegistry(List.of(first, second)))
             .isInstanceOf(IllegalStateException.class);
@@ -89,5 +92,17 @@ class PermissionScopeRegistryTest {
     private static Set<String> union(Set<String> first, Set<String> second) {
         return Stream.concat(first.stream(), second.stream())
             .collect(Collectors.toUnmodifiableSet());
+    }
+
+    // Synthetic scope enum kept local to the test so aggregation/tiering is exercised without coupling to the
+    // production scope catalog (the real security.scope.* enums are contributed and verified separately).
+    private enum TestPermissionScope implements PermissionScopeType {
+
+        ALPHA_VIEW,
+        ALPHA_EDIT,
+        ALPHA_MANAGE,
+        BETA_VIEW,
+        BETA_DELETE,
+        X_SCOPE
     }
 }

--- a/server/ee/libs/platform/platform-ai/platform-ai-agent/platform-ai-agent-api/src/main/java/com/bytechef/ee/platform/ai/agent/catalog/CatalogChatClientResolver.java
+++ b/server/ee/libs/platform/platform-ai/platform-ai-agent/platform-ai-agent-api/src/main/java/com/bytechef/ee/platform/ai/agent/catalog/CatalogChatClientResolver.java
@@ -43,4 +43,16 @@ public interface CatalogChatClientResolver {
      */
     @Nullable
     ChatClient resolveDefault(int environment);
+
+    /**
+     * Resolves a {@link ChatClient} for a specific preferred provider, using that provider's configured default chat
+     * model. Returns {@code null} (caller falls back to {@link #resolveDefault(int)}) when the provider key is blank,
+     * or the provider is disabled, unconfigured, or has no default model in the environment.
+     *
+     * @param providerKey the catalog provider key to prefer (e.g. {@code "anthropic"})
+     * @param environment the environment ordinal
+     * @return a configured {@link ChatClient}, or {@code null} when the preferred provider can't be resolved
+     */
+    @Nullable
+    ChatClient resolvePreferred(String providerKey, int environment);
 }

--- a/server/ee/libs/platform/platform-ai/platform-ai-agent/platform-ai-agent-service/src/main/java/com/bytechef/ee/platform/ai/agent/catalog/CatalogChatClientResolverImpl.java
+++ b/server/ee/libs/platform/platform-ai/platform-ai-agent/platform-ai-agent-service/src/main/java/com/bytechef/ee/platform/ai/agent/catalog/CatalogChatClientResolverImpl.java
@@ -91,4 +91,23 @@ public class CatalogChatClientResolverImpl implements CatalogChatClientResolver 
 
         return resolve(defaultModel.provider(), defaultModel.model(), environment);
     }
+
+    @Override
+    public @Nullable ChatClient resolvePreferred(String providerKey, int environment) {
+        if (providerKey == null || providerKey.isBlank()) {
+            return null;
+        }
+
+        if (environment < 0 || environment >= Environment.values().length) {
+            return null;
+        }
+
+        AiDefaultModelDTO defaultModel = aiProviderFacade.getAiDefaultChatModel(providerKey, environment);
+
+        if (defaultModel == null) {
+            return null;
+        }
+
+        return resolve(defaultModel.provider(), defaultModel.model(), environment);
+    }
 }

--- a/server/ee/libs/platform/platform-configuration/platform-configuration-api/src/main/java/com/bytechef/ee/platform/configuration/facade/AiProviderFacade.java
+++ b/server/ee/libs/platform/platform-configuration/platform-configuration-api/src/main/java/com/bytechef/ee/platform/configuration/facade/AiProviderFacade.java
@@ -24,6 +24,13 @@ public interface AiProviderFacade {
 
     AiDefaultModelDTO getAiDefaultChatModel(int environmentId);
 
+    /**
+     * Resolves the default chat model for a specific provider, applying the same eligibility rules as
+     * {@link #getAiDefaultChatModel(int)} (provider must be enabled, a chat provider, and have a configured model) but
+     * scoped to a single provider key. Returns {@code null} when the provider is not eligible in the environment.
+     */
+    AiDefaultModelDTO getAiDefaultChatModel(String providerKey, int environmentId);
+
     AiDefaultModelWithApiKeyDTO getAiDefaultChatModelApiKey(int environmentId);
 
     AiDefaultModelDTO getAiDefaultEmbeddingModel(int environmentId);

--- a/server/ee/libs/platform/platform-configuration/platform-configuration-service/src/main/java/com/bytechef/ee/platform/configuration/facade/AiProviderFacadeImpl.java
+++ b/server/ee/libs/platform/platform-configuration/platform-configuration-service/src/main/java/com/bytechef/ee/platform/configuration/facade/AiProviderFacadeImpl.java
@@ -111,11 +111,18 @@ public class AiProviderFacadeImpl implements AiProviderFacade {
     @Override
     @Transactional(readOnly = true)
     public AiDefaultModelDTO getAiDefaultChatModel(int environmentId) {
+        return getAiDefaultChatModel(null, environmentId);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public AiDefaultModelDTO getAiDefaultChatModel(String providerKey, int environmentId) {
         return getAiProviders(environmentId)
             .stream()
             .filter(AiProviderDTO::enabled)
             .map(aiProviderDTO -> getProvider(aiProviderDTO.id()))
             .filter(Provider.CHAT_PROVIDERS::contains)
+            .filter(provider -> providerKey == null || Objects.equals(provider.getKey(), providerKey))
             .map(provider -> {
                 String model = resolveDefaultChatModel(provider);
 

--- a/server/libs/ai/ai-api/src/main/java/com/bytechef/ai/agent/tool/AgentType.java
+++ b/server/libs/ai/ai-api/src/main/java/com/bytechef/ai/agent/tool/AgentType.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2025 ByteChef
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.bytechef.ai.agent.tool;
+
+/**
+ * Identity of an AI agent, used by the usage-observation handling (and the expensive tool callbacks) to attribute LLM
+ * and tool calls to the right agent. Implemented once per module by a domain enum (e.g. {@code AiHubAgentType},
+ * {@code CopilotAgentType}) so the set of valid agent types is assembled from the modules that own them rather than
+ * hardcoded in one central enum. Every implementation is contributed through {@link AgentTypeProvider} and aggregated
+ * by {@link AgentTypeRegistry}.
+ *
+ * @author Ivica Cardic
+ */
+public interface AgentType {
+
+    /**
+     * Stable identity used for cost-attribution persistence (e.g. {@code "RESEARCH"}). Satisfied for free by every enum
+     * that implements this interface.
+     */
+    String name();
+
+    /**
+     * The wire-format key for this agent — matches the {@code agentId} routed by the chat REST controller (e.g.
+     * {@code "research"}).
+     */
+    String key();
+
+    /**
+     * Whether this type represents a coarse fallback emitted because no more specific agent was bound.
+     */
+    boolean isFallback();
+}

--- a/server/libs/ai/ai-api/src/main/java/com/bytechef/ai/agent/tool/AgentTypeProvider.java
+++ b/server/libs/ai/ai-api/src/main/java/com/bytechef/ai/agent/tool/AgentTypeProvider.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2025 ByteChef
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.bytechef.ai.agent.tool;
+
+import java.util.Set;
+
+/**
+ * SPI contributed once per module to declare the {@link AgentType}s that module owns. Discovered via
+ * {@link java.util.ServiceLoader} and aggregated by {@link AgentTypeRegistry}, so a new module adds its agent types by
+ * dropping in a provider (registered with {@code @AutoService(AgentTypeProvider.class)}) rather than editing a central
+ * enum. Mirrors the {@code @AutoService(ComponentHandler.class)} discovery used for components.
+ *
+ * @author Ivica Cardic
+ */
+public interface AgentTypeProvider {
+
+    /**
+     * The agent types this module owns. Keys must be unique across all providers.
+     */
+    Set<AgentType> agentTypes();
+}

--- a/server/libs/ai/ai-api/src/main/java/com/bytechef/ai/agent/tool/AgentTypeRegistry.java
+++ b/server/libs/ai/ai-api/src/main/java/com/bytechef/ai/agent/tool/AgentTypeRegistry.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2025 ByteChef
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.bytechef.ai.agent.tool;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.ServiceLoader;
+
+/**
+ * Central view of every {@link AgentType} contributed by the per-module {@link AgentTypeProvider}s. The providers are
+ * discovered once via {@link ServiceLoader}, so the catalog is assembled from the modules that own the types rather
+ * than from a central enum. The built-in {@link CoreAgentType} values (currently the {@link CoreAgentType#UNKNOWN}
+ * fallback) are always registered.
+ *
+ * @author Ivica Cardic
+ */
+public final class AgentTypeRegistry {
+
+    private static final Map<String, AgentType> AGENT_TYPES_BY_KEY = load();
+
+    private AgentTypeRegistry() {
+    }
+
+    public static AgentType fromKey(String key) {
+        if (key == null) {
+            return CoreAgentType.UNKNOWN;
+        }
+
+        return AGENT_TYPES_BY_KEY.getOrDefault(key, CoreAgentType.UNKNOWN);
+    }
+
+    private static Map<String, AgentType> load() {
+        Map<String, AgentType> agentTypesByKey = new HashMap<>();
+
+        for (CoreAgentType coreAgentType : CoreAgentType.values()) {
+            agentTypesByKey.put(coreAgentType.key(), coreAgentType);
+        }
+
+        for (AgentTypeProvider agentTypeProvider : ServiceLoader.load(
+            AgentTypeProvider.class, AgentTypeRegistry.class.getClassLoader())) {
+
+            for (AgentType agentType : agentTypeProvider.agentTypes()) {
+                AgentType existing = agentTypesByKey.putIfAbsent(agentType.key(), agentType);
+
+                if (existing != null && existing != agentType) {
+                    throw new IllegalStateException(
+                        "Agent type key '" + agentType.key() + "' declared by more than one provider (" +
+                            existing.name() + " and " + agentType.name() + ")");
+                }
+            }
+        }
+
+        return agentTypesByKey;
+    }
+}

--- a/server/libs/ai/ai-api/src/main/java/com/bytechef/ai/agent/tool/CoreAgentType.java
+++ b/server/libs/ai/ai-api/src/main/java/com/bytechef/ai/agent/tool/CoreAgentType.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2025 ByteChef
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.bytechef.ai.agent.tool;
+
+/**
+ * Edition-neutral agent types owned by the core module. Currently just the universal {@link #UNKNOWN} fallback returned
+ * by {@link AgentTypeRegistry#fromKey(String)} when a key matches no contributed {@link AgentType}.
+ *
+ * @author Ivica Cardic
+ */
+public enum CoreAgentType implements AgentType {
+
+    UNKNOWN("unknown", true);
+
+    private final String key;
+    private final boolean fallback;
+
+    CoreAgentType(String key, boolean fallback) {
+        this.key = key;
+        this.fallback = fallback;
+    }
+
+    @Override
+    public String key() {
+        return key;
+    }
+
+    @Override
+    public boolean isFallback() {
+        return fallback;
+    }
+}

--- a/server/libs/ai/ai-api/src/main/java/com/bytechef/ai/agent/tool/CurrentAgentContext.java
+++ b/server/libs/ai/ai-api/src/main/java/com/bytechef/ai/agent/tool/CurrentAgentContext.java
@@ -31,7 +31,7 @@ public final class CurrentAgentContext {
      * Immutable two-tuple of the agent and (optionally) the parent agent. {@code parentAgent} is {@code null} for
      * top-level ai_hub calls.
      */
-    public record AgentBinding(Agent agentName, @Nullable Agent parentAgent) {
+    public record AgentBinding(AgentType agentName, @Nullable AgentType parentAgent) {
     }
 
     private static final InheritableThreadLocal<AgentBinding> HOLDER = new InheritableThreadLocal<>();
@@ -50,7 +50,7 @@ public final class CurrentAgentContext {
      * Pushes a binding for the duration of {@code runnable}. The previous binding (if any) is restored even if the
      * runnable throws.
      */
-    public static void runWith(Agent agentName, @Nullable Agent parentAgent, Runnable runnable) {
+    public static void runWith(AgentType agentName, @Nullable AgentType parentAgent, Runnable runnable) {
         AgentBinding previous = HOLDER.get();
 
         HOLDER.set(new AgentBinding(agentName, parentAgent));
@@ -67,9 +67,9 @@ public final class CurrentAgentContext {
     }
 
     /**
-     * Variant of {@link #runWith(Agent, Agent, Runnable)} that returns the supplier's value.
+     * Variant of {@link #runWith(AgentType, AgentType, Runnable)} that returns the supplier's value.
      */
-    public static <T> T callWith(Agent agentName, @Nullable Agent parentAgent, Supplier<T> supplier) {
+    public static <T> T callWith(AgentType agentName, @Nullable AgentType parentAgent, Supplier<T> supplier) {
         AgentBinding previous = HOLDER.get();
 
         HOLDER.set(new AgentBinding(agentName, parentAgent));

--- a/server/libs/ai/ai-api/src/test/java/com/bytechef/ai/agent/tool/AgentTypeRegistryTest.java
+++ b/server/libs/ai/ai-api/src/test/java/com/bytechef/ai/agent/tool/AgentTypeRegistryTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2025 ByteChef
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.bytechef.ai.agent.tool;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.bytechef.ai.agent.tool.TestAgentTypeProvider.TestAgentType;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Ivica Cardic
+ */
+class AgentTypeRegistryTest {
+
+    @Test
+    void testFromKeyResolvesContributedType() {
+        assertThat(AgentTypeRegistry.fromKey("test_alpha")).isEqualTo(TestAgentType.ALPHA);
+        assertThat(AgentTypeRegistry.fromKey("test_beta")).isEqualTo(TestAgentType.BETA);
+    }
+
+    @Test
+    void testFromKeyResolvesBuiltInCoreType() {
+        assertThat(AgentTypeRegistry.fromKey("unknown")).isEqualTo(CoreAgentType.UNKNOWN);
+    }
+
+    @Test
+    void testFromKeyFallsBackToUnknownForNull() {
+        assertThat(AgentTypeRegistry.fromKey(null)).isEqualTo(CoreAgentType.UNKNOWN);
+    }
+
+    @Test
+    void testFromKeyFallsBackToUnknownForUnrecognizedKey() {
+        assertThat(AgentTypeRegistry.fromKey("no_such_agent")).isEqualTo(CoreAgentType.UNKNOWN);
+    }
+}

--- a/server/libs/ai/ai-api/src/test/java/com/bytechef/ai/agent/tool/TestAgentTypeProvider.java
+++ b/server/libs/ai/ai-api/src/test/java/com/bytechef/ai/agent/tool/TestAgentTypeProvider.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2025 ByteChef
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.bytechef.ai.agent.tool;
+
+import java.util.Set;
+
+/**
+ * Synthetic provider registered via {@code META-INF/services} so {@link AgentTypeRegistry} discovers it on the test
+ * classpath, exercising cross-provider aggregation without coupling the test to the production agent-type catalog.
+ *
+ * @author Ivica Cardic
+ */
+public class TestAgentTypeProvider implements AgentTypeProvider {
+
+    enum TestAgentType implements AgentType {
+
+        ALPHA("test_alpha", false),
+        BETA("test_beta", true);
+
+        private final String key;
+        private final boolean fallback;
+
+        TestAgentType(String key, boolean fallback) {
+            this.key = key;
+            this.fallback = fallback;
+        }
+
+        @Override
+        public String key() {
+            return key;
+        }
+
+        @Override
+        public boolean isFallback() {
+            return fallback;
+        }
+    }
+
+    @Override
+    public Set<AgentType> agentTypes() {
+        return Set.of(TestAgentType.values());
+    }
+}

--- a/server/libs/ai/ai-api/src/test/resources/META-INF/services/com.bytechef.ai.agent.tool.AgentTypeProvider
+++ b/server/libs/ai/ai-api/src/test/resources/META-INF/services/com.bytechef.ai.agent.tool.AgentTypeProvider
@@ -1,0 +1,1 @@
+com.bytechef.ai.agent.tool.TestAgentTypeProvider

--- a/server/libs/ai/ai-copilot/ai-copilot-service/build.gradle.kts
+++ b/server/libs/ai/ai-copilot/ai-copilot-service/build.gradle.kts
@@ -6,7 +6,7 @@ val copyDocs = tasks.register<Copy>("copyDocs") {
         include("**/*.md", "**/*.mdx")
         exclude("reference/components/**", "reference/flow-controls/**")
     }
-    into(layout.projectDirectory.dir("src/main/resources/docs"))
+    into(layout.buildDirectory.dir("generated-resources/docs"))
 }
 
 val copyComponentDocs = tasks.register<Copy>("copyComponentDocs") {
@@ -21,7 +21,7 @@ val copyComponentDocs = tasks.register<Copy>("copyComponentDocs") {
         }
         includeEmptyDirs = false
     }
-    into(layout.projectDirectory.dir("src/main/resources/docs/reference/components"))
+    into(layout.buildDirectory.dir("generated-resources/docs/reference/components"))
 }
 
 val copyEeComponentDocs = tasks.register<Copy>("copyEeComponentDocs") {
@@ -36,7 +36,7 @@ val copyEeComponentDocs = tasks.register<Copy>("copyEeComponentDocs") {
         }
         includeEmptyDirs = false
     }
-    into(layout.projectDirectory.dir("src/main/resources/docs/reference/components"))
+    into(layout.buildDirectory.dir("generated-resources/docs/reference/components"))
 }
 
 val copyTaskDispatcherDocs = tasks.register<Copy>("copyTaskDispatcherDocs") {
@@ -51,7 +51,7 @@ val copyTaskDispatcherDocs = tasks.register<Copy>("copyTaskDispatcherDocs") {
         }
         includeEmptyDirs = false
     }
-    into(layout.projectDirectory.dir("src/main/resources/docs/reference/task-dispatchers"))
+    into(layout.buildDirectory.dir("generated-resources/docs/reference/task-dispatchers"))
 }
 
 val copyEeTaskDispatcherDocs = tasks.register<Copy>("copyEeTaskDispatcherDocs") {
@@ -66,7 +66,7 @@ val copyEeTaskDispatcherDocs = tasks.register<Copy>("copyEeTaskDispatcherDocs") 
         }
         includeEmptyDirs = false
     }
-    into(layout.projectDirectory.dir("src/main/resources/docs/reference/task-dispatchers"))
+    into(layout.buildDirectory.dir("generated-resources/docs/reference/task-dispatchers"))
 }
 
 val copyAllDocs = tasks.register("copyAllDocs") {
@@ -82,6 +82,14 @@ tasks.compileJava {
 
 tasks.processResources {
     dependsOn(copyAllDocs)
+}
+
+sourceSets {
+    named("main") {
+        resources {
+            srcDir(layout.buildDirectory.dir("generated-resources"))
+        }
+    }
 }
 
 spotless {

--- a/server/libs/ai/ai-copilot/ai-copilot-tool/build.gradle.kts
+++ b/server/libs/ai/ai-copilot/ai-copilot-tool/build.gradle.kts
@@ -1,5 +1,8 @@
 dependencies {
+    annotationProcessor(rootProject.libs.com.google.auto.service.auto.service)
+
     implementation("org.slf4j:slf4j-api")
+    implementation(rootProject.libs.com.google.auto.service.auto.service.annotations)
     implementation(libs.org.springaicommunity.spring.ai.agent.utils)
     implementation("org.springframework.security:spring-security-core")
     implementation("org.springframework.ai:spring-ai-client-chat")

--- a/server/libs/ai/ai-copilot/ai-copilot-tool/src/main/java/com/bytechef/ai/copilot/tool/ClusterElementAgentToolCallback.java
+++ b/server/libs/ai/ai-copilot/ai-copilot-tool/src/main/java/com/bytechef/ai/copilot/tool/ClusterElementAgentToolCallback.java
@@ -16,7 +16,7 @@
 
 package com.bytechef.ai.copilot.tool;
 
-import com.bytechef.ai.agent.tool.Agent;
+import com.bytechef.ai.agent.tool.AgentType;
 import com.bytechef.ai.agent.tool.CurrentAgentContext;
 import com.bytechef.ai.agent.tool.CurrentAgentContext.AgentBinding;
 import com.bytechef.ai.agent.tool.ToolErrors;
@@ -96,12 +96,12 @@ public class ClusterElementAgentToolCallback implements ToolCallback {
             }
 
             AgentBinding parent = CurrentAgentContext.current();
-            Agent parentAgent = parent != null ? parent.agentName() : null;
+            AgentType parentAgent = parent != null ? parent.agentName() : null;
 
             Map<String, Object> forwardedContext = toolContext == null ? Map.of() : toolContext.getContext();
 
             String result = CurrentAgentContext.callWith(
-                Agent.CLUSTER_ELEMENT_AGENT, parentAgent,
+                CopilotAgentType.CLUSTER_ELEMENT_AGENT, parentAgent,
                 () -> clusterElementChatClient.prompt(request)
                     .toolContext(forwardedContext)
                     .call()

--- a/server/libs/ai/ai-copilot/ai-copilot-tool/src/main/java/com/bytechef/ai/copilot/tool/CodeEditorAgentToolCallback.java
+++ b/server/libs/ai/ai-copilot/ai-copilot-tool/src/main/java/com/bytechef/ai/copilot/tool/CodeEditorAgentToolCallback.java
@@ -16,7 +16,7 @@
 
 package com.bytechef.ai.copilot.tool;
 
-import com.bytechef.ai.agent.tool.Agent;
+import com.bytechef.ai.agent.tool.AgentType;
 import com.bytechef.ai.agent.tool.CurrentAgentContext;
 import com.bytechef.ai.agent.tool.CurrentAgentContext.AgentBinding;
 import com.bytechef.ai.agent.tool.ToolErrors;
@@ -95,12 +95,12 @@ public class CodeEditorAgentToolCallback implements ToolCallback {
             }
 
             AgentBinding parent = CurrentAgentContext.current();
-            Agent parentAgent = parent != null ? parent.agentName() : null;
+            AgentType parentAgent = parent != null ? parent.agentName() : null;
 
             Map<String, Object> forwardedContext = toolContext == null ? Map.of() : toolContext.getContext();
 
             String result = CurrentAgentContext.callWith(
-                Agent.CODE_EDITOR_AGENT, parentAgent,
+                CopilotAgentType.CODE_EDITOR_AGENT, parentAgent,
                 () -> codeEditorChatClient.prompt(request)
                     .toolContext(forwardedContext)
                     .call()

--- a/server/libs/ai/ai-copilot/ai-copilot-tool/src/main/java/com/bytechef/ai/copilot/tool/ConverterAgentToolCallback.java
+++ b/server/libs/ai/ai-copilot/ai-copilot-tool/src/main/java/com/bytechef/ai/copilot/tool/ConverterAgentToolCallback.java
@@ -16,7 +16,7 @@
 
 package com.bytechef.ai.copilot.tool;
 
-import com.bytechef.ai.agent.tool.Agent;
+import com.bytechef.ai.agent.tool.AgentType;
 import com.bytechef.ai.agent.tool.CurrentAgentContext;
 import com.bytechef.ai.agent.tool.CurrentAgentContext.AgentBinding;
 import com.bytechef.ai.agent.tool.ToolErrors;
@@ -95,12 +95,12 @@ public class ConverterAgentToolCallback implements ToolCallback {
             }
 
             AgentBinding parent = CurrentAgentContext.current();
-            Agent parentAgent = parent != null ? parent.agentName() : null;
+            AgentType parentAgent = parent != null ? parent.agentName() : null;
 
             Map<String, Object> forwardedContext = toolContext == null ? Map.of() : toolContext.getContext();
 
             String result = CurrentAgentContext.callWith(
-                Agent.CONVERTER_AGENT, parentAgent,
+                CopilotAgentType.CONVERTER_AGENT, parentAgent,
                 () -> converterChatClient.prompt(request)
                     .toolContext(forwardedContext)
                     .call()

--- a/server/libs/ai/ai-copilot/ai-copilot-tool/src/main/java/com/bytechef/ai/copilot/tool/CopilotAgentType.java
+++ b/server/libs/ai/ai-copilot/ai-copilot-tool/src/main/java/com/bytechef/ai/copilot/tool/CopilotAgentType.java
@@ -14,16 +14,18 @@
  * limitations under the License.
  */
 
-package com.bytechef.ai.agent.tool;
+package com.bytechef.ai.copilot.tool;
+
+import com.bytechef.ai.agent.tool.AgentType;
 
 /**
+ * The copilot-owned agent types: the workflow-editor, code-editor and cluster-element chat flows (each with its
+ * ASK/BUILD variants and a coarse fallback), plus the copilot subagents invoked as tools.
+ *
  * @author Ivica Cardic
  */
-public enum Agent {
+public enum CopilotAgentType implements AgentType {
 
-    AI_HUB_ASK("ai_hub_ask", false),
-    AI_HUB_BUILD("ai_hub_build", false),
-    AI_HUB("ai_hub", true),
     WORKFLOW_EDITOR_ASK("workflow_editor_ask", false),
     WORKFLOW_EDITOR_BUILD("workflow_editor_build", false),
     WORKFLOW_EDITOR("workflow_editor", true),
@@ -33,13 +35,6 @@ public enum Agent {
     CLUSTER_ELEMENT_ASK("cluster_element_ask", false),
     CLUSTER_ELEMENT_BUILD("cluster_element_build", false),
     CLUSTER_ELEMENT("cluster_element", true),
-    FILES("files", true),
-    RESEARCH("research", false),
-    DATA_ANALYST("data_analyst", false),
-    IMAGE_GENERATOR("image_generator", false),
-    SLIDE_BUILDER("slide_builder", false),
-    WORKFLOW_BUILDER("workflow_builder", false),
-    UNKNOWN("unknown", true),
     SKILLS("skills", false),
     CLUSTER_ELEMENT_AGENT("cluster_element_agent", false),
     CODE_EDITOR_AGENT("code_editor_agent", false),
@@ -50,40 +45,18 @@ public enum Agent {
     private final String key;
     private final boolean fallback;
 
-    Agent(String key, boolean fallback) {
+    CopilotAgentType(String key, boolean fallback) {
         this.key = key;
         this.fallback = fallback;
     }
 
-    /**
-     * The wire-format key for this agent — matches the {@code agentId} routed by the chat REST controller.
-     */
+    @Override
     public String key() {
         return key;
     }
 
-    /**
-     * Whether this enum value represents a coarse fallback emitted because no {@link CurrentAgentContext.AgentBinding}
-     * was bound.
-     */
+    @Override
     public boolean isFallback() {
         return fallback;
-    }
-
-    /**
-     * Resolves an {@link Agent} from its wire-format key (case-sensitive).
-     */
-    public static Agent fromKey(String key) {
-        if (key == null) {
-            return UNKNOWN;
-        }
-
-        for (Agent agent : values()) {
-            if (agent.key.equals(key)) {
-                return agent;
-            }
-        }
-
-        return UNKNOWN;
     }
 }

--- a/server/libs/ai/ai-copilot/ai-copilot-tool/src/main/java/com/bytechef/ai/copilot/tool/CopilotAgentTypeProvider.java
+++ b/server/libs/ai/ai-copilot/ai-copilot-tool/src/main/java/com/bytechef/ai/copilot/tool/CopilotAgentTypeProvider.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2025 ByteChef
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.bytechef.ai.copilot.tool;
+
+import com.bytechef.ai.agent.tool.AgentType;
+import com.bytechef.ai.agent.tool.AgentTypeProvider;
+import com.google.auto.service.AutoService;
+import java.util.Set;
+
+/**
+ * Contributes the copilot {@link CopilotAgentType} values to the {@code AgentTypeRegistry}.
+ *
+ * @author Ivica Cardic
+ */
+@AutoService(AgentTypeProvider.class)
+public class CopilotAgentTypeProvider implements AgentTypeProvider {
+
+    @Override
+    public Set<AgentType> agentTypes() {
+        return Set.of(CopilotAgentType.values());
+    }
+}

--- a/server/libs/ai/ai-copilot/ai-copilot-tool/src/main/java/com/bytechef/ai/copilot/tool/CreateConnectionToolCallback.java
+++ b/server/libs/ai/ai-copilot/ai-copilot-tool/src/main/java/com/bytechef/ai/copilot/tool/CreateConnectionToolCallback.java
@@ -106,16 +106,33 @@ public class CreateConnectionToolCallback implements ToolCallback {
             Optional<ComponentDefinition> componentDefinition = componentDefinitionService.fetchComponentDefinition(
                 componentName, null);
 
+            String resolvedFromComponentName = null;
+
             if (componentDefinition.isEmpty()) {
-                return toolError(
-                    ComponentSlugUtils.unknownComponentMessage(componentName, componentDefinitionService));
+                String resolvedComponentName = ComponentSlugUtils.resolveSingleMatch(
+                    componentName, componentDefinitionService);
+
+                if (resolvedComponentName == null) {
+                    return toolError(ComponentSlugUtils.unknownComponentMessage(componentName,
+                        componentDefinitionService));
+                }
+
+                resolvedFromComponentName = componentName;
+                componentName = resolvedComponentName;
+                componentDefinition = componentDefinitionService.fetchComponentDefinition(componentName, null);
+
+                if (componentDefinition.isEmpty()) {
+                    return toolError(
+                        ComponentSlugUtils.unknownComponentMessage(componentName, componentDefinitionService));
+                }
             }
 
             String componentLabel = resolveComponentLabel(componentDefinition.get(), componentName);
 
             return JsonUtils.write(
                 new CreateConnectionOutput(
-                    "create-connection", componentName, componentLabel, input.suggestedName()));
+                    "create-connection", componentName, componentLabel, resolvedFromComponentName,
+                    input.suggestedName()));
         } catch (JacksonException exception) {
             log.warn(
                 "createConnection rejected malformed tool input: {} — first 200 chars of input: {}",
@@ -143,7 +160,7 @@ public class CreateConnectionToolCallback implements ToolCallback {
     }
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    public record CreateConnectionOutput(
-        String kind, String componentName, String componentLabel, @Nullable String suggestedName) {
+    public record CreateConnectionOutput(String kind, String componentName, String componentLabel,
+        @Nullable String resolvedFromComponentName, @Nullable String suggestedName) {
     }
 }

--- a/server/libs/ai/ai-copilot/ai-copilot-tool/src/main/java/com/bytechef/ai/copilot/tool/SkillsAgentToolCallback.java
+++ b/server/libs/ai/ai-copilot/ai-copilot-tool/src/main/java/com/bytechef/ai/copilot/tool/SkillsAgentToolCallback.java
@@ -16,7 +16,7 @@
 
 package com.bytechef.ai.copilot.tool;
 
-import com.bytechef.ai.agent.tool.Agent;
+import com.bytechef.ai.agent.tool.AgentType;
 import com.bytechef.ai.agent.tool.CurrentAgentContext;
 import com.bytechef.ai.agent.tool.CurrentAgentContext.AgentBinding;
 import com.bytechef.ai.agent.tool.ToolErrors;
@@ -95,12 +95,12 @@ public class SkillsAgentToolCallback implements ToolCallback {
             }
 
             AgentBinding parent = CurrentAgentContext.current();
-            Agent parentAgent = parent != null ? parent.agentName() : null;
+            AgentType parentAgent = parent != null ? parent.agentName() : null;
 
             Map<String, Object> forwardedContext = toolContext == null ? Map.of() : toolContext.getContext();
 
             String result = CurrentAgentContext.callWith(
-                Agent.SKILLS, parentAgent,
+                CopilotAgentType.SKILLS, parentAgent,
                 () -> skillsChatClient.prompt(request)
                     .toolContext(forwardedContext)
                     .call()

--- a/server/libs/ai/ai-copilot/ai-copilot-tool/src/main/java/com/bytechef/ai/copilot/tool/WorkflowEditorAgentToolCallback.java
+++ b/server/libs/ai/ai-copilot/ai-copilot-tool/src/main/java/com/bytechef/ai/copilot/tool/WorkflowEditorAgentToolCallback.java
@@ -16,7 +16,7 @@
 
 package com.bytechef.ai.copilot.tool;
 
-import com.bytechef.ai.agent.tool.Agent;
+import com.bytechef.ai.agent.tool.AgentType;
 import com.bytechef.ai.agent.tool.CurrentAgentContext;
 import com.bytechef.ai.agent.tool.CurrentAgentContext.AgentBinding;
 import com.bytechef.ai.agent.tool.ToolErrors;
@@ -96,12 +96,12 @@ public class WorkflowEditorAgentToolCallback implements ToolCallback {
             }
 
             AgentBinding parent = CurrentAgentContext.current();
-            Agent parentAgent = parent != null ? parent.agentName() : null;
+            AgentType parentAgent = parent != null ? parent.agentName() : null;
 
             Map<String, Object> forwardedContext = toolContext == null ? Map.of() : toolContext.getContext();
 
             String result = CurrentAgentContext.callWith(
-                Agent.WORKFLOW_EDITOR_AGENT, parentAgent,
+                CopilotAgentType.WORKFLOW_EDITOR_AGENT, parentAgent,
                 () -> workflowEditorChatClient.prompt(request)
                     .toolContext(forwardedContext)
                     .call()

--- a/server/libs/ai/ai-copilot/ai-copilot-tool/src/test/java/com/bytechef/ai/copilot/tool/CreateConnectionToolCallbackTest.java
+++ b/server/libs/ai/ai-copilot/ai-copilot-tool/src/test/java/com/bytechef/ai/copilot/tool/CreateConnectionToolCallbackTest.java
@@ -81,17 +81,22 @@ class CreateConnectionToolCallbackTest {
     }
 
     @Test
-    void testCallUnknownComponentReturnsErrorWithSuggestions() throws Exception {
+    void testCallAmbiguousComponentReturnsErrorWithSuggestions() throws Exception {
         ComponentDefinition googleMail = mock(ComponentDefinition.class);
+        ComponentDefinition googleDrive = mock(ComponentDefinition.class);
 
         when(googleMail.getName()).thenReturn("googleMail");
         when(googleMail.getTitle()).thenReturn("Gmail");
+        when(googleDrive.getName()).thenReturn("googleDrive");
+        when(googleDrive.getTitle()).thenReturn("Google Drive");
 
-        when(componentDefinitionService.fetchComponentDefinition(eq("gmail"), any()))
+        // "google" matches two components, so there is no single unambiguous slug to auto-resolve to — fail loud with
+        // candidates rather than opening the wrong Connect dialog.
+        when(componentDefinitionService.fetchComponentDefinition(eq("google"), any()))
             .thenReturn(Optional.empty());
-        when(componentDefinitionService.getComponentDefinitions()).thenReturn(List.of(googleMail));
+        when(componentDefinitionService.getComponentDefinitions()).thenReturn(List.of(googleMail, googleDrive));
 
-        String result = callback.call("{\"componentName\":\"gmail\"}");
+        String result = callback.call("{\"componentName\":\"google\"}");
 
         JsonNode node = jsonMapper.readTree(result);
 
@@ -101,8 +106,48 @@ class CreateConnectionToolCallbackTest {
         String error = node.get("error")
             .asText();
 
-        assertThat(error).contains("gmail");
+        assertThat(error).contains("google");
         assertThat(error).contains("googleMail (Gmail)");
+        assertThat(error).contains("googleDrive (Google Drive)");
+    }
+
+    @Test
+    void testCallAutoResolvesSingleFuzzyMatch() throws Exception {
+        assertAutoResolves("gmail");
+    }
+
+    @Test
+    void testCallAutoResolvesHyphenatedName() throws Exception {
+        // "google-mail" used to match nothing (the hyphen broke the substring match); normalized matching now resolves
+        // it to the single googleMail slug instead of forcing the agent to retry.
+        assertAutoResolves("google-mail");
+    }
+
+    private void assertAutoResolves(String requestedComponentName) throws Exception {
+        ComponentDefinition googleMail = mock(ComponentDefinition.class);
+
+        when(googleMail.getName()).thenReturn("googleMail");
+        when(googleMail.getTitle()).thenReturn("Gmail");
+
+        when(componentDefinitionService.fetchComponentDefinition(eq(requestedComponentName), any()))
+            .thenReturn(Optional.empty());
+        when(componentDefinitionService.getComponentDefinitions()).thenReturn(List.of(googleMail));
+        when(componentDefinitionService.fetchComponentDefinition(eq("googleMail"), any()))
+            .thenReturn(Optional.of(googleMail));
+
+        String result = callback.call("{\"componentName\":\"" + requestedComponentName + "\"}");
+
+        JsonNode node = jsonMapper.readTree(result);
+
+        assertThat(node.has("error")).isFalse();
+        assertThat(node.get("kind")
+            .asText()).isEqualTo("create-connection");
+        assertThat(node.get("componentName")
+            .asText()).isEqualTo("googleMail");
+        assertThat(node.get("componentLabel")
+            .asText()).isEqualTo("Gmail");
+        assertThat(node.get("resolvedFromComponentName")
+            .asText()).isEqualTo(requestedComponentName);
     }
 
     @Test


### PR DESCRIPTION
- **Wire AI provider catalog GraphQL module**
- **5338 Remove AI provider catalog GraphQL from AI gateway**
- **5338 Add AI provider catalog GraphQL to platform-configuration**
- **5338 client - Align Copilot composer bottom with left workflow editor**
- **5338 Authorize Copilot workflow access on the request thread**
- **5338 client - Fix Switch checked thumb alignment for symmetric borders**
- **5352 Disable fromAi expression for skillsTool skillId property**
- **5338 Resolve copilot RAG embedding environment from request state**
- **5338 client - Increase composer action gap so send button clears the mode toggle**
- **5338 Resolve copilot chat model provider from the request environment**
- **1345 Add text and image capability flags to AI providers**
- **1345 Generate**
- **1345 client - Show text/image/embeddings capability badges for AI providers**
- **1345 client - Regenerate AI provider middleware model with capability flags**
- **5338 Remove copilot RAG environment diagnostic log**
- **5338 client - Send last-used copilot model when the store selection is empty**
- **5338 Use OpenAI SDK wire values for chat model ids**
- **5338 Regenerate OpenAI component definition with corrected chat model ids**
- **5338 client - Show a no-enabled-providers empty state in the Copilot panel**
- **5352 client - Gate tools cluster Dynamic toggle on expressionEnabled**
- **5352 client - Preserve array item expressionEnabled on hydration**
- **5338 Route Skills and Converter copilot agents through the environment chat resolver**
- **5338 client - Add model picker to the Create Skill with AI composer**
- **5338 Extract CopilotSpringAIAgent base to share the override chat-client resolution**
- **5338 Mark the Copilot docs embedding provider on AI providers**
- **5338 Generate**
- **5338 client - Show a Copilot Docs badge on the AI provider**
- **5338 client - Generate**
- **5338 client - Move Create Skill with AI chat scrollbar to panel edge**
- **5338 Support Azure OpenAI in the chat catalog via a stored endpoint**
- **5352 client - Re-sync array item values from saved parameters after save**
- **5338 client - Add Azure OpenAI endpoint input to the AI provider form**
- **client - Delay cluster canvas mount until dialog settles to fix edge reopen snap**
- **1570 Move ai copilot to CE**
- **5343 client - Adjust item alignments**
- **1570 Add Mistral as an embedding provider**
- **5338 Reorganize**
- **5338 Drop redundant ChatModel qualifier in resolveChatModel return type**
- **5338 Suppress FileLength for ApplicationProperties**
- **4545 SF**
- **5338 Drive AI provider form field requirements from server flags**
- **5338 Generate**
- **5338 client - Generate**
- **5338 client - Drive AI provider form field requirements from server flags**
- **5338 Do not drop the exception from the warning log**
- **1570 Document AI provider catalog environment variables**
- **1570 Generate copilot documentation into build/ instead of tracked resources**
- **1570 Honor BYTECHEF_AI_COPILOT_PROVIDER as the EE Copilot default provider**
- ** 1570 Auto-resolve a single fuzzy component match in createConnection**
- **1051 Add EE permission scope and role constants**
- **1051 Add EE PermissionService with scope registry and tenant-scoped cache**
- **1570 Replace Agent enum with contributed AgentType registry**
- **5343 client - Standardize list and list item styling across embedded and automation pages**
- **1570 Remove stale @PreAuthorize from getAiDefaultEmbeddingModelApiKey**
