### PR TITLE
520 / 1779 / 3839 / 4572 - Remove shipped feature flags and document two missing surfaces

### DIFF
--- a/.agents/coming-soon-inventory.md
+++ b/.agents/coming-soon-inventory.md
@@ -117,7 +117,7 @@ arriving soon was not helping a reader.
 | [`/developer-guide/architecture`](/developer-guide/architecture) | **AI & Agents** | **all commented out** |
 | [`/platform/automation/ai/skills`](/platform/automation/ai/skills) | Create With AI; The Skills Copilot; Skills as Tools for Other Agents; Test with Evals | rendered |
 | [`/platform/automation/build/connections`](/platform/automation/build/connections) | Get Started; Managing Connections | rendered |
-| [`/platform/automation/build/workflows/ai/agent`](/platform/automation/build/workflows/ai/agent) | Chat Memory Slot; Chat memory vs Auto Memory; Guardrails Slot; The Agent Utils toolset; Test with Evals; **Realtime Chat** | **1 of 6 commented out** |
+| [`/platform/automation/build/workflows/ai/agent`](/platform/automation/build/workflows/ai/agent) | Chat Memory Slot; Chat memory vs Auto Memory; Guardrails Slot; Tools Slot; The Agent Utils toolset; Test with Evals; **Realtime Chat** | **1 of 6 commented out** |
 | [`/platform/automation/build/workflows/ai/agent/agent-utils`](/platform/automation/build/workflows/ai/agent/agent-utils) | Ask User Question; Agent Client; Auto Memory | rendered |
 | [`/platform/automation/build/workflows/flow-controls`](/platform/automation/build/workflows/flow-controls) | (page intro); Outputs; Graph | rendered |
 | [`/platform/automation/build/workflows/human-in-the-loop`](/platform/automation/build/workflows/human-in-the-loop) | Coming soon: expanded approvals | rendered |

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -166,7 +166,6 @@ function App() {
     useFetchInterceptor();
 
     const ff_1023 = useFeatureFlagsStore()('ff-1023');
-    const ff_1779 = useFeatureFlagsStore()('ff-1779');
     const ff_2446 = useFeatureFlagsStore()('ff-2446');
     const ff_2311 = useFeatureFlagsStore()('ff-2311');
     const ff_2396 = useFeatureFlagsStore()('ff-2396');
@@ -205,14 +204,7 @@ function App() {
             return ff_2446;
         }
 
-        if (
-            (ff_1779 && navItem.href === '/embedded/automation-workflows') ||
-            navItem.href !== '/embedded/automation-workflows'
-        ) {
-            return true;
-        }
-
-        return false;
+        return true;
     });
 
     let navigation: NavigationType[] = [];

--- a/client/src/pages/home/Home.tsx
+++ b/client/src/pages/home/Home.tsx
@@ -1,6 +1,5 @@
 import {PlatformType, usePlatformTypeStore} from '@/pages/home/stores/usePlatformTypeStore';
-import {useFeatureFlagsStore} from '@/shared/stores/useFeatureFlagsStore';
-import {useCallback, useEffect, useState} from 'react';
+import {useEffect, useState} from 'react';
 import {useNavigate} from 'react-router-dom';
 
 import ModeSelectionDialog from './components/ModeSelectionDialog';
@@ -12,17 +11,7 @@ const Home = () => {
 
     const navigate = useNavigate();
 
-    const ff_520 = useFeatureFlagsStore()('ff-520');
-
-    const memoizedNavigate = useCallback(() => navigate('/automation'), [navigate]);
-
     useEffect(() => {
-        if (!ff_520) {
-            memoizedNavigate();
-
-            return;
-        }
-
         if (currentType !== undefined) {
             if (currentType === PlatformType.AUTOMATION) {
                 navigate('/automation');
@@ -34,9 +23,9 @@ const Home = () => {
         if (currentType === undefined) {
             setIsDialogOpen(true);
         }
-    }, [ff_520, currentType, memoizedNavigate, navigate]);
+    }, [currentType, navigate]);
 
-    if (!ff_520 || !isDialogOpen) {
+    if (!isDialogOpen) {
         return <></>;
     }
 

--- a/client/src/shared/layout/Settings.tsx
+++ b/client/src/shared/layout/Settings.tsx
@@ -43,7 +43,7 @@ const Settings = ({sidebarNavItems, title = 'Settings'}: SettingsProps) => {
                     (isFeatureFlagEnabled('ff-1025') ||
                         isFeatureFlagEnabled('ff-1039') ||
                         isFeatureFlagEnabled('ff-4814'))) ||
-                (currentType === PlatformType.EMBEDDED && isFeatureFlagEnabled('ff-520'))
+                currentType === PlatformType.EMBEDDED
             );
         }
 

--- a/client/src/shared/layout/app-sidebar/AppSidebarFooter.tsx
+++ b/client/src/shared/layout/app-sidebar/AppSidebarFooter.tsx
@@ -21,7 +21,6 @@ import {useGetUserWorkspacesQuery} from '@/shared/queries/automation/workspaces.
 import {useApplicationInfoStore} from '@/shared/stores/useApplicationInfoStore';
 import {useAuthenticationStore} from '@/shared/stores/useAuthenticationStore';
 import {useEnvironmentStore} from '@/shared/stores/useEnvironmentStore';
-import {useFeatureFlagsStore} from '@/shared/stores/useFeatureFlagsStore';
 import {useQueryClient} from '@tanstack/react-query';
 import {
     AudioLinesIcon,
@@ -72,8 +71,6 @@ export function AppSidebarFooter() {
     const navigate = useNavigate();
 
     const queryClient = useQueryClient();
-
-    const ff_520 = useFeatureFlagsStore()('ff-520');
 
     /* eslint-disable @typescript-eslint/no-non-null-asserted-optional-chain */
     const {data: environmentsQuery} = useEnvironmentsQuery();
@@ -191,7 +188,7 @@ export function AppSidebarFooter() {
 
                 <DropdownMenuSeparator />
 
-                {ff_520 && application?.edition === 'EE' && (
+                {application?.edition === 'EE' && (
                     <>
                         <DropdownMenuSub>
                             <DropdownMenuSubTrigger className="cursor-pointer font-semibold">

--- a/docs/content/docs/platform/automation/build/ai-copilot.mdx
+++ b/docs/content/docs/platform/automation/build/ai-copilot.mdx
@@ -38,6 +38,7 @@ Copilot is context-aware: each surface has its own pair of Ask and Build agents 
 | **Code workflow editor** | Ask and Build assistants scoped to a code-backed project or integration (see [Code Workflows](/platform/automation/build/workflows/code-workflows#copilot)) |
 | **Cluster Elements** (AI Agent component, vector database components) | Generate full element configurations from scratch |
 | **Workflow execution** | Analyze a finished or failed execution and debug errors |
+| **Evals** (AI Agent editor) | Explain and edit an agent's evaluation scenarios, judges, and tests — the Copilot button sits in the **Evals** panel header, beside the agent editor's own |
 | **Skills** | Explain, audit, and edit AI Skills — opens as a side panel for the open skill. To create a skill from a prompt, use **Create Skill → Create With AI** (see [Generating a workflow or skill from a prompt](#generating-a-workflow-or-skill-from-a-prompt)) |
 | **Automation listing pages** — Projects, Project Deployments, MCP Servers, API Collections, Data Tables, Knowledge Bases, Context Stores, Skills, Files, Workflow Executions | A sparkle button in the page header opens a Copilot panel scoped to that page — Ask mode lists and reads the page's items, Build mode creates and modifies them. On Skills, this listing-page panel is in addition to the per-skill side panel described above |
 

--- a/docs/content/docs/platform/automation/build/workflows/ai/agent/index.mdx
+++ b/docs/content/docs/platform/automation/build/workflows/ai/agent/index.mdx
@@ -304,6 +304,7 @@ Tools turn workflow components into actions the agent can call mid-conversation.
 | MCP Client | [mcpClient/v1](/reference/components/mcp-client_v1) | Connect the agent to an external MCP server and expose that server's tools to the model. |
 | Vector store / Knowledge Base search | The Search tool cluster element on any [supported vector store](#compatible-vector-stores) or [knowledgeBase/v1](/reference/components/knowledgeBase_v1) | Let the agent search a vector store or Knowledge Base *on demand* — retrieval as a tool the model chooses to call, complementing the always-on [RAG slot](#rag-slot). |
 | Script | [script/v1](/reference/components/script_v1) | Run custom Python, JavaScript, or Ruby as a tool when no built-in action fits. |
+| AI Agent *(coming soon)* | [aiAgent/v1](/reference/components/ai-agent_v1) | Let one agent call another as a tool, for the agent-of-agents compositions described above — a sub-agent owns a self-contained domain and returns a result to its caller. |
 
 ### Supplying tool parameters with fromAi
 


### PR DESCRIPTION
Three separate commits from a continued audit of feature flags against master.

### `3839 / 4572 docs - Document agent-as-tool and the Evals Copilot surface`

Both capabilities exist behind a flag but appeared in no table a reader would consult.

The AI Agent page already stated in prose that an agent "exposes itself as a child tool that other agents can call" — yet the **Tools Slot** table, the list of what can actually go in that slot, did not carry AI Agent. Prose promised a capability the reference table denied. It is added with the italic `*(coming soon)*` marker the page already uses for Session chat memory, since the page itself is released.

The Copilot **Where it appears** table listed every Copilot surface except Evals, whose panel header carries a Copilot button behind `ff-4572`. That page is `comingSoon` in full, so the new row inherits it.

The inventory's hand-maintained Partial row for the agent page gains **Tools Slot**.

### `520 client - Remove ff`

Embedded core infrastructure is no longer gated (#520 closed), so three surfaces become unconditional: the mode-selection dialog on the home route, the **Mode** switcher in the sidebar footer (still EE-only), and **Workspace API Keys** in embedded settings.

On the home route the flag was also the only thing forcing a redirect to `/automation`. Removing it lets the platform-type check pick the destination, which makes `memoizedNavigate` dead — and with it the file's last uses of `useCallback` and `useFeatureFlagsStore`.

### `1779 client - Remove ff`

The Embedded designer is no longer gated (#1779 closed), so **Automation Workflows** is always in the embedded navigation.

With the flag gone its guard reduces to a tautology — the href either equals `/embedded/automation-workflows` or it does not — so the branch and its unreachable `return false` collapse into the filter's default.

### Verification

The equivalent changes were applied on a feature branch and passed the full client gate there: `npm run check` — prettier, `eslint --max-warnings=0`, `tsc --noEmit`, and **617 test files / 5588 tests, all passing**. Docs: `npm run lint` — 551 URLs collected, 0 errored files, 0 link errors.

Four of the seven files differ between that branch and master, so those edits were re-derived against master's copies rather than carried across.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KwL2i65aw7YMmL5CPJs2Jm
