### PR TITLE
5381 client - Alias @bytechef/embedded to SDK source in Vite config

### DIFF
--- a/client/vite.config.mts
+++ b/client/vite.config.mts
@@ -59,7 +59,7 @@ export default ({mode}) => {
             tsconfigPaths: true,
             alias: {
                 '@': path.resolve(__dirname, './src'),
-                '@bytechef/embedded-react': path.resolve(__dirname, '../sdks/frontend/embedded/library/react/src/main.ts'),
+                '@bytechef/embedded': path.resolve(__dirname, '../sdks/frontend/embedded/library/src/main.ts'),
                 '@dagrejs/dagre': path.resolve(__dirname, 'node_modules/@dagrejs/dagre/dist/dagre.cjs.js'),
             },
         },


### PR DESCRIPTION
Resolve @bytechef/embedded via a Vite resolve.alias pointing at the SDK
source (../sdks/frontend/embedded/library/src/main.ts) instead of the
file: dependency's built dist/. A fresh checkout has no dist/, so
Rolldown failed to resolve the import from client/src/connect.tsx during
`npm run build`. Aliasing to source makes the client build self-contained.

Remove the now-unused @bytechef/embedded-react alias (imported nowhere in
client/src, not a client dependency).

Closes #5381

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
