### PR TITLE
5389 Disable MCP keep-alive pings and bound the async request-timeout

### DIFF
--- a/server/apps/server-app/src/main/resources/config/application.yml
+++ b/server/apps/server-app/src/main/resources/config/application.yml
@@ -225,7 +225,9 @@ spring:
       enabled: ${bytechef.mail.ssl.enabled}
   mvc:
     async:
-      request-timeout: -1
+      # Bound long-lived MCP Streamable HTTP SSE streams: far above the 30s servlet default so idle
+      # streams are not torn down, but finite so idle/leaked async requests are eventually reclaimed.
+      request-timeout: 10m
   liquibase:
     contexts: mono, #spring.profiles.active#
     enabled: ${bytechef.upgrade.enabled:true}

--- a/server/ee/apps/config-server-app/src/main/resources/config/apps/application.yml
+++ b/server/ee/apps/config-server-app/src/main/resources/config/apps/application.yml
@@ -112,7 +112,9 @@ spring:
     enabled: false
   mvc:
     async:
-      request-timeout: -1
+      # Bound long-lived MCP Streamable HTTP SSE streams: far above the 30s servlet default so idle
+      # streams are not torn down, but finite so idle/leaked async requests are eventually reclaimed.
+      request-timeout: 10m
   output:
     ansi:
       console-available: true

--- a/server/ee/libs/embedded/embedded-ai/embedded-ai-mcp-server/src/main/java/com/bytechef/ee/embedded/ai/mcp/server/config/EmbeddedMcpServerConfiguration.java
+++ b/server/ee/libs/embedded/embedded-ai/embedded-ai-mcp-server/src/main/java/com/bytechef/ee/embedded/ai/mcp/server/config/EmbeddedMcpServerConfiguration.java
@@ -85,7 +85,6 @@ import io.modelcontextprotocol.common.McpTransportContext;
 import io.modelcontextprotocol.server.McpServerFeatures;
 import io.modelcontextprotocol.spec.McpSchema;
 import jakarta.servlet.http.HttpServletRequest;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -120,7 +119,6 @@ public class EmbeddedMcpServerConfiguration {
     WebMvcStreamableServerTransportProvider embeddedWebMvcStreamableHttpServerTransportProvider() {
         return WebMvcStreamableServerTransportProvider.builder()
             .mcpEndpoint("/api/embedded/{secretKey}/mcp")
-            .keepAliveInterval(Duration.ofSeconds(30))
             .contextExtractor(serverRequest -> {
                 String externalUserId = SecurityUtils.getCurrentUserLogin();
                 String secretKey = serverRequest.pathVariable(SECRET_KEY);

--- a/server/libs/ai/ai-mcp/ai-mcp-server/src/main/java/com/bytechef/ai/mcp/server/config/ManagementMcpServerConfiguration.java
+++ b/server/libs/ai/ai-mcp/ai-mcp-server/src/main/java/com/bytechef/ai/mcp/server/config/ManagementMcpServerConfiguration.java
@@ -34,7 +34,6 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.modelcontextprotocol.server.McpAsyncServer;
 import io.modelcontextprotocol.server.McpServer;
 import io.modelcontextprotocol.spec.McpSchema;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import org.springframework.ai.mcp.McpToolUtils;
@@ -93,7 +92,6 @@ public class ManagementMcpServerConfiguration {
     WebMvcStreamableServerTransportProvider webMvcStreamableHttpServerTransportProvider() {
         return WebMvcStreamableServerTransportProvider.builder()
             .mcpEndpoint("/api/management/{secretKey}/mcp")
-            .keepAliveInterval(Duration.ofSeconds(30))
             .build();
     }
 

--- a/server/libs/automation/automation-ai/automation-ai-mcp-server/src/main/java/com/bytechef/automation/ai/mcp/server/config/AutomationMcpServerConfiguration.java
+++ b/server/libs/automation/automation-ai/automation-ai-mcp-server/src/main/java/com/bytechef/automation/ai/mcp/server/config/AutomationMcpServerConfiguration.java
@@ -82,7 +82,6 @@ import com.bytechef.tenant.TenantContext;
 import io.modelcontextprotocol.common.McpTransportContext;
 import io.modelcontextprotocol.server.McpServerFeatures;
 import io.modelcontextprotocol.spec.McpSchema;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -111,7 +110,6 @@ public class AutomationMcpServerConfiguration {
     WebMvcStreamableServerTransportProvider automationWebMvcStreamableHttpServerTransportProvider() {
         return WebMvcStreamableServerTransportProvider.builder()
             .mcpEndpoint("/api/automation/{secretKey}/mcp")
-            .keepAliveInterval(Duration.ofSeconds(30))
             .contextExtractor(serverRequest -> {
                 String secretKey = serverRequest.pathVariable(SECRET_KEY);
 


### PR DESCRIPTION
Fixes #5389

Rolls back the problematic parts of #5367 ("Keep MCP connections alive with server-side keep-alive pings"), which had two coupled changes.

### 1. Disable keep-alive pings (the log-flood root cause)

The cloud `server-app` disk fills over a day with repeated WARN lines:

```
WARN io.modelcontextprotocol.util.KeepAliveScheduler -- Failed to send keep-alive ping to session ...: Stream unavailable for session <uuid>
```

Confirmed against the MCP SDK source (`io.modelcontextprotocol.util.KeepAliveScheduler`, mcp-core 2.0.0):

- Its own comment states it does not support streamable HTTP:
  ```java
  // TODO Currently we do not support the streams (streamable http session created by
  // http post/get)
  ```
- Each tick calls `session.sendRequest(METHOD_PING, …)` on every session, logs `warn(...)` on failure, then `onErrorComplete()` — it never evicts the failing session. A streamable-HTTP session has no persistent server→client stream to ping over, so the ping fails with `Stream unavailable for session <id>` and re-warns every 30s indefinitely.

All three MCP servers use `WebMvcStreamableServerTransportProvider`, so keep-alive was never functional. Removed `keepAliveInterval` (and the now-unused `Duration` import) from the management, automation, and embedded configs.

### 2. Bound the async request-timeout instead of disabling it

#5367 also set `spring.mvc.async.request-timeout: -1` (no timeout) in `server-app` and EE `config-server-app` `application.yml`, to stop the servlet container tearing down idle Streamable HTTP SSE streams at the 30s default. Disabling the timeout entirely means leaked/hung async requests are never reclaimed.

Replaced `-1` with a bounded `10m`: comfortably above the 30s default and long enough for long-lived MCP streams and long tool calls, but finite so idle/leaked async requests are eventually reclaimed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)