### PR TITLE
3158 - Filter the Claude Code component out of the node popover

### DIFF
--- a/client/src/pages/platform/workflow-editor/components/WorkflowNodesPopoverMenuComponentList.tsx
+++ b/client/src/pages/platform/workflow-editor/components/WorkflowNodesPopoverMenuComponentList.tsx
@@ -73,6 +73,7 @@ const WorkflowNodesPopoverMenuComponentList = memo(
         const getFeatureFlag = useFeatureFlagsStore();
 
         const ff_797 = getFeatureFlag('ff-797');
+        const ff_3158 = getFeatureFlag('ff-3158');
         const ff_3827 = getFeatureFlag('ff-3827');
         const ff_3839 = getFeatureFlag('ff-3839');
 
@@ -88,6 +89,7 @@ const WorkflowNodesPopoverMenuComponentList = memo(
                 .filter(
                     ({name}) =>
                         ((!ff_797 && name !== 'dataStream') || ff_797) &&
+                        ((!ff_3158 && name !== 'claudeCode') || ff_3158) &&
                         ((!knowledgeBaseEnabled && name !== 'knowledgeBase') || knowledgeBaseEnabled)
                 );
 
@@ -98,7 +100,7 @@ const WorkflowNodesPopoverMenuComponentList = memo(
             }
 
             return actionComponents;
-        }, [componentsWithActions, clusterElementType, ff_797, knowledgeBaseEnabled]);
+        }, [componentsWithActions, clusterElementType, ff_797, ff_3158, knowledgeBaseEnabled]);
 
         const filteredTaskDispatcherDefinitions = useMemo(
             () =>


### PR DESCRIPTION
Closes #3158.

`useComponentFiltering` already withheld the Claude Code component unless `ff-3158` was on, but the workflow editor's **node popover** builds its own component list and applied no such filter — so `claudeCode` was reachable there regardless of the flag.

This adds the same gate to `filteredActionComponentDefinitions`, matching the existing `ff-797` / `knowledgeBaseEnabled` style in that filter.

### Why only the action list

The component declares `.actions(...)` and neither triggers nor cluster elements, so the trigger and cluster-element lists in the same file cannot surface it. Gating those too would be dead code.

### Note

This touches the same file as #5543, on different lines — the two merge cleanly in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KwL2i65aw7YMmL5CPJs2Jm
