### PR TITLE
5402 client - Skip null holes in object-array hydration to stop condition panel crash

### DIFF
--- a/client/src/pages/platform/workflow-editor/components/properties/hooks/tests/useArrayPropertyHydration.test.ts
+++ b/client/src/pages/platform/workflow-editor/components/properties/hooks/tests/useArrayPropertyHydration.test.ts
@@ -150,6 +150,98 @@ describe('useArrayProperty — hydration from currentNode.parameters', () => {
         expect(result.current.arrayItems).toHaveLength(2);
     });
 
+    it('does not crash when a nested condition array contains a null hole (issue #5402)', async () => {
+        hoisted.storeState.currentNode = {
+            componentName: 'condition',
+            parameters: {
+                conditions: [[{operation: 'CONTAINS', type: 'string', value1: '${var_1}', value2: 'x'}, null]],
+            },
+            workflowNodeName: 'condition_1',
+        };
+
+        const {useArrayProperty} = await import('../useArrayProperty');
+
+        const conditionTypeItems = ['boolean', 'dateTime', 'number', 'string'].map((typeName) => ({
+            name: typeName,
+            properties: [
+                {controlType: 'TEXT', name: 'value1', type: 'STRING'},
+                {controlType: 'SELECT', name: 'operation', type: 'STRING'},
+                {controlType: 'TEXT', name: 'value2', type: 'STRING'},
+            ],
+            type: 'OBJECT',
+        }));
+
+        const {result} = renderHook(() =>
+            useArrayProperty({
+                onDeleteClick: vi.fn(),
+                path: 'conditions[0]',
+                property: {
+                    controlType: 'ARRAY_BUILDER',
+                    items: conditionTypeItems,
+                    name: '0',
+                    type: 'ARRAY',
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                } as any,
+            })
+        );
+
+        await act(async () => {
+            await Promise.resolve();
+        });
+
+        const items = result.current.arrayItems as Array<{name: string}>;
+
+        expect(items).toHaveLength(1);
+        expect(items[0].name).toBe('0');
+    });
+
+    it('keeps original index-based names for items surviving a leading null hole (issue #5402)', async () => {
+        // The surviving item's name must stay aligned with its index in the saved
+        // array, otherwise its parameter path would point at the null slot.
+        hoisted.storeState.currentNode = {
+            componentName: 'condition',
+            parameters: {
+                conditions: [[null, {operation: 'CONTAINS', type: 'string', value1: '${var_1}', value2: 'x'}]],
+            },
+            workflowNodeName: 'condition_1',
+        };
+
+        const {useArrayProperty} = await import('../useArrayProperty');
+
+        const conditionTypeItems = ['boolean', 'dateTime', 'number', 'string'].map((typeName) => ({
+            name: typeName,
+            properties: [
+                {controlType: 'TEXT', name: 'value1', type: 'STRING'},
+                {controlType: 'SELECT', name: 'operation', type: 'STRING'},
+                {controlType: 'TEXT', name: 'value2', type: 'STRING'},
+            ],
+            type: 'OBJECT',
+        }));
+
+        const {result} = renderHook(() =>
+            useArrayProperty({
+                onDeleteClick: vi.fn(),
+                path: 'conditions[0]',
+                property: {
+                    controlType: 'ARRAY_BUILDER',
+                    items: conditionTypeItems,
+                    name: '0',
+                    type: 'ARRAY',
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                } as any,
+            })
+        );
+
+        await act(async () => {
+            await Promise.resolve();
+        });
+
+        const items = result.current.arrayItems as Array<{name: string}>;
+
+        expect(items).toHaveLength(1);
+        expect(items[0].name).toBe('1');
+    });
+
     it('hydrates three STRING items from parameters.value on mount (var component scenario)', async () => {
         // This mirrors the workflow JSON from the bug report:
         //   parameters: {type: 'ARRAY', value: ['www', 'wqewqe', 'rrrr']}

--- a/client/src/pages/platform/workflow-editor/components/properties/hooks/useArrayProperty.ts
+++ b/client/src/pages/platform/workflow-editor/components/properties/hooks/useArrayProperty.ts
@@ -312,6 +312,10 @@ export function useArrayProperty({onDeleteClick, parentArrayItems, path, propert
             Array.isArray(parameterValue)
         ) {
             const parameterArrayItems = parameterValue.map((parameterItem: ArrayPropertyType, index: number) => {
+                if (parameterItem == null) {
+                    return null;
+                }
+
                 const matchingItem = items?.find((item) => item.name === parameterItem.type);
 
                 if (!matchingItem) {
@@ -352,8 +356,13 @@ export function useArrayProperty({onDeleteClick, parentArrayItems, path, propert
                 };
             });
 
-            if (parameterArrayItems?.length) {
-                setArrayItems(parameterArrayItems);
+            const definedParameterArrayItems = parameterArrayItems.filter(
+                (parameterArrayItem): parameterArrayItem is NonNullable<typeof parameterArrayItem> =>
+                    parameterArrayItem != null
+            );
+
+            if (definedParameterArrayItems.length) {
+                setArrayItems(definedParameterArrayItems);
             }
         } else if (items?.length && items[0].type === 'OBJECT' && Array.isArray(parameterValue)) {
             const parameterArrayItems = parameterValue.map((parameterItem: ArrayPropertyType, index: number) => {


### PR DESCRIPTION
A removed condition leaves a null hole in a condition's saved conditions
array. The object-array hydration branch in useArrayProperty dereferenced
parameterItem.type on the null, throwing; the ArrayProperty ErrorBoundary
blanked the properties panel, so the raw Expression field disappeared and
edits reverted to the stored value. Skip null items during hydration and
drop them before setArrayItems; surviving items keep their original
index-based names so their paths stay aligned with the saved array.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012hvpHQ8Z8g5ogsRPaSLPZG
