### PR TITLE
1570 Add default AI models for all providers and resolve them per request

### DIFF
--- a/docs/content/docs/self-hosting/configuration/environment-variables.md
+++ b/docs/content/docs/self-hosting/configuration/environment-variables.md
@@ -10,7 +10,7 @@ ByteChef can be configured using environment variables. This page documents all 
 | Environment Variable | Description | Default Value |
 |---|---|---|
 | `BYTECHEF_AI_COPILOT_ENABLED` | Enable or disable the AI copilot feature | `false` |
-| `BYTECHEF_AI_COPILOT_PROVIDER` | Chat-model provider key (e.g. `anthropic`, `openAi`) to prefer for Copilot. In CE it overrides auto-detection from the configured provider API keys/endpoints. In EE it is used as the environment default provider when set, provided that provider is enabled and has a configured chat model (`BYTECHEF_AI_PROVIDER_CHAT_<PROVIDER>_OPTIONS_MODEL`); otherwise Copilot falls back to the first enabled chat provider. A per-turn model picked in the Copilot toolbar always overrides this. | - |
+| `BYTECHEF_AI_COPILOT_PROVIDER` | Chat-model provider to prefer for Copilot — accepts the short provider name (e.g. `anthropic`, `openAi`) or the full catalog key (e.g. `ai.provider.anthropic`), case-insensitively; unrecognized values fall back to auto-detection. In CE it overrides auto-detection from the configured provider API keys/endpoints. In EE it is used as the environment default provider when set, provided that provider is enabled and has a configured chat model (`BYTECHEF_AI_PROVIDER_CHAT_<PROVIDER>_OPTIONS_MODEL`); otherwise Copilot falls back to the first enabled chat provider. A per-turn model picked in the Copilot toolbar always overrides this. | - |
 | `BYTECHEF_AI_COPILOT_DOCS_EMBEDDING_PROVIDER` | Embedding provider for the Copilot documentation index (OLLAMA, OPENAI) | - |
 | `BYTECHEF_AI_COPILOT_DOCS_EMBEDDING_APIKEY` | API key for the Copilot documentation embedding provider — OpenAI only; Ollama runs locally and needs none (sensitive) | - |
 
@@ -74,25 +74,31 @@ ByteChef can be configured using environment variables. This page documents all 
 | `BYTECHEF_AI_PROVIDER_CHAT_ANTHROPIC_OPTIONS_MODEL` | Anthropic chat model name | `claude-sonnet-4-6` |
 | `BYTECHEF_AI_PROVIDER_CHAT_ANTHROPIC_OPTIONS_TEMPERATURE` | Anthropic chat temperature (0.0-1.0) | `0.5` |
 | `BYTECHEF_AI_PROVIDER_CHAT_AZURE_OPENAI_OPTIONS_MODEL` | Azure OpenAI chat model name (e.g., `gpt-4o`) | - |
-| `BYTECHEF_AI_PROVIDER_CHAT_DEEP_SEEK_OPTIONS_MODEL` | DeepSeek chat model name (e.g., `deepseek-chat`) | - |
-| `BYTECHEF_AI_PROVIDER_CHAT_GROQ_OPTIONS_MODEL` | Groq chat model name (e.g., `llama-3.3-70b-versatile`) | - |
-| `BYTECHEF_AI_PROVIDER_CHAT_MISTRAL_OPTIONS_MODEL` | Mistral chat model name (e.g., `mistral-large-latest`) | - |
-| `BYTECHEF_AI_PROVIDER_CHAT_NVIDIA_OPTIONS_MODEL` | NVIDIA chat model name (e.g., `meta/llama-3.1-70b-instruct`) | - |
-| `BYTECHEF_AI_PROVIDER_CHAT_OLLAMA_OPTIONS_MODEL` | Ollama chat model name (e.g., `llama3.1`) | - |
+| `BYTECHEF_AI_PROVIDER_CHAT_DEEP_SEEK_OPTIONS_MODEL` | DeepSeek chat model name | `deepseek-chat` |
+| `BYTECHEF_AI_PROVIDER_CHAT_GROQ_OPTIONS_MODEL` | Groq chat model name | `llama-3.3-70b-versatile` |
+| `BYTECHEF_AI_PROVIDER_CHAT_MISTRAL_OPTIONS_MODEL` | Mistral chat model name | `mistral-large-latest` |
+| `BYTECHEF_AI_PROVIDER_CHAT_NVIDIA_OPTIONS_MODEL` | NVIDIA chat model name | `meta/llama-3.1-70b-instruct` |
+| `BYTECHEF_AI_PROVIDER_CHAT_OLLAMA_OPTIONS_MODEL` | Ollama chat model name (e.g., `deepseek-r1:8b`) — no default; the model must be pulled on your Ollama instance | - |
 | `BYTECHEF_AI_PROVIDER_CHAT_OPENAI_OPTIONS_MODEL` | OpenAI chat model name | `gpt-5.1` |
 | `BYTECHEF_AI_PROVIDER_CHAT_OPENAI_OPTIONS_TEMPERATURE` | OpenAI chat temperature (0.0-2.0) | `1` |
 | `BYTECHEF_AI_PROVIDER_CHAT_OPENAI_OPTIONS_REASONINGEFFECT` | OpenAI reasoning effect (NONE, LOW, MEDIUM, HIGH) | `MEDIUM` |
 | `BYTECHEF_AI_PROVIDER_CHAT_OPENAI_OPTIONS_VERBOSITY` | OpenAI response verbosity (NONE, LOW, MEDIUM, HIGH) | `LOW` |
-| `BYTECHEF_AI_PROVIDER_CHAT_PERPLEXITY_OPTIONS_MODEL` | Perplexity chat model name (e.g., `sonar`) | - |
-| `BYTECHEF_AI_PROVIDER_CHAT_VERTEX_GEMINI_OPTIONS_MODEL` | Vertex Gemini chat model name (e.g., `gemini-1.5-pro`) | - |
+| `BYTECHEF_AI_PROVIDER_CHAT_PERPLEXITY_OPTIONS_MODEL` | Perplexity chat model name | `sonar` |
+| `BYTECHEF_AI_PROVIDER_CHAT_VERTEX_GEMINI_OPTIONS_MODEL` | Vertex Gemini chat model name | `gemini-2.5-pro` |
 
 ## AI Embedding Model Configuration
 
 | Environment Variable | Description | Default Value |
 |---|---|---|
-| `BYTECHEF_AI_PROVIDER_EMBEDDING_MISTRAL_OPTIONS_MODEL` | Mistral embedding model name (e.g., `mistral-embed`) | - |
-| `BYTECHEF_AI_PROVIDER_EMBEDDING_OLLAMA_OPTIONS_MODEL` | Ollama embedding model name | `qwen3-embedding:8b` |
+| `BYTECHEF_AI_PROVIDER_EMBEDDING_MISTRAL_OPTIONS_MODEL` | Mistral embedding model name | `mistral-embed` |
+| `BYTECHEF_AI_PROVIDER_EMBEDDING_OLLAMA_OPTIONS_MODEL` | Ollama embedding model name (e.g., `qwen3-embedding:8b`) — no default; the model must be pulled on your Ollama instance | - |
 | `BYTECHEF_AI_PROVIDER_EMBEDDING_OPENAI_OPTIONS_MODEL` | OpenAI embedding model name | `text-embedding-3-small` |
+
+## AI Image Model Configuration
+
+| Environment Variable | Description | Default Value |
+|---|---|---|
+| `BYTECHEF_AI_PROVIDER_IMAGE_OPENAI_OPTIONS_MODEL` | OpenAI image model name | `dall-e-3` |
 
 ## AI Vectorstore Configuration
 

--- a/server/apps/server-app/src/main/resources/config/application-bytechef.yml
+++ b/server/apps/server-app/src/main/resources/config/application-bytechef.yml
@@ -16,19 +16,41 @@ bytechef:
           options:
             model: claude-sonnet-4-6
             temperature: 0.5
+        deep-seek:
+          options:
+            model: deepseek-chat
+        groq:
+          options:
+            model: llama-3.3-70b-versatile
+        mistral:
+          options:
+            model: mistral-large-latest
+        nvidia:
+          options:
+            model: meta/llama-3.1-70b-instruct
         openai:
           options:
             model: gpt-5.1
             temperature: 1
             reasoning-effect: medium
             verbosity: low
-      embedding:
-        ollama:
+        perplexity:
           options:
-            model: qwen3-embedding:8b
+            model: sonar
+        vertex-gemini:
+          options:
+            model: gemini-2.5-pro
+      embedding:
+        mistral:
+          options:
+            model: mistral-embed
         openai:
           options:
             model: text-embedding-3-small
+      image:
+        openai:
+          options:
+            model: dall-e-3
     vectorstore:
       provider: pgvector
   analytics:

--- a/server/ee/libs/ai/ai-copilot/ai-copilot-service/src/main/java/com/bytechef/ee/ai/copilot/agent/CopilotChatClientResolver.java
+++ b/server/ee/libs/ai/ai-copilot/ai-copilot-service/src/main/java/com/bytechef/ee/ai/copilot/agent/CopilotChatClientResolver.java
@@ -26,6 +26,7 @@ import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
@@ -98,6 +99,11 @@ public class CopilotChatClientResolver implements OverrideChatClientResolver {
         }
 
         return catalogChatClientResolver.resolveDefault(environmentId.intValue());
+    }
+
+    @Override
+    public @Nullable ChatModel resolveDefaultChatModel(int environmentId) {
+        return catalogChatClientResolver.resolveDefaultChatModel(defaultProvider, environmentId);
     }
 
     // ---------------------------------------------------------------------------------------------------------------

--- a/server/ee/libs/platform/platform-ai/platform-ai-agent/platform-ai-agent-api/src/main/java/com/bytechef/ee/platform/ai/agent/catalog/CatalogChatClientResolver.java
+++ b/server/ee/libs/platform/platform-ai/platform-ai-agent/platform-ai-agent-api/src/main/java/com/bytechef/ee/platform/ai/agent/catalog/CatalogChatClientResolver.java
@@ -9,6 +9,7 @@ package com.bytechef.ee.platform.ai.agent.catalog;
 
 import org.jspecify.annotations.Nullable;
 import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.model.ChatModel;
 
 /**
  * Resolves an override {@link ChatClient} from the platform AI provider catalog: given a catalog provider key (e.g.
@@ -55,4 +56,17 @@ public interface CatalogChatClientResolver {
      */
     @Nullable
     ChatClient resolvePreferred(String providerKey, int environment);
+
+    /**
+     * Resolves the environment-default {@link ChatModel} (same provider/model selection as
+     * {@link #resolveDefault(int)}, optionally preferring a specific provider first) without wrapping it in a
+     * {@link ChatClient}, so callers can attach their own system prompt and tools.
+     *
+     * @param preferredProviderKey the catalog provider key to prefer, or {@code null}/blank to use the environment
+     *                             default
+     * @param environment          the environment ordinal
+     * @return the resolved {@link ChatModel}, or {@code null} when nothing is resolvable
+     */
+    @Nullable
+    ChatModel resolveDefaultChatModel(@Nullable String preferredProviderKey, int environment);
 }

--- a/server/ee/libs/platform/platform-ai/platform-ai-agent/platform-ai-agent-service/src/main/java/com/bytechef/ee/platform/ai/agent/catalog/CatalogChatClientResolverImpl.java
+++ b/server/ee/libs/platform/platform-ai/platform-ai-agent/platform-ai-agent-service/src/main/java/com/bytechef/ee/platform/ai/agent/catalog/CatalogChatClientResolverImpl.java
@@ -47,6 +47,43 @@ public class CatalogChatClientResolverImpl implements CatalogChatClientResolver 
             return null;
         }
 
+        ChatModel chatModel = resolveChatModel(providerKey, model, environment);
+
+        if (chatModel == null) {
+            return null;
+        }
+
+        return ChatClient.builder(chatModel)
+            .defaultOptions(
+                ChatOptions.builder()
+                    .model(model))
+            .build();
+    }
+
+    @Override
+    public @Nullable ChatModel resolveDefaultChatModel(@Nullable String preferredProviderKey, int environment) {
+        if (environment < 0 || environment >= Environment.values().length) {
+            return null;
+        }
+
+        AiDefaultModelDTO defaultModel = null;
+
+        if (preferredProviderKey != null && !preferredProviderKey.isBlank()) {
+            defaultModel = aiProviderFacade.getAiDefaultChatModel(preferredProviderKey, environment);
+        }
+
+        if (defaultModel == null) {
+            defaultModel = aiProviderFacade.getAiDefaultChatModel(environment);
+        }
+
+        if (defaultModel == null) {
+            return null;
+        }
+
+        return resolveChatModel(defaultModel.provider(), defaultModel.model(), environment);
+    }
+
+    private @Nullable ChatModel resolveChatModel(String providerKey, String model, int environment) {
         Provider provider = Arrays.stream(Provider.values())
             .filter(curProvider -> Objects.equals(curProvider.getKey(), providerKey))
             .findFirst()
@@ -64,17 +101,7 @@ public class CatalogChatClientResolverImpl implements CatalogChatClientResolver 
 
         String url = aiProviderFacade.getUrl(provider.getKey(), environment);
 
-        ChatModel chatModel = catalogChatModelFactory.createChatModel(provider, model, apiKey, url);
-
-        if (chatModel == null) {
-            return null;
-        }
-
-        return ChatClient.builder(chatModel)
-            .defaultOptions(
-                ChatOptions.builder()
-                    .model(model))
-            .build();
+        return catalogChatModelFactory.createChatModel(provider, model, apiKey, url);
     }
 
     @Override

--- a/server/ee/libs/platform/platform-configuration/platform-configuration-service/src/main/java/com/bytechef/ee/platform/configuration/facade/AiProviderFacadeImpl.java
+++ b/server/ee/libs/platform/platform-configuration/platform-configuration-service/src/main/java/com/bytechef/ee/platform/configuration/facade/AiProviderFacadeImpl.java
@@ -117,12 +117,14 @@ public class AiProviderFacadeImpl implements AiProviderFacade {
     @Override
     @Transactional(readOnly = true)
     public AiDefaultModelDTO getAiDefaultChatModel(String providerKey, int environmentId) {
+        Provider preferredProvider = Provider.fetchByNameOrKey(providerKey);
+
         return getAiProviders(environmentId)
             .stream()
             .filter(AiProviderDTO::enabled)
             .map(aiProviderDTO -> getProvider(aiProviderDTO.id()))
             .filter(Provider.CHAT_PROVIDERS::contains)
-            .filter(provider -> providerKey == null || Objects.equals(provider.getKey(), providerKey))
+            .filter(provider -> providerKey == null || provider == preferredProvider)
             .map(provider -> {
                 String model = resolveDefaultChatModel(provider);
 

--- a/server/ee/libs/platform/platform-configuration/platform-configuration-service/src/test/java/com/bytechef/ee/platform/configuration/facade/AiProviderFacadeDefaultModelTest.java
+++ b/server/ee/libs/platform/platform-configuration/platform-configuration-service/src/test/java/com/bytechef/ee/platform/configuration/facade/AiProviderFacadeDefaultModelTest.java
@@ -59,6 +59,28 @@ class AiProviderFacadeDefaultModelTest {
     }
 
     @Test
+    void testResolvesPreferredProviderByShortName() {
+        stubProviderComponentsWithNoStoredProperties();
+
+        when(applicationProperties.getAi()
+            .getProvider()
+            .getAnthropic()
+            .getApiKey()).thenReturn("sk-anthropic");
+        when(applicationProperties.getAi()
+            .getProvider()
+            .getChat()
+            .getAnthropic()
+            .getOptions()
+            .getModel()).thenReturn("claude-sonnet-4-6");
+
+        AiDefaultModelDTO result = facade.getAiDefaultChatModel("anthropic", ENVIRONMENT);
+
+        assertThat(result).isNotNull();
+        assertThat(result.provider()).isEqualTo("ai.provider.anthropic");
+        assertThat(result.model()).isEqualTo("claude-sonnet-4-6");
+    }
+
+    @Test
     void testReturnsAnthropicWhenAnthropicApiKeyConfigured() {
         stubProviderComponentsWithNoStoredProperties();
 

--- a/server/libs/ai/ai-copilot/ai-copilot-api/src/main/java/com/bytechef/ai/copilot/agent/OverrideChatClientResolver.java
+++ b/server/libs/ai/ai-copilot/ai-copilot-api/src/main/java/com/bytechef/ai/copilot/agent/OverrideChatClientResolver.java
@@ -19,6 +19,7 @@ package com.bytechef.ai.copilot.agent;
 import com.agui.core.state.State;
 import org.jspecify.annotations.Nullable;
 import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.model.ChatModel;
 
 /**
  * Per-request resolver of an override {@link ChatClient} for Copilot agents. Used to swap the LLM at runtime when the
@@ -27,9 +28,17 @@ import org.springframework.ai.chat.client.ChatClient;
  *
  * @author Ivica Cardic
  */
-@FunctionalInterface
 public interface OverrideChatClientResolver {
 
     @Nullable
     ChatClient resolve(State state);
+
+    /**
+     * Resolves the environment-default {@link ChatModel} from the runtime provider catalog, honoring per-provider model
+     * overrides. Returns {@code null} when no catalog is active (CE) or nothing is resolvable — callers fall back to
+     * their startup-configured model.
+     */
+    default @Nullable ChatModel resolveDefaultChatModel(int environmentId) {
+        return null;
+    }
 }

--- a/server/libs/ai/ai-copilot/ai-copilot-service/src/main/java/com/bytechef/ai/copilot/config/CopilotConfiguration.java
+++ b/server/libs/ai/ai-copilot/ai-copilot-service/src/main/java/com/bytechef/ai/copilot/config/CopilotConfiguration.java
@@ -65,6 +65,8 @@ import com.bytechef.platform.component.service.ComponentDefinitionService;
 import com.bytechef.platform.component.service.ConnectionDefinitionService;
 import com.bytechef.platform.component.service.TriggerDefinitionService;
 import com.bytechef.platform.configuration.ai.EmbeddingProviderStatusProvider;
+import com.bytechef.platform.configuration.context.EnvironmentContext;
+import com.bytechef.platform.configuration.domain.Environment;
 import com.bytechef.platform.configuration.facade.WorkflowNodeOutputFacade;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
@@ -73,6 +75,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Supplier;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.client.advisor.api.Advisor;
 import org.springframework.ai.chat.memory.ChatMemory;
@@ -81,6 +84,7 @@ import org.springframework.ai.support.ToolCallbacks;
 import org.springframework.ai.tool.ToolCallback;
 import org.springframework.ai.vectorstore.VectorStore;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
@@ -543,6 +547,47 @@ public class CopilotConfiguration {
                 projectTools, projectWorkflowTools, taskTools, scriptTools, workflowValidatorTools,
                 workflowInstructionTools)
             .build();
+    }
+
+    /**
+     * Per-request converter subagent {@link ChatClient} supplier: when an EE {@link OverrideChatClientResolver} can
+     * resolve the environment-default {@link ChatModel} from the AI provider catalog (honoring per-provider model
+     * overrides), the client is rebuilt around it with the converter system prompt and tools; otherwise the
+     * startup-configured bean is returned.
+     */
+    @Bean
+    Supplier<ChatClient> converterBuildSubAgentChatClientSupplier(
+        @Qualifier("converterBuildSubAgentChatClient") ChatClient converterChatClient, ProjectTools projectTools,
+        ProjectWorkflowTools projectWorkflowTools, TaskTools taskTools, ScriptTools scriptTools,
+        ObjectProvider<OverrideChatClientResolver> overrideChatClientResolverProvider) {
+
+        return () -> {
+            OverrideChatClientResolver overrideChatClientResolver =
+                overrideChatClientResolverProvider.getIfAvailable();
+
+            if (overrideChatClientResolver == null) {
+                return converterChatClient;
+            }
+
+            Environment environment = EnvironmentContext.fetchCurrentEnvironment();
+
+            if (environment == null) {
+                return converterChatClient;
+            }
+
+            ChatModel resolvedChatModel = overrideChatClientResolver.resolveDefaultChatModel(environment.ordinal());
+
+            if (resolvedChatModel == null) {
+                return converterChatClient;
+            }
+
+            return ChatClient.builder(resolvedChatModel)
+                .defaultSystem(getSystemPrompt(promptConverterBuildResource))
+                .defaultTools(
+                    projectTools, projectWorkflowTools, taskTools, scriptTools, workflowValidatorTools,
+                    workflowInstructionTools)
+                .build();
+        };
     }
 
     @Bean

--- a/server/libs/ai/ai-copilot/ai-copilot-service/src/main/java/com/bytechef/ai/copilot/config/ToolCallbackContributorConfiguration.java
+++ b/server/libs/ai/ai-copilot/ai-copilot-service/src/main/java/com/bytechef/ai/copilot/config/ToolCallbackContributorConfiguration.java
@@ -25,6 +25,7 @@ import com.bytechef.ai.mcp.server.spi.McpServerToolCallbackContributor;
 import com.bytechef.automation.ai.tool.SkillsTools;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Supplier;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.support.ToolCallbacks;
 import org.springframework.ai.tool.ToolCallback;
@@ -46,7 +47,8 @@ class ToolCallbackContributorConfiguration {
         @Qualifier("codeEditorBuildSubAgentChatClient") ObjectProvider<ChatClient> codeEditorProvider,
         @Qualifier("clusterElementBuildSubAgentChatClient") ObjectProvider<ChatClient> clusterElementProvider,
         @Qualifier("skillsBuildSubAgentChatClient") ObjectProvider<ChatClient> skillsProvider,
-        @Qualifier("converterBuildSubAgentChatClient") ObjectProvider<ChatClient> converterProvider) {
+        @Qualifier("converterBuildSubAgentChatClientSupplier") //
+        ObjectProvider<Supplier<ChatClient>> converterSupplierProvider) {
 
         return () -> {
             List<ToolCallback> toolCallbacks = new ArrayList<>();
@@ -62,8 +64,9 @@ class ToolCallbackContributorConfiguration {
                 chatClient -> toolCallbacks.add(new ClusterElementAgentToolCallback(chatClient)));
             skillsProvider.ifAvailable(
                 chatClient -> toolCallbacks.add(new SkillsAgentToolCallback(chatClient)));
-            converterProvider.ifAvailable(
-                chatClient -> toolCallbacks.add(new ConverterAgentToolCallback(chatClient)));
+            converterSupplierProvider.ifAvailable(
+                converterChatClientSupplier -> toolCallbacks.add(
+                    new ConverterAgentToolCallback(converterChatClientSupplier)));
 
             return toolCallbacks;
         };

--- a/server/libs/ai/ai-copilot/ai-copilot-service/src/test/java/com/bytechef/ai/copilot/config/McpServerToolCallbackContributorConfigurationTest.java
+++ b/server/libs/ai/ai-copilot/ai-copilot-service/src/test/java/com/bytechef/ai/copilot/config/McpServerToolCallbackContributorConfigurationTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.mock;
 
 import com.bytechef.ai.mcp.server.spi.McpServerToolCallbackContributor;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 import org.junit.jupiter.api.Test;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.beans.factory.ObjectProvider;
@@ -37,9 +38,14 @@ class McpServerToolCallbackContributorConfigurationTest {
 
     @Test
     void contributesAgentCallbacksWhenChatClientsPresent() {
+        ChatClient converterChatClient = mock(ChatClient.class);
+
+        Supplier<ChatClient> converterChatClientSupplier = () -> converterChatClient;
+
         McpServerToolCallbackContributor contributor = configuration.copilotAgentToolCallbackContributor(
             emptyProvider(), present(mock(ChatClient.class)), present(mock(ChatClient.class)),
-            present(mock(ChatClient.class)), present(mock(ChatClient.class)), present(mock(ChatClient.class)));
+            present(mock(ChatClient.class)), present(mock(ChatClient.class)),
+            present(converterChatClientSupplier));
 
         assertThat(contributor.getToolCallbacks()).hasSize(5);
     }

--- a/server/libs/ai/ai-copilot/ai-copilot-tool/src/main/java/com/bytechef/ai/copilot/tool/ConverterAgentToolCallback.java
+++ b/server/libs/ai/ai-copilot/ai-copilot-tool/src/main/java/com/bytechef/ai/copilot/tool/ConverterAgentToolCallback.java
@@ -23,6 +23,7 @@ import com.bytechef.ai.agent.tool.ToolErrors;
 import com.bytechef.commons.util.JsonUtils;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Map;
+import java.util.function.Supplier;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,11 +63,16 @@ public class ConverterAgentToolCallback implements ToolCallback {
                 "required": ["request"]
             }""";
 
-    private final ChatClient converterChatClient;
+    private final Supplier<ChatClient> converterChatClientSupplier;
 
     @SuppressFBWarnings("EI_EXPOSE_REP2")
     public ConverterAgentToolCallback(ChatClient converterChatClient) {
-        this.converterChatClient = converterChatClient;
+        this(() -> converterChatClient);
+    }
+
+    @SuppressFBWarnings("EI_EXPOSE_REP2")
+    public ConverterAgentToolCallback(Supplier<ChatClient> converterChatClientSupplier) {
+        this.converterChatClientSupplier = converterChatClientSupplier;
     }
 
     @Override
@@ -98,6 +104,8 @@ public class ConverterAgentToolCallback implements ToolCallback {
             AgentType parentAgent = parent != null ? parent.agentName() : null;
 
             Map<String, Object> forwardedContext = toolContext == null ? Map.of() : toolContext.getContext();
+
+            ChatClient converterChatClient = converterChatClientSupplier.get();
 
             String result = CurrentAgentContext.callWith(
                 CopilotAgentType.CONVERTER_AGENT, parentAgent,

--- a/server/libs/ai/ai-copilot/ai-copilot-tool/src/test/java/com/bytechef/ai/copilot/tool/ConverterAgentToolCallbackTest.java
+++ b/server/libs/ai/ai-copilot/ai-copilot-tool/src/test/java/com/bytechef/ai/copilot/tool/ConverterAgentToolCallbackTest.java
@@ -27,6 +27,7 @@ import com.bytechef.test.extension.ObjectMapperSetupExtension;
 import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -174,6 +175,33 @@ class ConverterAgentToolCallbackTest {
         callback.call("{\"request\":\"any\"}", null);
 
         verify(requestSpec).toolContext(Map.of());
+    }
+
+    @Test
+    void testCallResolvesChatClientFromSupplierPerCall() {
+        ChatClient chatClient = mock(ChatClient.class);
+        ChatClientRequestSpec requestSpec = mock(ChatClientRequestSpec.class);
+        CallResponseSpec responseSpec = mock(CallResponseSpec.class);
+
+        when(chatClient.prompt(anyString())).thenReturn(requestSpec);
+        stubToolContext(requestSpec);
+        when(requestSpec.call()).thenReturn(responseSpec);
+        when(responseSpec.content()).thenReturn("converted");
+
+        AtomicInteger supplierCalls = new AtomicInteger();
+
+        ConverterAgentToolCallback callback = new ConverterAgentToolCallback(() -> {
+            supplierCalls.incrementAndGet();
+
+            return chatClient;
+        });
+
+        String firstResult = callback.call("{\"request\":\"convert this n8n workflow\"}");
+        String secondResult = callback.call("{\"request\":\"convert that make workflow\"}");
+
+        assertThat(firstResult).isEqualTo("converted");
+        assertThat(secondResult).isEqualTo("converted");
+        assertThat(supplierCalls.get()).isEqualTo(2);
     }
 
     @Test

--- a/server/libs/config/ai-model-config/src/main/java/com/bytechef/ai/model/config/AiModelConfiguration.java
+++ b/server/libs/config/ai-model-config/src/main/java/com/bytechef/ai/model/config/AiModelConfiguration.java
@@ -45,6 +45,8 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.HashMap;
 import java.util.Map;
 import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.embedding.EmbeddingModel;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -63,6 +65,8 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
 @Configuration
 @ConditionalOnCEVersion
 class AiModelConfiguration {
+
+    private static final Logger log = LoggerFactory.getLogger(AiModelConfiguration.class);
 
     private final ApplicationProperties applicationProperties;
     private final String openAiApiKey;
@@ -115,7 +119,15 @@ class AiModelConfiguration {
             .getProvider();
 
         if (explicitProviderKey != null && !explicitProviderKey.isBlank()) {
-            return Provider.valueOfKey(explicitProviderKey);
+            Provider explicitProvider = Provider.fetchByNameOrKey(explicitProviderKey);
+
+            if (explicitProvider != null) {
+                return explicitProvider;
+            }
+
+            log.warn(
+                "bytechef.ai.copilot.provider value '{}' matches no AI provider; falling back to auto-detection",
+                explicitProviderKey);
         }
 
         for (Provider provider : Provider.CHAT_PROVIDERS) {

--- a/server/libs/config/ai-model-config/src/test/java/com/bytechef/ai/model/config/AiModelConfigurationTest.java
+++ b/server/libs/config/ai-model-config/src/test/java/com/bytechef/ai/model/config/AiModelConfigurationTest.java
@@ -74,6 +74,40 @@ class AiModelConfigurationTest {
     }
 
     @Test
+    void acceptsShortProviderNameForCopilotOverride() {
+        ApplicationProperties applicationProperties = new ApplicationProperties();
+
+        applicationProperties.getAi()
+            .getProvider()
+            .getOpenAi()
+            .setApiKey("test-api-key");
+        applicationProperties.getAi()
+            .getCopilot()
+            .setProvider("anthropic");
+
+        AiModelConfiguration aiModelConfiguration = new AiModelConfiguration(applicationProperties);
+
+        assertThat(aiModelConfiguration.resolveProvider()).isEqualTo(Provider.ANTHROPIC);
+    }
+
+    @Test
+    void fallsBackToAutoDetectionForUnknownCopilotOverride() {
+        ApplicationProperties applicationProperties = new ApplicationProperties();
+
+        applicationProperties.getAi()
+            .getProvider()
+            .getOpenAi()
+            .setApiKey("test-api-key");
+        applicationProperties.getAi()
+            .getCopilot()
+            .setProvider("does-not-exist");
+
+        AiModelConfiguration aiModelConfiguration = new AiModelConfiguration(applicationProperties);
+
+        assertThat(aiModelConfiguration.resolveProvider()).isEqualTo(Provider.OPEN_AI);
+    }
+
+    @Test
     void doesNotAutoSelectKeylessOllamaWithoutExplicitConfiguration() {
         ApplicationProperties applicationProperties = new ApplicationProperties();
 

--- a/server/libs/config/app-config/src/main/java/com/bytechef/config/ApplicationProperties.java
+++ b/server/libs/config/app-config/src/main/java/com/bytechef/config/ApplicationProperties.java
@@ -807,8 +807,12 @@ public class ApplicationProperties {
             private Docs docs = new Docs();
 
             /**
-             * Explicit CE chat-model provider key (e.g. openAi) to use for Copilot, overriding auto-detection from the
-             * configured provider API keys/endpoints. Ignored when the EE AI Providers catalog is active.
+             * Explicit chat-model provider to prefer for Copilot — accepts the short provider name (e.g. openAi) or the
+             * full catalog key (e.g. ai.provider.openAi), case-insensitively; unrecognized values fall back to
+             * auto-detection. In CE it overrides auto-detection from the configured provider API keys/endpoints. In EE
+             * it is used as the environment default provider when set, provided that provider is enabled and has a
+             * configured chat model; otherwise resolution falls back to the first enabled chat provider. A per-turn
+             * model picked in the Copilot toolbar always overrides this.
              */
             private String provider;
 
@@ -1173,6 +1177,11 @@ public class ApplicationProperties {
             private Groq groq = new Groq();
 
             /**
+             * Image model configuration grouped by provider
+             */
+            private Image image = new Image();
+
+            /**
              * Mistral AI configuration
              */
             private Mistral mistral = new Mistral();
@@ -1255,6 +1264,10 @@ public class ApplicationProperties {
                 return groq;
             }
 
+            public Image getImage() {
+                return image;
+            }
+
             public Nvidia getNvidia() {
                 return nvidia;
             }
@@ -1329,6 +1342,10 @@ public class ApplicationProperties {
 
             public void setGroq(Groq groq) {
                 this.groq = groq;
+            }
+
+            public void setImage(Image image) {
+                this.image = image;
             }
 
             public void setNvidia(Nvidia nvidia) {
@@ -2407,6 +2424,63 @@ public class ApplicationProperties {
 
                         /**
                          * Embedding model name (e.g., text-embedding-ada-002)
+                         */
+                        private String model;
+
+                        public String getModel() {
+                            return model;
+                        }
+
+                        public void setModel(String model) {
+                            this.model = model;
+                        }
+                    }
+                }
+            }
+
+            /**
+             * Image model configuration grouped by provider.
+             */
+            public static class Image {
+
+                /**
+                 * OpenAI image model configuration
+                 */
+                private OpenAi openAi = new OpenAi();
+
+                public OpenAi getOpenAi() {
+                    return openAi;
+                }
+
+                public void setOpenAi(OpenAi openAi) {
+                    this.openAi = openAi;
+                }
+
+                /**
+                 * OpenAI image model configuration.
+                 */
+                public static class OpenAi {
+
+                    /**
+                     * Image model options
+                     */
+                    private Options options = new Options();
+
+                    public Options getOptions() {
+                        return options;
+                    }
+
+                    public void setOptions(Options options) {
+                        this.options = options;
+                    }
+
+                    /**
+                     * OpenAI image model options.
+                     */
+                    public static class Options {
+
+                        /**
+                         * Image model name (e.g., dall-e-3)
                          */
                         private String model;
 

--- a/server/libs/platform/platform-ai/platform-ai-api/src/main/java/com/bytechef/platform/ai/llm/Provider.java
+++ b/server/libs/platform/platform-ai/platform-ai-api/src/main/java/com/bytechef/platform/ai/llm/Provider.java
@@ -87,6 +87,41 @@ public enum Provider {
         this.name = name;
     }
 
+    /**
+     * Resolves a provider from either its short name (e.g. {@code anthropic}) or its full catalog key (e.g.
+     * {@code ai.provider.anthropic}), case-insensitively. Returns {@code null} when the value matches no provider, so
+     * callers can fall back instead of failing.
+     */
+    public static Provider fetchByNameOrKey(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+
+        for (Provider provider : values()) {
+            if (provider.key.equalsIgnoreCase(value) || provider.name.equalsIgnoreCase(value)) {
+                return provider;
+            }
+        }
+
+        return null;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public String getName() {
+        return name;
+    }
+
     public boolean isEmbeddingSupported() {
         return EMBEDDING_PROVIDERS.contains(this);
     }
@@ -105,22 +140,6 @@ public enum Provider {
 
     public boolean requiresEndpoint() {
         return ENDPOINT_PROVIDERS.contains(this);
-    }
-
-    public int getId() {
-        return id;
-    }
-
-    public String getLabel() {
-        return label;
-    }
-
-    public String getKey() {
-        return key;
-    }
-
-    public String getName() {
-        return name;
     }
 
     public static Provider valueOfKey(String key) {


### PR DESCRIPTION
Ship chat model defaults for every provider in application-bytechef.yml
(DeepSeek, Groq, Mistral, NVIDIA, Perplexity and Vertex Gemini alongside
the existing Anthropic/OpenAI), a Mistral embedding default, and the new
bytechef.ai.provider.image.openai.options.model key (dall-e-3) with its
ApplicationProperties binding. Azure OpenAI and Ollama deliberately ship
no defaults: Azure's model is the customer's deployment name, and
Ollama's usable models (chat and embedding) are whatever the local
instance has pulled - for embeddings an explicit choice also matters
because switching models invalidates vectors already stored in Knowledge
Bases.

The property copilot and the n8n converter sub-agent now resolve their
chat model per request from the AI provider catalog
(CatalogChatClientResolver.resolveDefaultChatModel, honoring the
bytechef.ai.copilot.provider preference and per-environment provider
enablement) instead of the startup-built ChatModel bean, falling back to
that bean on CE or when nothing is resolvable. The converter subagent
ChatClient is rebuilt per request around the resolved model, keeping its
system prompt and tools.
