### PR TITLE
2197 - Gate the management MCP server settings page behind ff-2197

### DIFF
--- a/client/src/shared/layout/Settings.tsx
+++ b/client/src/shared/layout/Settings.tsx
@@ -47,6 +47,10 @@ const Settings = ({sidebarNavItems, title = 'Settings'}: SettingsProps) => {
             );
         }
 
+        if (navItem.href === 'mcp-server') {
+            return isFeatureFlagEnabled('ff-2197');
+        }
+
         if (navItem.href === 'admin-api-keys') {
             return isFeatureFlagEnabled('ff-1024');
         }


### PR DESCRIPTION
Re-gates **Settings → MCP Server** behind `ff-2197` (#2197).

The management MCP server is on the upcoming release track — its docs page carries `comingSoon: true` — yet the settings page is reachable in production at `/automation/settings/mcp-server`, so the docs and the app disagree about whether the capability exists.

### Why the gate was missing

It existed and was removed in `9dc5ecf9808` ("4252 - removed feature flag ff-2197"), a four-line deletion made as part of unrelated work. Removing the whole `if` block did not restore an intended default of *visible* — it left the nav item falling through to the filter's trailing `return true`, which is how a coming-soon page ended up shipped. This puts the block back.

### Verification

`npm run check` on a worktree at this branch: prettier, `eslint --max-warnings=0`, `tsc --noEmit`, and **351 test files / 3779 tests passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KwL2i65aw7YMmL5CPJs2Jm
