### PR TITLE
5537 - Stop reporting the end of a session as an error

### DIFF
--- a/client/src/config/tests/useFetchInterceptor.test.ts
+++ b/client/src/config/tests/useFetchInterceptor.test.ts
@@ -380,6 +380,52 @@ describe('useFetchInterceptor', () => {
             expect(hoisted.toastError).not.toHaveBeenCalled();
         });
 
+        it('clears the session instead of toasting an unauthenticated GraphQL error', async () => {
+            renderHook(() => useFetchInterceptor());
+
+            const response = createMockResponse({
+                jsonData: {
+                    errors: [{extensions: {errorCode: 'AUTHENTICATION_REQUIRED'}, message: 'Authentication required'}],
+                },
+                status: 200,
+                url: 'http://localhost/graphql',
+            });
+
+            hoisted.registeredHandlers!.response(response);
+
+            await act(async () => {
+                await new Promise((resolve) => setTimeout(resolve, 0));
+            });
+
+            expect(hoisted.toastError).not.toHaveBeenCalled();
+            expect(hoisted.clearAuthentication).toHaveBeenCalled();
+            expect(hoisted.clearCurrentWorkspaceId).toHaveBeenCalled();
+        });
+
+        it('still toasts GraphQL errors carrying an unrelated error code', async () => {
+            renderHook(() => useFetchInterceptor());
+
+            const response = createMockResponse({
+                jsonData: {errors: [{extensions: {errorCode: 'ACCESS_DENIED'}, message: 'Access denied'}]},
+                status: 200,
+                url: 'http://localhost/graphql',
+            });
+
+            hoisted.registeredHandlers!.response(response);
+
+            await act(async () => {
+                await new Promise((resolve) => setTimeout(resolve, 0));
+            });
+
+            expect(hoisted.toastError).toHaveBeenCalledWith('Error', {
+                description: 'Access denied',
+                id: 'fetch-error-200',
+                onAutoClose: expect.any(Function),
+                onDismiss: expect.any(Function),
+            });
+            expect(hoisted.clearAuthentication).not.toHaveBeenCalled();
+        });
+
         it('does not check GraphQL errors for non-graphql URLs', async () => {
             renderHook(() => useFetchInterceptor());
 

--- a/client/src/config/useFetchInterceptor.ts
+++ b/client/src/config/useFetchInterceptor.ts
@@ -36,6 +36,17 @@ function handlesErrorInline(url: string): boolean {
     return url.includes('/approval-form/');
 }
 
+const AUTHENTICATION_REQUIRED_ERROR_CODE = 'AUTHENTICATION_REQUIRED';
+
+interface GraphQlErrorI {
+    extensions?: {errorCode?: string};
+    message?: string;
+}
+
+function isAuthenticationError(error: GraphQlErrorI): boolean {
+    return error.extensions?.errorCode === AUTHENTICATION_REQUIRED_ERROR_CODE;
+}
+
 function resolveUrl(input: RequestInfo | URL): string {
     if (typeof input === 'string') {
         return input;
@@ -161,10 +172,19 @@ export default function useFetchInterceptor() {
 
                     clonedResponse
                         .json()
-                        .then((data: {errors?: Array<{message?: string}>}) => {
-                            if (data.errors?.length) {
+                        .then((data: {errors?: Array<GraphQlErrorI>}) => {
+                            const errors = data.errors ?? [];
+
+                            if (errors.some(isAuthenticationError)) {
+                                clearAuthentication();
+                                clearCurrentWorkspaceId();
+
+                                return;
+                            }
+
+                            if (errors.length) {
                                 const errorMessage = [
-                                    ...new Set(data.errors.map((error) => error.message || 'Unknown error')),
+                                    ...new Set(errors.map((error) => error.message || 'Unknown error')),
                                 ].join('\n');
 
                                 showErrorToast(toastId, 'Error', {description: errorMessage});

--- a/client/src/shared/layout/app-sidebar/AppSidebarFooter.test.tsx
+++ b/client/src/shared/layout/app-sidebar/AppSidebarFooter.test.tsx
@@ -5,7 +5,7 @@ import {beforeEach, describe, expect, it, vi} from 'vitest';
 
 import {AppSidebarFooter} from './AppSidebarFooter';
 
-const {logoutMock} = vi.hoisted(() => ({logoutMock: vi.fn()}));
+const {logoutMock} = vi.hoisted(() => ({logoutMock: vi.fn(() => Promise.resolve())}));
 
 vi.mock('@/shared/middleware/graphql', () => ({
     useEnvironmentsQuery: () => ({data: {environments: []}}),

--- a/client/src/shared/layout/app-sidebar/AppSidebarFooter.test.tsx
+++ b/client/src/shared/layout/app-sidebar/AppSidebarFooter.test.tsx
@@ -1,8 +1,11 @@
 import {render, screen, userEvent} from '@/shared/util/test-utils';
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
 import {MemoryRouter} from 'react-router-dom';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
 
 import {AppSidebarFooter} from './AppSidebarFooter';
+
+const {logoutMock} = vi.hoisted(() => ({logoutMock: vi.fn()}));
 
 vi.mock('@/shared/middleware/graphql', () => ({
     useEnvironmentsQuery: () => ({data: {environments: []}}),
@@ -29,7 +32,7 @@ vi.mock('@/shared/stores/useApplicationInfoStore', () => ({
 vi.mock('@/shared/stores/useAuthenticationStore', () => ({
     useAuthenticationStore: vi.fn(
         (selector: (state: {account: {email: string; id: number} | undefined; logout: () => void}) => unknown) =>
-            selector({account: {email: 'user@localhost.com', id: 1}, logout: vi.fn()})
+            selector({account: {email: 'user@localhost.com', id: 1}, logout: logoutMock})
     ),
 }));
 
@@ -88,5 +91,30 @@ describe('AppSidebarFooter', () => {
         expect(screen.getByText('Log Out')).toBeInTheDocument();
         // Email appears in both the trigger and the open menu.
         expect(screen.getAllByText('user@localhost.com').length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('drops the query cache on log out without refetching anything', async () => {
+        const user = userEvent.setup();
+        const queryClient = new QueryClient();
+
+        const cancelQueriesSpy = vi.spyOn(queryClient, 'cancelQueries');
+        const clearSpy = vi.spyOn(queryClient, 'clear');
+        const resetQueriesSpy = vi.spyOn(queryClient, 'resetQueries');
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AppSidebarFooter />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await user.click(screen.getByRole('button', {name: 'User menu'}));
+        await user.click(screen.getByText('Log Out'));
+
+        expect(resetQueriesSpy).not.toHaveBeenCalled();
+        expect(cancelQueriesSpy).toHaveBeenCalled();
+        expect(logoutMock).toHaveBeenCalled();
+        expect(clearSpy).toHaveBeenCalled();
     });
 });

--- a/client/src/shared/layout/app-sidebar/AppSidebarFooter.tsx
+++ b/client/src/shared/layout/app-sidebar/AppSidebarFooter.tsx
@@ -80,10 +80,14 @@ export function AppSidebarFooter() {
 
     const {data: workspaces} = useGetUserWorkspacesQuery(account?.id!, !!account);
 
-    const handleLogOutClick = () => {
+    const handleLogOutClick = async () => {
         analytics.reset();
-        queryClient.resetQueries();
-        logout();
+
+        await queryClient.cancelQueries();
+
+        await logout();
+
+        queryClient.clear();
     };
 
     const handlePlatformTypeChange = (value: string) => {

--- a/client/src/shared/stores/useAuthenticationStore.ts
+++ b/client/src/shared/stores/useAuthenticationStore.ts
@@ -19,7 +19,7 @@ export interface AuthenticationI {
     clearAuthentication: () => void;
     getAccount: () => Promise<UserI | undefined>;
     login: (email: string, password: string, rememberMe: boolean) => Promise<UserI | undefined>;
-    logout: () => void;
+    logout: () => Promise<void>;
     reset: () => void;
     verifyMfa: (code: string) => Promise<UserI | undefined>;
 }


### PR DESCRIPTION
Fixes #5537.

Two behaviours combined to report a successful log out as a failure.

### Logging out no longer refetches everything on the way out

The log-out handler reset the whole query cache *before* the log-out request completed, which made every active query refetch. Those refetches raced the log-out, so some arrived after the session was destroyed and came back unauthenticated.

It now cancels in-flight queries, awaits the log-out, and **clears** the cache rather than resetting it — there is nothing worth re-reading at the moment a session ends, so the race disappears rather than being narrowed.

### An unauthenticated GraphQL error is no longer toasted

A GraphQL response carries its errors inside a 2xx body, so the interceptor's unauthenticated branch — keyed on HTTP status — never saw them, and the GraphQL branch toasted the errors array unconditionally.

The server already marks this specific failure with a machine-readable code in the error extensions, so the client now matches on `extensions.errorCode === 'AUTHENTICATION_REQUIRED'` rather than on the human-readable message, which is free to change. On a match it drops the session and lets the route guard send the user to the login page — the same treatment an unauthenticated REST response already gets.

That second half is more than cosmetic: when a session expired mid-work, the user previously got a generic red toast and was left on a page that would never load, instead of being returned to the login page.

### Verification

`npm run check` on a worktree at this branch: prettier, `eslint --max-warnings=0`, `tsc --noEmit`, and **350 test files / 3757 tests passing**. Includes new tests covering the interceptor's authentication-error branch and the log-out sequence.

### Note

Touches `AppSidebarFooter.tsx`, which #5544 also edits, and `useFetchInterceptor.ts`, which #5546 also edits — different regions in both cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KwL2i65aw7YMmL5CPJs2Jm
