### PR TITLE
2894 / 2311 / 3827 - Remove feature flags for streaming chat, Ask (stream) and the Form trigger

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -167,9 +167,7 @@ function App() {
 
     const ff_1023 = useFeatureFlagsStore()('ff-1023');
     const ff_2446 = useFeatureFlagsStore()('ff-2446');
-    const ff_2311 = useFeatureFlagsStore()('ff-2311');
     const ff_2396 = useFeatureFlagsStore()('ff-2396');
-    const ff_2894 = useFeatureFlagsStore()('ff-2894');
 
     const filteredAutomationNavigation = automationNavigation.filter((navItem) => {
         if (
@@ -182,10 +180,6 @@ function App() {
 
         if (navItem.href === '/automation/api-platform') {
             return ff_1023;
-        }
-
-        if (navItem.href === '/automation/chat') {
-            return ff_2311 || ff_2894;
         }
 
         if (navItem.href === '/automation/knowledge-bases') {

--- a/client/src/pages/platform/workflow-editor/components/WorkflowNodesPopoverMenuComponentList.tsx
+++ b/client/src/pages/platform/workflow-editor/components/WorkflowNodesPopoverMenuComponentList.tsx
@@ -74,7 +74,6 @@ const WorkflowNodesPopoverMenuComponentList = memo(
 
         const ff_797 = getFeatureFlag('ff-797');
         const ff_3158 = getFeatureFlag('ff-3158');
-        const ff_3827 = getFeatureFlag('ff-3827');
 
         const knowledgeBaseEnabled = useApplicationInfoStore((state) => state.ai.knowledgeBase.enabled);
 
@@ -112,9 +111,9 @@ const WorkflowNodesPopoverMenuComponentList = memo(
                 return [];
             }
 
-            let triggerComponents = componentsWithActions
-                .filter(({triggersCount}) => triggersCount && triggersCount > 0)
-                .filter(({name}) => (!ff_3827 && name !== 'form') || ff_3827);
+            let triggerComponents = componentsWithActions.filter(
+                ({triggersCount}) => triggersCount && triggersCount > 0
+            );
 
             if (clusterElementType) {
                 triggerComponents = triggerComponents.filter((component) =>
@@ -123,7 +122,7 @@ const WorkflowNodesPopoverMenuComponentList = memo(
             }
 
             return triggerComponents;
-        }, [componentsWithActions, clusterElementType, ff_3827]);
+        }, [componentsWithActions, clusterElementType]);
 
         const filteredClusterElementComponentDefinitions = useMemo(() => {
             if (!componentsWithActions || !clusterElementType) {

--- a/client/src/pages/platform/workflow-editor/components/WorkflowNodesPopoverMenuOperationList.tsx
+++ b/client/src/pages/platform/workflow-editor/components/WorkflowNodesPopoverMenuOperationList.tsx
@@ -11,7 +11,6 @@ import {ActionDefinitionKeys} from '@/shared/queries/platform/actionDefinitions.
 import {ClusterElementDefinitionKeys} from '@/shared/queries/platform/clusterElementDefinitions.queries';
 import {TriggerDefinitionKeys} from '@/shared/queries/platform/triggerDefinitions.queries';
 import {DEFINITION_STALE_TIME} from '@/shared/queries/queryConstants';
-import {useFeatureFlagsStore} from '@/shared/stores/useFeatureFlagsStore';
 import {ClickedOperationType, ClusterElementItemType, NodeDataType, PropertyAllType} from '@/shared/types';
 import {useQueryClient} from '@tanstack/react-query';
 import {ComponentIcon, Loader2Icon} from 'lucide-react';
@@ -97,9 +96,6 @@ const WorkflowNodesPopoverMenuOperationList = ({
             }))
         );
 
-    const ff_2311 = useFeatureFlagsStore()('ff-2311');
-    const ff_2894 = useFeatureFlagsStore()('ff-2894');
-
     const {captureComponentUsed} = useAnalytics();
 
     const {updateWorkflowMutation} = useWorkflowEditor();
@@ -121,42 +117,9 @@ const WorkflowNodesPopoverMenuOperationList = ({
         return matchingOperations;
     }, [clusterElementType, clusterElements]);
 
-    const isOperationVisible = useCallback(
-        (operationName: string): boolean => {
-            if (ff_2894) {
-                return true;
-            }
-
-            if (['streamChat', 'streamResponseToRequest'].includes(operationName)) {
-                return false;
-            }
-
-            if (!ff_2311 && operationName === 'streamAsk') {
-                return false;
-            }
-
-            return true;
-        },
-        [ff_2311, ff_2894]
-    );
-
     const operations = useMemo(
-        () =>
-            (trigger
-                ? triggers
-                : clusterElementsCanvasOpen && clusterElement
-                  ? clusterElementOperations
-                  : actions
-            )?.filter((operation) => isOperationVisible(operation.name)),
-        [
-            trigger,
-            triggers,
-            clusterElementsCanvasOpen,
-            clusterElement,
-            clusterElementOperations,
-            actions,
-            isOperationVisible,
-        ]
+        () => (trigger ? triggers : clusterElementsCanvasOpen && clusterElement ? clusterElementOperations : actions),
+        [trigger, triggers, clusterElementsCanvasOpen, clusterElement, clusterElementOperations, actions]
     );
 
     const getNodeData = useCallback(


### PR DESCRIPTION
Closes #2894, closes #2311, closes #3827.

Three shipped capabilities were still gated in the workflow editor. Removing their flags makes them unconditional.

| Flag | Capability | Was gated in |
|---|---|---|
| `ff-2894` | `streamChat` — AI Agent SSE streaming | operation list, Chats nav item |
| `ff-2311` | `streamAsk` — Ask (stream) on OpenAI / Anthropic | operation list, Chats nav item |
| `ff-3827` | `form` trigger component | component list |

### Notes

**`isOperationVisible` is gone.** With `ff-2894` and `ff-2311` removed it returned `true` for every operation, so the callback, the `.filter(…)` it fed, and the now-unused `useFeatureFlagsStore` import all go with it — 38 lines out of `WorkflowNodesPopoverMenuOperationList.tsx`.

**One entry in that hide list was already dead.** `streamResponseToRequest` matched no action: `grep` finds the name nowhere in `server/`, only in the client filter itself. It was guarding an operation no component defines, so its removal changes nothing.

**The Chats nav item is now unconditional.** `/automation/chat` was gated on `ff_2311 || ff_2894`; the filter falls through to `return true`, so removing the branch leaves it always visible.

### Verification

The equivalent change was applied on a feature branch and passed the full client gate there: `npm run check` — prettier, `eslint --max-warnings=0`, `tsc --noEmit`, and **617 test files / 5588 tests, all passing**. This branch carries the same edits rebuilt against master's copies of the three files, which differ slightly (master still gates the Chats nav item in `App.tsx`; the feature branch had already replaced that with an edition check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KwL2i65aw7YMmL5CPJs2Jm
