### PR TITLE
fix: distinguish try and error branches in Error Handler execution history

### DIFF
--- a/client/src/shared/components/workflow-executions/WorkflowExecutionsAccordionItem.tsx
+++ b/client/src/shared/components/workflow-executions/WorkflowExecutionsAccordionItem.tsx
@@ -14,6 +14,18 @@ import {twMerge} from 'tailwind-merge';
 
 const ITERATIONS_PAGE_SIZE = 100;
 
+const ON_ERROR_BRANCH_LABELS = ['Try branch', 'Error branch'];
+
+const isOnErrorDispatcher = (type?: string) => type?.toLowerCase().includes('on-error') ?? false;
+
+const getIterationLabel = (taskExecution: TaskExecution, index: number) => {
+    if (isOnErrorDispatcher(taskExecution.type)) {
+        return ON_ERROR_BRANCH_LABELS[index] ?? `Branch ${index + 1}`;
+    }
+
+    return `${taskExecution.title || ''} iteration ${index + 1}`;
+};
+
 const isTaskExecution = (execution: TaskExecution | TriggerExecution): execution is TaskExecution =>
     'jobId' in execution;
 
@@ -109,12 +121,17 @@ const WorkflowExecutionsAccordionItem = ({
             >
                 {hasIterations ? (
                     <Accordion className="mt-2 space-y-2" defaultValue={defaultValue} type="multiple">
-                        {taskExecution.iterations?.slice(0, visibleIterationCount).map((iteration, index) => {
+                        {taskExecution.iterations
+                            ?.slice(0, visibleIterationCount)
+                            .map((iteration, index) => ({index, iteration}))
+                            .filter(({iteration}) => !isOnErrorDispatcher(taskExecution.type) || iteration.length > 0)
+                            .map(({iteration, index}) => {
                             const iterationValue = `${taskExecution.id}-iteration-${index}`;
                             const currentIterationItem = taskExecution.input?.items?.[index];
                             const convertedIterationItems = (iteration as unknown[]).map((item) =>
                                 TaskExecutionFromJSON(item)
                             );
+                            const iterationLabel = getIterationLabel(taskExecution, index);
 
                             return (
                                 <AccordionItem className="border-b-0" key={iterationValue} value={iterationValue}>
@@ -123,7 +140,7 @@ const WorkflowExecutionsAccordionItem = ({
                                             <AccordionTrigger className="flex w-full min-w-0 items-center justify-between rounded-md border border-stroke-neutral-primary p-2 hover:border-stroke-brand-primary hover:no-underline focus-visible:outline-stroke-brand-focus focus-visible:transition-colors data-[state=open]:hover:border-stroke-brand-secondary [&_svg]:size-5 [&[data-state=closed]:hover>svg]:rotate-0! [&[data-state=open]>svg]:rotate-180!">
                                                 <div className="flex w-full items-center justify-between">
                                                     <span className="text-sm font-medium text-content-neutral-primary">
-                                                        {taskExecution.title || ''} iteration {index + 1}
+                                                        {iterationLabel}
                                                     </span>
 
                                                     <div className="mr-2 flex items-center gap-x-1 text-xs text-content-neutral-secondary">

--- a/server/libs/platform/platform-workflow/platform-workflow-execution/platform-workflow-execution-api/build.gradle.kts
+++ b/server/libs/platform/platform-workflow/platform-workflow-execution/platform-workflow-execution-api/build.gradle.kts
@@ -11,4 +11,6 @@ dependencies {
     implementation(project(":server:libs:core:commons:commons-data"))
     implementation(project(":server:libs:core:commons:commons-util"))
     implementation(project(":server:libs:core:tenant:tenant-api"))
+
+    testImplementation(project(":server:libs:test:test-support"))
 }

--- a/server/libs/platform/platform-workflow/platform-workflow-execution/platform-workflow-execution-api/src/main/java/com/bytechef/platform/workflow/execution/dto/TaskExecutionDTO.java
+++ b/server/libs/platform/platform-workflow/platform-workflow-execution/platform-workflow-execution-api/src/main/java/com/bytechef/platform/workflow/execution/dto/TaskExecutionDTO.java
@@ -17,14 +17,18 @@
 package com.bytechef.platform.workflow.execution.dto;
 
 import com.bytechef.atlas.configuration.domain.WorkflowTask;
+import com.bytechef.atlas.configuration.util.WorkflowTaskUtils;
 import com.bytechef.atlas.execution.domain.TaskExecution;
+import com.bytechef.commons.util.MapUtils;
 import com.bytechef.error.ExecutionError;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -121,10 +125,62 @@ public record TaskExecutionDTO(
             return new TaskExecutionDTO(taskExecutionDTO, List.of(), iterationItems, taskExecutionDTO.childJob());
         }
 
+        if (type != null && type.toLowerCase()
+            .contains("on-error")) {
+            WorkflowTask workflowTask = taskExecutionDTO.workflowTask();
+
+            Set<String> mainBranchTaskNames = collectBranchTaskNames(workflowTask, "main-branch");
+            Set<String> errorBranchTaskNames = collectBranchTaskNames(workflowTask, "on-error-branch");
+
+            List<TaskExecutionDTO> mainBranchTasks = new ArrayList<>();
+            List<TaskExecutionDTO> errorBranchTasks = new ArrayList<>();
+
+            for (TaskExecutionDTO child : matchingChildren) {
+                TaskExecutionDTO builtChild = buildTasksTree(child, tasksMap);
+                String childTaskName = builtChild.workflowTask() == null ? null : builtChild.workflowTask().getName();
+
+                if (childTaskName != null && errorBranchTaskNames.contains(childTaskName)) {
+                    errorBranchTasks.add(builtChild);
+                }
+                else if (childTaskName != null && mainBranchTaskNames.contains(childTaskName)) {
+                    mainBranchTasks.add(builtChild);
+                }
+                else {
+                    mainBranchTasks.add(builtChild);
+                }
+            }
+
+            List<List<TaskExecutionDTO>> branchItems = new ArrayList<>();
+
+            if (!mainBranchTasks.isEmpty()) {
+                branchItems.add(mainBranchTasks);
+            }
+
+            if (!errorBranchTasks.isEmpty()) {
+                branchItems.add(errorBranchTasks);
+            }
+
+            return new TaskExecutionDTO(taskExecutionDTO, List.of(), branchItems, taskExecutionDTO.childJob());
+        }
+
         List<TaskExecutionDTO> children = matchingChildren.stream()
             .map(child -> buildTasksTree(child, tasksMap))
             .toList();
 
         return new TaskExecutionDTO(taskExecutionDTO, children, List.of(), taskExecutionDTO.childJob());
+    }
+
+    private static Set<String> collectBranchTaskNames(WorkflowTask workflowTask, String branchKey) {
+        if (workflowTask == null) {
+            return Set.of();
+        }
+
+        List<WorkflowTask> branchTasks = MapUtils.getList(
+            workflowTask.getParameters(), branchKey, WorkflowTask.class, List.of());
+
+        return WorkflowTaskUtils.getTasks(branchTasks, null)
+            .stream()
+            .map(WorkflowTask::getName)
+            .collect(Collectors.toCollection(HashSet::new));
     }
 }

--- a/server/libs/platform/platform-workflow/platform-workflow-execution/platform-workflow-execution-api/src/main/java/com/bytechef/platform/workflow/execution/dto/TaskExecutionDTO.java
+++ b/server/libs/platform/platform-workflow/platform-workflow-execution/platform-workflow-execution-api/src/main/java/com/bytechef/platform/workflow/execution/dto/TaskExecutionDTO.java
@@ -137,26 +137,22 @@ public record TaskExecutionDTO(
 
             for (TaskExecutionDTO child : matchingChildren) {
                 TaskExecutionDTO builtChild = buildTasksTree(child, tasksMap);
-                String childTaskName = builtChild.workflowTask() == null ? null : builtChild.workflowTask().getName();
+                String childTaskName = builtChild.workflowTask() == null ? null : builtChild.workflowTask()
+                    .getName();
 
                 if (childTaskName != null && errorBranchTaskNames.contains(childTaskName)) {
                     errorBranchTasks.add(builtChild);
-                }
-                else if (childTaskName != null && mainBranchTaskNames.contains(childTaskName)) {
+                } else if (childTaskName != null && mainBranchTaskNames.contains(childTaskName)) {
                     mainBranchTasks.add(builtChild);
-                }
-                else {
+                } else {
                     mainBranchTasks.add(builtChild);
                 }
             }
 
             List<List<TaskExecutionDTO>> branchItems = new ArrayList<>();
 
-            if (!mainBranchTasks.isEmpty()) {
+            if (!mainBranchTasks.isEmpty() || !errorBranchTasks.isEmpty()) {
                 branchItems.add(mainBranchTasks);
-            }
-
-            if (!errorBranchTasks.isEmpty()) {
                 branchItems.add(errorBranchTasks);
             }
 

--- a/server/libs/platform/platform-workflow/platform-workflow-execution/platform-workflow-execution-api/src/test/java/com/bytechef/platform/workflow/execution/dto/TaskExecutionDTOTest.java
+++ b/server/libs/platform/platform-workflow/platform-workflow-execution/platform-workflow-execution-api/src/test/java/com/bytechef/platform/workflow/execution/dto/TaskExecutionDTOTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025 ByteChef
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.bytechef.platform.workflow.execution.dto;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.bytechef.atlas.configuration.domain.WorkflowTask;
+import com.bytechef.atlas.execution.domain.TaskExecution;
+import com.bytechef.commons.util.MapUtils;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * @author Anshul Goel
+ */
+class TaskExecutionDTOTest {
+
+    static {
+        MapUtils.setObjectMapper(JsonMapper.builder().build());
+    }
+
+    @Test
+    void buildHierarchyShouldGroupOnErrorDispatcherTasksByBranch() {
+        WorkflowTask onErrorWorkflowTask = new WorkflowTask(
+            Map.of(
+                "name", "onError",
+                "type", "on-error/v1",
+                "parameters", Map.of(
+                    "main-branch", List.of(
+                        Map.of("name", "mainTask", "type", "test/v1")),
+                    "on-error-branch", List.of(
+                        Map.of("name", "errorTask", "type", "test/v1")))));
+
+        TaskExecution onErrorTaskExecution = TaskExecution.builder()
+            .id(1L)
+            .workflowTask(onErrorWorkflowTask)
+            .build();
+
+        TaskExecution mainTaskExecution = TaskExecution.builder()
+            .id(2L)
+            .parentId(1L)
+            .workflowTask(new WorkflowTask(Map.of("name", "mainTask", "type", "test/v1")))
+            .build();
+
+        TaskExecution errorTaskExecution = TaskExecution.builder()
+            .id(3L)
+            .parentId(1L)
+            .workflowTask(new WorkflowTask(Map.of("name", "errorTask", "type", "test/v1")))
+            .build();
+
+        List<TaskExecutionDTO> flatTaskExecutions = List.of(
+            new TaskExecutionDTO(onErrorTaskExecution, "On Error", "icon", Map.of(), null, null),
+            new TaskExecutionDTO(mainTaskExecution, "Main Task", "icon", Map.of(), null, null),
+            new TaskExecutionDTO(errorTaskExecution, "Error Task", "icon", Map.of(), null, null));
+
+        List<TaskExecutionDTO> hierarchy = TaskExecutionDTO.buildHierarchy(flatTaskExecutions);
+
+        assertEquals(1, hierarchy.size());
+
+        TaskExecutionDTO onErrorTaskExecutionDTO = hierarchy.getFirst();
+
+        assertTrue(onErrorTaskExecutionDTO.children().isEmpty());
+        assertEquals(2, onErrorTaskExecutionDTO.iterations().size());
+        assertEquals(1, onErrorTaskExecutionDTO.iterations().get(0).size());
+        assertEquals("mainTask", onErrorTaskExecutionDTO.iterations().get(0).getFirst().workflowTask().getName());
+        assertEquals(1, onErrorTaskExecutionDTO.iterations().get(1).size());
+        assertEquals("errorTask", onErrorTaskExecutionDTO.iterations().get(1).getFirst().workflowTask().getName());
+    }
+}

--- a/server/libs/platform/platform-workflow/platform-workflow-execution/platform-workflow-execution-api/src/test/java/com/bytechef/platform/workflow/execution/dto/TaskExecutionDTOTest.java
+++ b/server/libs/platform/platform-workflow/platform-workflow-execution/platform-workflow-execution-api/src/test/java/com/bytechef/platform/workflow/execution/dto/TaskExecutionDTOTest.java
@@ -21,20 +21,17 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.bytechef.atlas.configuration.domain.WorkflowTask;
 import com.bytechef.atlas.execution.domain.TaskExecution;
-import com.bytechef.commons.util.MapUtils;
+import com.bytechef.test.extension.ObjectMapperSetupExtension;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
-import tools.jackson.databind.json.JsonMapper;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * @author Anshul Goel
  */
+@ExtendWith(ObjectMapperSetupExtension.class)
 class TaskExecutionDTOTest {
-
-    static {
-        MapUtils.setObjectMapper(JsonMapper.builder().build());
-    }
 
     @Test
     void buildHierarchyShouldGroupOnErrorDispatcherTasksByBranch() {
@@ -76,11 +73,71 @@ class TaskExecutionDTOTest {
 
         TaskExecutionDTO onErrorTaskExecutionDTO = hierarchy.getFirst();
 
-        assertTrue(onErrorTaskExecutionDTO.children().isEmpty());
-        assertEquals(2, onErrorTaskExecutionDTO.iterations().size());
-        assertEquals(1, onErrorTaskExecutionDTO.iterations().get(0).size());
-        assertEquals("mainTask", onErrorTaskExecutionDTO.iterations().get(0).getFirst().workflowTask().getName());
-        assertEquals(1, onErrorTaskExecutionDTO.iterations().get(1).size());
-        assertEquals("errorTask", onErrorTaskExecutionDTO.iterations().get(1).getFirst().workflowTask().getName());
+        assertTrue(onErrorTaskExecutionDTO.children()
+            .isEmpty());
+        assertEquals(2, onErrorTaskExecutionDTO.iterations()
+            .size());
+        assertEquals(1, onErrorTaskExecutionDTO.iterations()
+            .get(0)
+            .size());
+        assertEquals("mainTask", onErrorTaskExecutionDTO.iterations()
+            .get(0)
+            .getFirst()
+            .workflowTask()
+            .getName());
+        assertEquals(1, onErrorTaskExecutionDTO.iterations()
+            .get(1)
+            .size());
+        assertEquals("errorTask", onErrorTaskExecutionDTO.iterations()
+            .get(1)
+            .getFirst()
+            .workflowTask()
+            .getName());
+    }
+
+    @Test
+    void buildHierarchyShouldPreserveBranchOrderWhenOnlyErrorBranchHasTasks() {
+        WorkflowTask onErrorWorkflowTask = new WorkflowTask(
+            Map.of(
+                "name", "onError",
+                "type", "on-error/v1",
+                "parameters", Map.of(
+                    "main-branch", List.of(
+                        Map.of("name", "mainTask", "type", "test/v1")),
+                    "on-error-branch", List.of(
+                        Map.of("name", "errorTask", "type", "test/v1")))));
+
+        TaskExecution onErrorTaskExecution = TaskExecution.builder()
+            .id(1L)
+            .workflowTask(onErrorWorkflowTask)
+            .build();
+
+        TaskExecution errorTaskExecution = TaskExecution.builder()
+            .id(2L)
+            .parentId(1L)
+            .workflowTask(new WorkflowTask(Map.of("name", "errorTask", "type", "test/v1")))
+            .build();
+
+        List<TaskExecutionDTO> flatTaskExecutions = List.of(
+            new TaskExecutionDTO(onErrorTaskExecution, "On Error", "icon", Map.of(), null, null),
+            new TaskExecutionDTO(errorTaskExecution, "Error Task", "icon", Map.of(), null, null));
+
+        List<TaskExecutionDTO> hierarchy = TaskExecutionDTO.buildHierarchy(flatTaskExecutions);
+
+        TaskExecutionDTO onErrorTaskExecutionDTO = hierarchy.getFirst();
+
+        assertEquals(2, onErrorTaskExecutionDTO.iterations()
+            .size());
+        assertTrue(onErrorTaskExecutionDTO.iterations()
+            .get(0)
+            .isEmpty());
+        assertEquals(1, onErrorTaskExecutionDTO.iterations()
+            .get(1)
+            .size());
+        assertEquals("errorTask", onErrorTaskExecutionDTO.iterations()
+            .get(1)
+            .getFirst()
+            .workflowTask()
+            .getName());
     }
 }


### PR DESCRIPTION
Fixes #5058

## Description

When an Error Handler dispatcher runs, execution history showed all child tasks in a flat list. It was unclear which tasks belonged to the **try** (`main-branch`) path vs the **error** (`on-error-branch`) path. Loop dispatcher already groups iterations clearly; Error Handler did not.

This PR:
- Groups on-error dispatcher child tasks into branch iterations in `TaskExecutionDTO.buildTasksTree` (using `main-branch` / `on-error-branch` task names from workflow parameters).
- Labels those groups as **Try branch** and **Error branch** in `WorkflowExecutionsAccordionItem`.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Added `TaskExecutionDTOTest.buildHierarchyShouldGroupOnErrorDispatcherTasksByBranch`
- Ran locally:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
