### PR TITLE
520 - Name the two embedded webhook operations apart

### DIFF
--- a/server/ee/libs/embedded/embedded-webhook/embedded-webhook-public-rest/generated/src/main/java/com/bytechef/ee/embedded/webhook/public_/web/rest/AppEventTriggerApi.java
+++ b/server/ee/libs/embedded/embedded-webhook/embedded-webhook-public-rest/generated/src/main/java/com/bytechef/ee/embedded/webhook/public_/web/rest/AppEventTriggerApi.java
@@ -46,8 +46,8 @@ public interface AppEventTriggerApi {
 
     String PATH_EXECUTE_WORKFLOWS = "/app-events";
     /**
-     * POST /app-events : Execute workflows
-     * Execute workflows.
+     * POST /app-events : Trigger all subscribed workflows
+     * Fires an App Event for the connected user, starting every one of their enabled workflows that has an App Event trigger. Returns no body; inspect the runs through the workflow executions endpoints.
      *
      * @param xEnvironment The environment. (optional)
      * @return Successful operation. (status code 204)
@@ -63,8 +63,8 @@ public interface AppEventTriggerApi {
      */
     @Operation(
         operationId = "executeWorkflows",
-        summary = "Execute workflows",
-        description = "Execute workflows.",
+        summary = "Trigger all subscribed workflows",
+        description = "Fires an App Event for the connected user, starting every one of their enabled workflows that has an App Event trigger. Returns no body; inspect the runs through the workflow executions endpoints.",
         tags = { "app-event-trigger" },
         responses = {
             @ApiResponse(responseCode = "204", description = "Successful operation."),

--- a/server/ee/libs/embedded/embedded-webhook/embedded-webhook-public-rest/generated/src/main/java/com/bytechef/ee/embedded/webhook/public_/web/rest/RequestTriggerApi.java
+++ b/server/ee/libs/embedded/embedded-webhook/embedded-webhook-public-rest/generated/src/main/java/com/bytechef/ee/embedded/webhook/public_/web/rest/RequestTriggerApi.java
@@ -46,8 +46,8 @@ public interface RequestTriggerApi {
 
     String PATH_EXECUTE_WORKFLOW = "/workflows/{workflowUuid}";
     /**
-     * POST /workflows/{workflowUuid} : Execute workflows
-     * Execute workflows.
+     * POST /workflows/{workflowUuid} : Execute a workflow
+     * Executes a single workflow through its Request trigger and returns the result the workflow produces.
      *
      * @param workflowUuid The workflow uuid. (required)
      * @param xEnvironment The environment. (optional)
@@ -64,8 +64,8 @@ public interface RequestTriggerApi {
      */
     @Operation(
         operationId = "executeWorkflow",
-        summary = "Execute workflows",
-        description = "Execute workflows.",
+        summary = "Execute a workflow",
+        description = "Executes a single workflow through its Request trigger and returns the result the workflow produces.",
         tags = { "request-trigger" },
         responses = {
             @ApiResponse(responseCode = "200", description = "The result returned by the workflow's request trigger.", content = {

--- a/server/ee/libs/embedded/embedded-webhook/embedded-webhook-public-rest/openapi.yaml
+++ b/server/ee/libs/embedded/embedded-webhook/embedded-webhook-public-rest/openapi.yaml
@@ -1,4 +1,8 @@
 ---
+# NOTE: any route defined below with NO {externalUserId} path parameter (e.g. /app-events,
+# /workflows/{workflowUuid}) is JWT-only by design -- add its literal first path segment to
+# ConnectedUserConstants.FRONTEND_RESERVED_PATH_SEGMENTS (embedded-connected-user-api) so
+# EmbeddedApiKeyAuthenticationConverter rejects non-JWT tokens on it instead of minting a phantom ConnectedUser.
 openapi: "3.0.1"
 info:
   title: "The Embedded Public V1 API"
@@ -13,8 +17,10 @@ tags:
 paths:
   /app-events:
     post:
-      description: "Execute workflows."
-      summary: "Execute workflows"
+      description: "Fires an App Event for the connected user, starting every one of their enabled\
+        \ workflows that has an App Event trigger. Returns no body; inspect the runs through the\
+        \ workflow executions endpoints."
+      summary: "Trigger all subscribed workflows"
       tags:
         - "app-event-trigger"
       operationId: "executeWorkflows"
@@ -48,8 +54,9 @@ paths:
           $ref: "#/components/responses/notImplemented"
   /workflows/{workflowUuid}:
     post:
-      description: "Execute workflows."
-      summary: "Execute workflows"
+      description: "Executes a single workflow through its Request trigger and returns the result\
+        \ the workflow produces."
+      summary: "Execute a workflow"
       tags:
         - "request-trigger"
       operationId: "executeWorkflow"


### PR DESCRIPTION
Both public embedded webhook operations were published as **"Execute workflows"** with the description *"Execute workflows."*, so the API reference showed two entries a caller could not tell apart — and neither summary described what its operation actually does.

| Operation | Now reads |
|---|---|
| `POST /app-events` (App Event trigger) | **Trigger all subscribed workflows** — fires an App Event for the connected user, starting every enabled workflow with an App Event trigger; returns no body |
| `POST /workflows/{workflowUuid}` (Request trigger) | **Execute a workflow** — executes one workflow through its Request trigger and returns the result it produces |

### Scope

Only those two operations are touched. The source commit was taken with openapi-generator **7.24.0** while master is still on **7.22.0**, so porting it whole would have rewritten every generated file in the module — `@Generated` timestamps, reordered example JSON, an added import — with churn unrelated to this change, and bumped the recorded generator version as a side effect.

Instead the `openapi.yaml` change is applied as-is and the same summary/description text is applied to master's existing generated sources, leaving `.openapi-generator/VERSION` and the model classes untouched. A later regeneration on 7.24.0 will produce the same text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KwL2i65aw7YMmL5CPJs2Jm
