### PR TITLE
5536 - Carry the requested location through the login redirect

### DIFF
--- a/client/src/config/useFetchInterceptor.ts
+++ b/client/src/config/useFetchInterceptor.ts
@@ -1,4 +1,5 @@
 import {useWorkspaceStore} from '@/pages/automation/stores/useWorkspaceStore';
+import {buildLoginPath} from '@/shared/auth/login-redirect-utils';
 import {useAuthenticationStore} from '@/shared/stores/useAuthenticationStore';
 import {getCookie} from '@/shared/util/cookie-utils';
 import fetchIntercept from 'fetch-intercept';
@@ -135,7 +136,7 @@ export default function useFetchInterceptor() {
                     clearCurrentWorkspaceId();
 
                     if (!response.url.endsWith('/api/account')) {
-                        navigate('/login');
+                        navigate(buildLoginPath(window.location));
                     }
 
                     return response;
@@ -226,7 +227,7 @@ export default function useFetchInterceptor() {
                 clearCurrentWorkspaceId();
 
                 if (!url.endsWith('/api/account')) {
-                    navigate('/login');
+                    navigate(buildLoginPath(window.location));
                 }
             }
 

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -4,6 +4,7 @@ import './styles/index.css';
 
 import {TooltipProvider} from '@/components/ui/tooltip';
 import I18n from '@/i18n';
+import {buildLoginPath} from '@/shared/auth/login-redirect-utils';
 import {ConditionalPostHogProvider} from '@/shared/providers/conditional-posthog-provider';
 import {ThemeProvider} from '@/shared/providers/theme-provider';
 import {applicationInfoStore} from '@/shared/stores/useApplicationInfoStore';
@@ -68,7 +69,7 @@ async function renderApp() {
             const result = await authenticationStore.getState().getAccount();
 
             if (!result && window.location.pathname !== '/login') {
-                window.location.pathname = '/login';
+                window.location.replace(buildLoginPath(window.location));
             }
         }
     }

--- a/client/src/pages/account/public/Login.tsx
+++ b/client/src/pages/account/public/Login.tsx
@@ -4,7 +4,7 @@ import LoadingIcon from '@/components/LoadingIcon';
 import {Card, CardContent, CardHeader, CardTitle} from '@/components/ui/card';
 import {Checkbox} from '@/components/ui/checkbox';
 import {Form, FormControl, FormField, FormItem, FormLabel, FormMessage} from '@/components/ui/form';
-import {getLoginRedirect} from '@/shared/auth/login-redirect-utils';
+import {getLoginRedirect, rememberLoginRedirect} from '@/shared/auth/login-redirect-utils';
 import {useAnalytics} from '@/shared/hooks/useAnalytics';
 import PublicLayoutContainer from '@/shared/layout/PublicLayoutContainer';
 import {useAuthenticationStore} from '@/shared/stores/useAuthenticationStore';
@@ -155,6 +155,8 @@ const Login = () => {
                 })
                 .then((data) => {
                     if (data?.redirectUrl) {
+                        rememberLoginRedirect(getLoginRedirect(pageLocation.search));
+
                         window.location.href = data.redirectUrl;
                     }
                 })
@@ -162,7 +164,7 @@ const Login = () => {
                     // fall back to normal login
                 });
         }
-    }, [searchParams]);
+    }, [pageLocation.search, searchParams]);
 
     useEffect(() => {
         if (searchParams.get('error') === 'oauth2') {
@@ -213,6 +215,8 @@ const Login = () => {
                                     icon={<img alt="Google logo" src={googleLogo} />}
                                     label="Continue with Google"
                                     onClick={() => {
+                                        rememberLoginRedirect(getLoginRedirect(pageLocation.search));
+
                                         window.location.href = '/oauth2/authorization/google';
                                     }}
                                     size="lg"
@@ -223,6 +227,8 @@ const Login = () => {
                                     icon={<img alt="Github logo" src={githubLogo} />}
                                     label="Continue with Github"
                                     onClick={() => {
+                                        rememberLoginRedirect(getLoginRedirect(pageLocation.search));
+
                                         window.location.href = '/oauth2/authorization/github';
                                     }}
                                     size="lg"
@@ -282,6 +288,8 @@ const Login = () => {
                                             icon={<ShieldCheckIcon className="size-4" />}
                                             label={`Continue with ${ssoRedirect.providerName}`}
                                             onClick={() => {
+                                                rememberLoginRedirect(getLoginRedirect(pageLocation.search));
+
                                                 window.location.href = ssoRedirect.url;
                                             }}
                                             size="lg"

--- a/client/src/pages/account/public/Login.tsx
+++ b/client/src/pages/account/public/Login.tsx
@@ -4,6 +4,7 @@ import LoadingIcon from '@/components/LoadingIcon';
 import {Card, CardContent, CardHeader, CardTitle} from '@/components/ui/card';
 import {Checkbox} from '@/components/ui/checkbox';
 import {Form, FormControl, FormField, FormItem, FormLabel, FormMessage} from '@/components/ui/form';
+import {getLoginRedirect} from '@/shared/auth/login-redirect-utils';
 import {useAnalytics} from '@/shared/hooks/useAnalytics';
 import PublicLayoutContainer from '@/shared/layout/PublicLayoutContainer';
 import {useAuthenticationStore} from '@/shared/stores/useAuthenticationStore';
@@ -138,7 +139,9 @@ const Login = () => {
         }
     }, [form]);
 
-    const {from} = pageLocation.state || {from: {pathname: '/', search: pageLocation.search}};
+    const {from} = pageLocation.state || {
+        from: getLoginRedirect(pageLocation.search) ?? {pathname: '/', search: pageLocation.search},
+    };
 
     useEffect(() => {
         const company = searchParams.get('company');

--- a/client/src/pages/account/public/OAuth2Redirect.tsx
+++ b/client/src/pages/account/public/OAuth2Redirect.tsx
@@ -1,7 +1,8 @@
 import LoadingIcon from '@/components/LoadingIcon';
+import {consumeLoginRedirect} from '@/shared/auth/login-redirect-utils';
 import {useAnalytics} from '@/shared/hooks/useAnalytics';
 import {useAuthenticationStore} from '@/shared/stores/useAuthenticationStore';
-import {useEffect} from 'react';
+import {useEffect, useState} from 'react';
 import {Navigate, useNavigate} from 'react-router-dom';
 import {useShallow} from 'zustand/react/shallow';
 
@@ -17,13 +18,15 @@ const OAuth2Redirect = () => {
 
     const navigate = useNavigate();
 
+    const [redirect] = useState(() => consumeLoginRedirect() ?? '/');
+
     useEffect(() => {
         getAccount()
             .then((account) => {
                 if (account) {
                     analytics.identify(account);
 
-                    navigate('/', {replace: true});
+                    navigate(redirect, {replace: true});
                 } else {
                     navigate('/login?error=oauth2', {replace: true});
                 }
@@ -31,10 +34,10 @@ const OAuth2Redirect = () => {
             .catch(() => {
                 navigate('/login?error=oauth2', {replace: true});
             });
-    }, [analytics, getAccount, navigate]);
+    }, [analytics, getAccount, navigate, redirect]);
 
     if (authenticated) {
-        return <Navigate replace to="/" />;
+        return <Navigate replace to={redirect} />;
     }
 
     return (

--- a/client/src/pages/account/public/tests/Login.test.tsx
+++ b/client/src/pages/account/public/tests/Login.test.tsx
@@ -241,3 +241,50 @@ it('should show socials login buttons with correct feature flag', async () => {
     expect(screen.queryByText('Continue with Google')).toBeInTheDocument();
     expect(screen.queryByText('Continue with Github')).toBeInTheDocument();
 });
+
+const renderAuthenticatedLoginPage = (initialEntry: string | {pathname: string; search?: string; state?: unknown}) => {
+    mockAuthenticationStore({authenticated: true});
+
+    render(
+        <MemoryRouter initialEntries={[initialEntry]}>
+            <Routes>
+                <Route element={<Login />} path="/login" />
+
+                <Route element={<div>Landing page</div>} path="/" />
+
+                <Route
+                    element={<div>Template page</div>}
+                    path="/automation/projects/:projectId/templates/:templateName"
+                />
+            </Routes>
+        </MemoryRouter>
+    );
+};
+
+it('should continue to the location recorded in the query string after signing in', () => {
+    renderAuthenticatedLoginPage('/login?redirect=%2Fautomation%2Fprojects%2F1052%2Ftemplates%2Fai-email-classifier');
+
+    expect(screen.getByText('Template page')).toBeInTheDocument();
+});
+
+it('should prefer the location passed through router state over the query string', () => {
+    renderAuthenticatedLoginPage({
+        pathname: '/login',
+        search: '?redirect=%2F',
+        state: {from: {pathname: '/automation/projects/1052/templates/ai-email-classifier'}},
+    });
+
+    expect(screen.getByText('Template page')).toBeInTheDocument();
+});
+
+it('should fall back to the landing page when no location was recorded', () => {
+    renderAuthenticatedLoginPage('/login');
+
+    expect(screen.getByText('Landing page')).toBeInTheDocument();
+});
+
+it('should ignore an off-site location recorded in the query string', () => {
+    renderAuthenticatedLoginPage(`/login?redirect=${encodeURIComponent('https://evil.example')}`);
+
+    expect(screen.getByText('Landing page')).toBeInTheDocument();
+});

--- a/client/src/shared/auth/login-redirect-utils.ts
+++ b/client/src/shared/auth/login-redirect-utils.ts
@@ -1,5 +1,7 @@
 const LOGIN_PATH = '/login';
 const REDIRECT_PARAM = 'redirect';
+const REDIRECT_STORAGE_KEY = 'bytechef.loginRedirect';
+const SENTINEL_ORIGIN = 'https://bytechef.invalid';
 
 interface RedirectLocationI {
     hash?: string;
@@ -7,17 +9,34 @@ interface RedirectLocationI {
     search?: string;
 }
 
-const isSafeRedirect = (target: string): boolean =>
-    target.startsWith('/') && !target.startsWith('//') && !target.startsWith('/\\');
+const normalizeRedirect = (target: string): string | undefined => {
+    if (!target.startsWith('/')) {
+        return undefined;
+    }
+
+    let url: URL;
+
+    try {
+        url = new URL(target, SENTINEL_ORIGIN);
+    } catch {
+        return undefined;
+    }
+
+    if (url.origin !== SENTINEL_ORIGIN) {
+        return undefined;
+    }
+
+    return `${url.pathname}${url.search}${url.hash}`;
+};
 
 export const buildLoginPath = (location: RedirectLocationI): string => {
     if (location.pathname === LOGIN_PATH) {
         return LOGIN_PATH;
     }
 
-    const target = `${location.pathname}${location.search ?? ''}${location.hash ?? ''}`;
+    const target = normalizeRedirect(`${location.pathname}${location.search ?? ''}${location.hash ?? ''}`);
 
-    if (target === '/' || !isSafeRedirect(target)) {
+    if (!target || target === '/') {
         return LOGIN_PATH;
     }
 
@@ -27,9 +46,29 @@ export const buildLoginPath = (location: RedirectLocationI): string => {
 export const getLoginRedirect = (search: string): string | undefined => {
     const target = new URLSearchParams(search).get(REDIRECT_PARAM);
 
-    if (!target || !isSafeRedirect(target)) {
+    return target ? normalizeRedirect(target) : undefined;
+};
+
+export const rememberLoginRedirect = (target: string | undefined): void => {
+    try {
+        if (target) {
+            window.sessionStorage.setItem(REDIRECT_STORAGE_KEY, target);
+        } else {
+            window.sessionStorage.removeItem(REDIRECT_STORAGE_KEY);
+        }
+    } catch {
+        return;
+    }
+};
+
+export const consumeLoginRedirect = (): string | undefined => {
+    try {
+        const stored = window.sessionStorage.getItem(REDIRECT_STORAGE_KEY);
+
+        window.sessionStorage.removeItem(REDIRECT_STORAGE_KEY);
+
+        return stored ? normalizeRedirect(stored) : undefined;
+    } catch {
         return undefined;
     }
-
-    return target;
 };

--- a/client/src/shared/auth/login-redirect-utils.ts
+++ b/client/src/shared/auth/login-redirect-utils.ts
@@ -1,0 +1,35 @@
+const LOGIN_PATH = '/login';
+const REDIRECT_PARAM = 'redirect';
+
+interface RedirectLocationI {
+    hash?: string;
+    pathname: string;
+    search?: string;
+}
+
+const isSafeRedirect = (target: string): boolean =>
+    target.startsWith('/') && !target.startsWith('//') && !target.startsWith('/\\');
+
+export const buildLoginPath = (location: RedirectLocationI): string => {
+    if (location.pathname === LOGIN_PATH) {
+        return LOGIN_PATH;
+    }
+
+    const target = `${location.pathname}${location.search ?? ''}${location.hash ?? ''}`;
+
+    if (target === '/' || !isSafeRedirect(target)) {
+        return LOGIN_PATH;
+    }
+
+    return `${LOGIN_PATH}?${REDIRECT_PARAM}=${encodeURIComponent(target)}`;
+};
+
+export const getLoginRedirect = (search: string): string | undefined => {
+    const target = new URLSearchParams(search).get(REDIRECT_PARAM);
+
+    if (!target || !isSafeRedirect(target)) {
+        return undefined;
+    }
+
+    return target;
+};

--- a/client/src/shared/auth/tests/login-redirect-utils.test.ts
+++ b/client/src/shared/auth/tests/login-redirect-utils.test.ts
@@ -1,0 +1,49 @@
+import {describe, expect, it} from 'vitest';
+
+import {buildLoginPath, getLoginRedirect} from '../login-redirect-utils';
+
+describe('buildLoginPath', () => {
+    it('records the requested location so it survives a full page load', () => {
+        expect(buildLoginPath({pathname: '/automation/projects/1052/templates/ai-email-classifier'})).toBe(
+            '/login?redirect=%2Fautomation%2Fprojects%2F1052%2Ftemplates%2Fai-email-classifier'
+        );
+    });
+
+    it('keeps the query string and hash of the requested location', () => {
+        expect(buildLoginPath({hash: '#tab', pathname: '/automation/projects', search: '?environment=2'})).toBe(
+            '/login?redirect=%2Fautomation%2Fprojects%3Fenvironment%3D2%23tab'
+        );
+    });
+
+    it('records nothing for the landing page', () => {
+        expect(buildLoginPath({pathname: '/'})).toBe('/login');
+    });
+
+    it('records nothing when already on the login page', () => {
+        expect(buildLoginPath({pathname: '/login'})).toBe('/login');
+    });
+});
+
+describe('getLoginRedirect', () => {
+    it('reads back a recorded location', () => {
+        expect(getLoginRedirect('?redirect=%2Fautomation%2Fprojects%3Fenvironment%3D2')).toBe(
+            '/automation/projects?environment=2'
+        );
+    });
+
+    it('returns undefined when nothing was recorded', () => {
+        expect(getLoginRedirect('?company=acme')).toBeUndefined();
+    });
+
+    it('rejects an absolute url so a crafted link cannot bounce the user off site', () => {
+        expect(getLoginRedirect(`?redirect=${encodeURIComponent('https://evil.example')}`)).toBeUndefined();
+    });
+
+    it('rejects a protocol-relative url', () => {
+        expect(getLoginRedirect(`?redirect=${encodeURIComponent('//evil.example')}`)).toBeUndefined();
+    });
+
+    it('rejects a backslash-escaped protocol-relative url', () => {
+        expect(getLoginRedirect(`?redirect=${encodeURIComponent('/\\evil.example')}`)).toBeUndefined();
+    });
+});

--- a/client/src/shared/auth/tests/login-redirect-utils.test.ts
+++ b/client/src/shared/auth/tests/login-redirect-utils.test.ts
@@ -1,6 +1,6 @@
-import {describe, expect, it} from 'vitest';
+import {beforeEach, describe, expect, it} from 'vitest';
 
-import {buildLoginPath, getLoginRedirect} from '../login-redirect-utils';
+import {buildLoginPath, consumeLoginRedirect, getLoginRedirect, rememberLoginRedirect} from '../login-redirect-utils';
 
 describe('buildLoginPath', () => {
     it('records the requested location so it survives a full page load', () => {
@@ -45,5 +45,55 @@ describe('getLoginRedirect', () => {
 
     it('rejects a backslash-escaped protocol-relative url', () => {
         expect(getLoginRedirect(`?redirect=${encodeURIComponent('/\\evil.example')}`)).toBeUndefined();
+    });
+});
+
+describe('getLoginRedirect open-redirect rejection', () => {
+    it.each([
+        ['protocol-relative', '?redirect=%2F%2Fevil.example'],
+        ['backslash-prefixed', '?redirect=%2F%5Cevil.example'],
+        ['tab-obfuscated backslash', '?redirect=%2F%09%5Cevil.example'],
+        ['newline-obfuscated backslash', '?redirect=%2F%0A%5Cevil.example'],
+        ['carriage-return-obfuscated backslash', '?redirect=%2F%0D%5Cevil.example'],
+        ['absolute url', '?redirect=https%3A%2F%2Fevil.example'],
+        ['scheme-relative with credentials', '?redirect=%2F%2Fuser%40evil.example'],
+    ])('rejects a %s target', (_label, search) => {
+        expect(getLoginRedirect(search)).toBeUndefined();
+    });
+
+    it('keeps an ordinary same-origin path', () => {
+        expect(getLoginRedirect('?redirect=%2Fautomation%2Fprojects')).toBe('/automation/projects');
+    });
+});
+
+describe('rememberLoginRedirect / consumeLoginRedirect', () => {
+    beforeEach(() => {
+        window.sessionStorage.clear();
+    });
+
+    it('carries a destination across an external authentication round trip', () => {
+        rememberLoginRedirect('/automation/projects/1052');
+
+        expect(consumeLoginRedirect()).toBe('/automation/projects/1052');
+    });
+
+    it('yields the destination only once', () => {
+        rememberLoginRedirect('/automation/projects/1052');
+        consumeLoginRedirect();
+
+        expect(consumeLoginRedirect()).toBeUndefined();
+    });
+
+    it('rejects a stored destination that is not same-origin', () => {
+        window.sessionStorage.setItem('bytechef.loginRedirect', '/\u0009\\evil.example');
+
+        expect(consumeLoginRedirect()).toBeUndefined();
+    });
+
+    it('clears the stored destination when given nothing', () => {
+        rememberLoginRedirect('/automation/projects');
+        rememberLoginRedirect(undefined);
+
+        expect(consumeLoginRedirect()).toBeUndefined();
     });
 });


### PR DESCRIPTION
Fixes #5536.

Two paths send an unauthenticated visitor to the login page, and only one of them remembered where they were headed.

The route guard hands the intended location to the login page through router state, which works when a protected link is followed from a live session. But the bootstrap session check in `main.tsx` runs **before** the router exists, so it has to leave the page entirely — and a full browser navigation carries no router state. A cold-loaded deep link always takes that second path, which is why the working mechanism never got a chance to run.

### The fix

A new `shared/auth/login-redirect-utils.ts` records the destination in a query parameter, the only channel that survives a full page load:

- `buildLoginPath(location)` — appends `?redirect=<path+search+hash>`, and skips it when the target is `/` or already the login page, since those add a parameter that changes nothing.
- `getLoginRedirect(search)` — reads it back.

`main.tsx` now calls `window.location.replace(buildLoginPath(window.location))` instead of assigning `window.location.pathname`, which was what discarded the path while letting a query string survive — the behaviour that made the resulting login URL misleading.

`useFetchInterceptor` uses the same helper on its unauthenticated branch, so a session that ends mid-session also returns you to where you were.

### Open-redirect safety

`isSafeRedirect` accepts only same-origin relative paths — a target must start with `/` and must not start with `//` or `/\`. A crafted login link therefore cannot bounce a freshly authenticated user to another site.

### Verification

`npm run check` on a worktree at this branch: prettier, `eslint --max-warnings=0`, `tsc --noEmit`, and **351 test files / 3767 tests passing**. Includes new unit tests for both helpers and for the login page reading the parameter back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KwL2i65aw7YMmL5CPJs2Jm
