### PR TITLE
3757 - Add the condition and loop task-dispatcher reference pages

### DIFF
--- a/server/libs/modules/task-dispatchers/condition/src/main/resources/README.mdx
+++ b/server/libs/modules/task-dispatchers/condition/src/main/resources/README.mdx
@@ -1,0 +1,84 @@
+The Condition flow control evaluates a logical expression and routes execution down one of two
+paths: **true** or **false**. Use it for binary decisions — threshold checks, validation, or simple
+yes/no branching.
+
+## Usage
+
+### Step 1: Add Condition to your workflow
+
+Select **Condition** from the **Flows** component panel and add it where the workflow needs to
+branch. The node creates two paths, **True** and **False**.
+
+### Step 2: Choose how to express the condition
+
+The **Raw Expression** toggle decides which of two editors you get. See
+[Expressions](/reference/expressions) for the full expression language.
+
+**Raw Expression enabled** — write the expression directly in the **Expression** field:
+
+```
+${order_1.total} > 1000
+${user_1.verified} == true && ${user_1.age} >= 18
+```
+
+Values like `${order_1.total}` come from data pills — output produced by an earlier component or
+trigger, or a value you configured by hand.
+
+**Raw Expression disabled** — build the condition visually. Conditions are structured as **OR**
+groups, each containing one or more **AND** conditions:
+
+1. Click **Add OR Condition** to create a group.
+2. Inside a group, click **Add AND Condition** to add a comparison.
+3. Pick the comparison type: Boolean, Date Time, Number, or String.
+
+Each comparison takes **Value 1**, an **Operation**, and (for every operation except `Empty`)
+**Value 2**.
+
+### Step 3: Build the two paths
+
+Add the components that should run when the condition is true to the **True** path, and those for
+the false case to the **False** path.
+
+## Available operations
+
+The operations offered depend on the comparison type you pick.
+
+### String
+
+| Operation | Meaning |
+|---|---|
+| `Equals` | Exact match |
+| `Equals Ignore Case` | Case-insensitive match |
+| `Not Equals` | Not equal to |
+| `Contains` | Value 1 includes Value 2 |
+| `Not Contains` | Value 1 does not include Value 2 |
+| `Starts With` | Value 1 begins with Value 2 |
+| `Ends With` | Value 1 ends with Value 2 |
+| `Regex` | Value 1 matches the regular expression in Value 2 |
+| `Empty` | Value 1 is an empty string — takes no Value 2 |
+
+### Number
+
+| Operation | Meaning |
+|---|---|
+| `Equals` | Value 1 == Value 2 |
+| `Not Equals` | Value 1 != Value 2 |
+| `Greater` | Value 1 > Value 2 |
+| `Greater or Equals` | Value 1 >= Value 2 |
+| `Less` | Value 1 < Value 2 |
+| `Less or Equals` | Value 1 <= Value 2 |
+| `Empty` | Value 1 is absent — takes no Value 2 |
+
+### Boolean
+
+| Operation | Meaning |
+|---|---|
+| `Equals` | Value 1 == Value 2 |
+| `Not Equals` | Value 1 != Value 2 |
+
+### Date Time
+
+| Operation | Meaning |
+|---|---|
+| `After` | Value 1 is later than Value 2 |
+| `Before` | Value 1 is earlier than Value 2 |

--- a/server/libs/modules/task-dispatchers/condition/src/main/resources/README.mdx
+++ b/server/libs/modules/task-dispatchers/condition/src/main/resources/README.mdx
@@ -61,20 +61,20 @@ The operations offered depend on the comparison type you pick.
 
 | Operation | Meaning |
 |---|---|
-| `Equals` | Value 1 == Value 2 |
-| `Not Equals` | Value 1 != Value 2 |
-| `Greater` | Value 1 > Value 2 |
-| `Greater or Equals` | Value 1 >= Value 2 |
-| `Less` | Value 1 < Value 2 |
-| `Less or Equals` | Value 1 <= Value 2 |
+| `Equals` | Value 1 equals Value 2 |
+| `Not Equals` | Value 1 does not equal Value 2 |
+| `Greater` | Value 1 is greater than Value 2 |
+| `Greater or Equals` | Value 1 is greater than or equal to Value 2 |
+| `Less` | Value 1 is less than Value 2 |
+| `Less or Equals` | Value 1 is less than or equal to Value 2 |
 | `Empty` | Value 1 is absent — takes no Value 2 |
 
 ### Boolean
 
 | Operation | Meaning |
 |---|---|
-| `Equals` | Value 1 == Value 2 |
-| `Not Equals` | Value 1 != Value 2 |
+| `Equals` | Value 1 equals Value 2 |
+| `Not Equals` | Value 1 does not equal Value 2 |
 
 ### Date Time
 

--- a/server/libs/modules/task-dispatchers/loop/src/main/resources/README.mdx
+++ b/server/libs/modules/task-dispatchers/loop/src/main/resources/README.mdx
@@ -1,0 +1,41 @@
+**Loop** and **Loop Break** are two halves of one mechanism, and this section covers both. Loop
+repeats a set of actions — either once for each item in a list, or continuously; Loop Break is the
+statement that ends a continuous loop from inside its body.
+
+## Using Loop
+
+### Step 1: Add Loop to your workflow
+
+Select **Loop** from the **Flows** component panel and add it where execution should repeat.
+
+### Step 2: Choose the loop mode
+
+**Iterate over a list** — leave **Loop Forever** off, and set **List of Items** to the collection to
+walk. The value normally comes from a data pill produced by an earlier step:
+
+```
+${googleSheets_1.rows}
+${salesforce_1.accounts}
+${webhook_1.orders}
+```
+
+The loop ends on its own when the list is exhausted.
+
+**Loop forever** — switch **Loop Forever** on. No list is needed; the loop runs until a **Loop
+Break** inside its body ends it.
+
+### Step 3: Add the loop body
+
+Click **+** inside the loop to add the components that should run on every pass. When iterating over
+a list, the current element is available as `${item}`, and its fields as `${item.email}`,
+`${item.status}`, and so on.
+
+## Using Loop Break
+
+Loop Break takes no properties. Add it inside a loop body, normally on a branch of a
+[Condition](/reference/flow-controls/condition_v1), and reaching it ends the enclosing loop
+immediately — the rest of the current pass does not run.
+
+**Loop Forever needs a reachable break.** With **Loop Forever** on and no Loop Break that can
+actually fire, the loop never terminates; it consumes resources until the run hits its execution
+timeout. Confirm the body contains a break condition that will be met before enabling it.


### PR DESCRIPTION
Two commits against #3757, both covering task-dispatcher reference pages that the navigation revamp left behind.

### `Port the aws-ec2-update docs branch onto the reorganized platform docs tree`

Adds the `condition` and `loop` task-dispatcher `README.mdx` pages, rewritten against the reorganized platform docs tree so their links resolve in the new structure.

### `docs - Hide unreleased pages from the sidebar, fix an MDX break, and inventory Coming Soon`

Fixes an MDX break in the `condition` page introduced by the port.

### Note

The two commits are kept separate and in order — the second edits a file the first adds, so squashing them would hide the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KwL2i65aw7YMmL5CPJs2Jm
