### PR TITLE
3757 - Correct three docs feature-status claims

### DIFF
--- a/.agents/coming-soon-inventory.md
+++ b/.agents/coming-soon-inventory.md
@@ -23,7 +23,7 @@ Two ways something here is hidden, and the tables below mark both:
 
 Both are reversible and neither deletes anything.
 
-**44 whole-page** (15 hidden) · **29 partial** pages (6 with a commented-out section)
+**46 whole-page** (15 hidden) · **29 partial** pages (6 with a commented-out section)
 
 ---
 
@@ -50,6 +50,7 @@ Both are reversible and neither deletes anything.
 | Asset Files | [`/platform/automation/data/asset-files`](/platform/automation/data/asset-files) | CE | visible |
 | Sources | [`/platform/automation/data/knowledge-base/sources`](/platform/automation/data/knowledge-base/sources) | CE | **hidden** |
 | A2A Servers | [`/platform/automation/deploy/a2a-servers`](/platform/automation/deploy/a2a-servers) | CE | **hidden** |
+| API Platform | [`/platform/automation/deploy/api-platform`](/platform/automation/deploy/api-platform) | — | visible |
 | Guardrails | [`/platform/automation/settings/ai-agents/guardrails`](/platform/automation/settings/ai-agents/guardrails) | EE | **hidden** |
 | System Prompt | [`/platform/automation/settings/ai-agents/system-prompt`](/platform/automation/settings/ai-agents/system-prompt) | EE | **hidden** |
 | AI Hub Connectors | [`/platform/automation/settings/ai-hub-connectors`](/platform/automation/settings/ai-hub-connectors) | EE | **hidden** |
@@ -63,6 +64,7 @@ Both are reversible and neither deletes anything.
 |---|---|---|---|
 | Automation Code Workflows | [`/platform/embedded/build/automations/automation-code-workflows`](/platform/embedded/build/automations/automation-code-workflows) | CE | visible |
 | Automation workflows | [`/platform/embedded/build/automations/automation-workflows`](/platform/embedded/build/automations/automation-workflows) | EE | visible |
+| Unified API | [`/platform/embedded/build/unified-api`](/platform/embedded/build/unified-api) | — | visible |
 
 ### Platform Settings
 

--- a/docs/content/docs/platform/automation/build/workflows/human-in-the-loop.mdx
+++ b/docs/content/docs/platform/automation/build/workflows/human-in-the-loop.mdx
@@ -221,10 +221,10 @@ itself — its filters, the fields on a request, and why an inbox can look empty
 
 <Callout type="warn" title="Coming soon">
   The capabilities in this section — the extra delivery channels, in-place
-  messenger resolution, the Approval Gate for AI-agent tools, the pending
-  approvals inbox, expiry reminders and escalation, and MCP/A2A approval
-  elicitation — are on the upcoming release track and are not yet available
-  in the latest released version of ByteChef.
+  messenger resolution, the Approval Gate for AI-agent tools, expiry
+  reminders and escalation, and MCP/A2A approval elicitation — are on the
+  upcoming release track and are not yet available in the latest released
+  version of ByteChef.
 </Callout>
 
 ByteChef separates two disjoint human-in-the-loop primitives: **Approval** (a

--- a/docs/content/docs/platform/automation/deploy/api-platform.mdx
+++ b/docs/content/docs/platform/automation/deploy/api-platform.mdx
@@ -1,6 +1,7 @@
 ---
 title: "API Platform"
 description: Publish workflows as your own REST API — collections of endpoints with API-client credentials.
+comingSoon: true
 ---
 
 <EEBadge />

--- a/docs/content/docs/platform/embedded/build/unified-api.mdx
+++ b/docs/content/docs/platform/embedded/build/unified-api.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Unified API"
 description: "One normalized, provider-agnostic REST schema across many CRM and Accounting providers — integrate once, support many."
+comingSoon: true
 ---
 
 The **Unified API** is a normalized REST layer that gives you a single schema across many third-party providers in the same category. Instead of learning HubSpot's account model, then Pipedrive's, then Xero's, you write against one ByteChef `account` shape and ByteChef translates every request and response to whichever provider your connected user actually connected.


### PR DESCRIPTION
Follow-up to #5541, from an audit of the 43 open `feature-flag` issues against master.

### Two pages presented an unreleased feature as available

`ff-743` (Unified API) and `ff-1023` (API Platform) are both still live feature flags on master, but neither page carried `comingSoon`, so both read as shipped. Since `comingSoon` is the authoritative feature-status gate read by the marketing site, an unmarked page for a gated feature misinforms downstream rather than merely saying nothing.

### One page contradicted another

`human-in-the-loop.mdx`'s *Coming soon* callout listed **"the pending approvals inbox"** among capabilities *"not yet available in the latest released version"*. That inbox is released: `monitor/approval-tasks` is a normal page carried in the automation sidebar via `automation/meta.json`, and the callout's own section body already refers to it as existing — "the **Approval Tasks** sidebar inbox", "The Approval Tasks page **will also gain** a pending run approvals section". The list item was stale, so it is removed.

### Verification

- `npm run lint` — 551 URLs collected, 0 errored files, 0 link errors.
- `npm run coming-soon:write` — inventory regenerated, 44 → 46 whole-page entries.

The one remaining ESLint error is pre-existing and unrelated: `docs/.remember/tmp/last-ndc.ts`, a git-ignored cache file the link checker writes, which ESLint does not exclude.

### Not included

The audit also found six gated features with no narrative documentation at all — `ff-1840` (async workflow outputs), `ff-2396` (global search), `ff-2894` (`streamResponseToRequest`), `ff-2311` (`streamAsk`), `ff-3839` (AI Agent as a tool), `ff-4572` (Copilot for Evaluations) — plus `agent/index.mdx`'s `### Chat (stream)` section, which is gated by `ff-2894` but rendered unmarked. Those are new pages and sections rather than status corrections, so they are left for separate work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KwL2i65aw7YMmL5CPJs2Jm
