### PR TITLE
3839 - Remove the AI Agent tool feature flag

### DIFF
--- a/.agents/coming-soon-inventory.md
+++ b/.agents/coming-soon-inventory.md
@@ -119,7 +119,7 @@ arriving soon was not helping a reader.
 | [`/developer-guide/architecture`](/developer-guide/architecture) | **AI & Agents** | **all commented out** |
 | [`/platform/automation/ai/skills`](/platform/automation/ai/skills) | Create With AI; The Skills Copilot; Skills as Tools for Other Agents; Test with Evals | rendered |
 | [`/platform/automation/build/connections`](/platform/automation/build/connections) | Get Started; Managing Connections | rendered |
-| [`/platform/automation/build/workflows/ai/agent`](/platform/automation/build/workflows/ai/agent) | Chat Memory Slot; Chat memory vs Auto Memory; Guardrails Slot; Tools Slot; The Agent Utils toolset; Test with Evals; **Realtime Chat** | **1 of 6 commented out** |
+| [`/platform/automation/build/workflows/ai/agent`](/platform/automation/build/workflows/ai/agent) | Chat Memory Slot; Chat memory vs Auto Memory; Guardrails Slot; The Agent Utils toolset; Test with Evals; **Realtime Chat** | **1 of 6 commented out** |
 | [`/platform/automation/build/workflows/ai/agent/agent-utils`](/platform/automation/build/workflows/ai/agent/agent-utils) | Ask User Question; Agent Client; Auto Memory | rendered |
 | [`/platform/automation/build/workflows/flow-controls`](/platform/automation/build/workflows/flow-controls) | (page intro); Outputs; Graph | rendered |
 | [`/platform/automation/build/workflows/human-in-the-loop`](/platform/automation/build/workflows/human-in-the-loop) | Coming soon: expanded approvals | rendered |

--- a/client/src/pages/platform/workflow-editor/components/WorkflowNodesPopoverMenuComponentList.tsx
+++ b/client/src/pages/platform/workflow-editor/components/WorkflowNodesPopoverMenuComponentList.tsx
@@ -75,7 +75,6 @@ const WorkflowNodesPopoverMenuComponentList = memo(
         const ff_797 = getFeatureFlag('ff-797');
         const ff_3158 = getFeatureFlag('ff-3158');
         const ff_3827 = getFeatureFlag('ff-3827');
-        const ff_3839 = getFeatureFlag('ff-3839');
 
         const knowledgeBaseEnabled = useApplicationInfoStore((state) => state.ai.knowledgeBase.enabled);
 
@@ -131,10 +130,8 @@ const WorkflowNodesPopoverMenuComponentList = memo(
                 return [];
             }
 
-            return componentsWithActions
-                .filter((component) => hasClusterElementType(component, clusterElementType))
-                .filter(({name}) => (!ff_3839 && name !== 'aiAgent') || ff_3839);
-        }, [componentsWithActions, clusterElementType, ff_3839]);
+            return componentsWithActions.filter((component) => hasClusterElementType(component, clusterElementType));
+        }, [componentsWithActions, clusterElementType]);
 
         return (
             <div className={twMerge('rounded-lg', actionPanelOpen ? 'w-node-popover-width' : 'w-full')}>

--- a/docs/content/docs/platform/automation/build/workflows/ai/agent/index.mdx
+++ b/docs/content/docs/platform/automation/build/workflows/ai/agent/index.mdx
@@ -304,7 +304,7 @@ Tools turn workflow components into actions the agent can call mid-conversation.
 | MCP Client | [mcpClient/v1](/reference/components/mcp-client_v1) | Connect the agent to an external MCP server and expose that server's tools to the model. |
 | Vector store / Knowledge Base search | The Search tool cluster element on any [supported vector store](#compatible-vector-stores) or [knowledgeBase/v1](/reference/components/knowledgeBase_v1) | Let the agent search a vector store or Knowledge Base *on demand* — retrieval as a tool the model chooses to call, complementing the always-on [RAG slot](#rag-slot). |
 | Script | [script/v1](/reference/components/script_v1) | Run custom Python, JavaScript, or Ruby as a tool when no built-in action fits. |
-| AI Agent *(coming soon)* | [aiAgent/v1](/reference/components/ai-agent_v1) | Let one agent call another as a tool, for the agent-of-agents compositions described above — a sub-agent owns a self-contained domain and returns a result to its caller. |
+| AI Agent | [aiAgent/v1](/reference/components/ai-agent_v1) | Let one agent call another as a tool, for the agent-of-agents compositions described above — a sub-agent owns a self-contained domain and returns a result to its caller. |
 
 ### Supplying tool parameters with fromAi
 


### PR DESCRIPTION
Closes #3839.

Nesting an AI Agent as a tool of another agent is no longer gated, so `aiAgent` now appears in the cluster-element picker that fills an agent's **Tools** slot.

### Scope of the gate

`ff-3839` guarded exactly one list — `filteredClusterElementComponentDefinitions`. The action and trigger lists never excluded `aiAgent`, so the component was always available as an ordinary workflow step; it was specifically the agent-of-agents composition that was withheld.

With the flag gone the remaining filter is a single `hasClusterElementType` predicate.

### Docs

The Tools Slot row added in #5544 carried an italic `*(coming soon)*` marker, correct while the flag stood and wrong now, so it comes off. The **Tools Slot** section leaves the Coming Soon inventory's partial list with it.

That row was worth adding regardless of the flag: the page already stated in prose that an agent "exposes itself as a child tool that other agents can call", while the table a reader consults for what goes in that slot did not list it.

### Verification

`npm run check` on a worktree at this branch: prettier, `eslint --max-warnings=0`, `tsc --noEmit`, and **351 test files / 3779 tests passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KwL2i65aw7YMmL5CPJs2Jm
