### PR TITLE
5553 client - Re-seed cluster root data when the canvas reopens

### DIFF
--- a/client/src/pages/platform/workflow-editor/hooks/useWorkflowEditorLayout.test.ts
+++ b/client/src/pages/platform/workflow-editor/hooks/useWorkflowEditorLayout.test.ts
@@ -7,13 +7,13 @@ import {beforeEach, describe, expect, it} from 'vitest';
 import useWorkflowEditorLayout from './useWorkflowEditorLayout';
 
 const aiAgentRootNode = {
-    clusterElements: {tools: [{name: 'stripe_1'}]},
+    clusterElements: {tools: [{name: 'stripe_1', type: 'stripe/v1/createCustomer'}]},
     clusterRoot: true,
     componentName: 'aiAgent',
     name: 'aiAgent_1',
     type: 'aiAgent/v1/chat',
     workflowNodeName: 'aiAgent_1',
-} as unknown as NodeDataType;
+} satisfies NodeDataType;
 
 beforeEach(() => {
     useWorkflowEditorStore.setState({clusterElementsCanvasOpen: false, rootClusterElementNodeData: undefined});

--- a/client/src/pages/platform/workflow-editor/hooks/useWorkflowEditorLayout.test.ts
+++ b/client/src/pages/platform/workflow-editor/hooks/useWorkflowEditorLayout.test.ts
@@ -1,0 +1,99 @@
+import useWorkflowEditorStore from '@/pages/platform/workflow-editor/stores/useWorkflowEditorStore';
+import useWorkflowNodeDetailsPanelStore from '@/pages/platform/workflow-editor/stores/useWorkflowNodeDetailsPanelStore';
+import {NodeDataType} from '@/shared/types';
+import {act, renderHook} from '@testing-library/react';
+import {beforeEach, describe, expect, it} from 'vitest';
+
+import useWorkflowEditorLayout from './useWorkflowEditorLayout';
+
+const aiAgentRootNode = {
+    clusterElements: {tools: [{name: 'stripe_1'}]},
+    clusterRoot: true,
+    componentName: 'aiAgent',
+    name: 'aiAgent_1',
+    type: 'aiAgent/v1/chat',
+    workflowNodeName: 'aiAgent_1',
+} as unknown as NodeDataType;
+
+beforeEach(() => {
+    useWorkflowEditorStore.setState({clusterElementsCanvasOpen: false, rootClusterElementNodeData: undefined});
+    useWorkflowNodeDetailsPanelStore.setState({currentNode: undefined});
+});
+
+describe('useWorkflowEditorLayout', () => {
+    it('seeds the root cluster element node data when the canvas opens on a main cluster root', () => {
+        renderHook(() => useWorkflowEditorLayout());
+
+        act(() => {
+            useWorkflowEditorStore.setState({clusterElementsCanvasOpen: true});
+            useWorkflowNodeDetailsPanelStore.setState({currentNode: aiAgentRootNode});
+        });
+
+        expect(useWorkflowEditorStore.getState().rootClusterElementNodeData).toEqual(aiAgentRootNode);
+    });
+
+    it('ignores a node that is not a main cluster root', () => {
+        renderHook(() => useWorkflowEditorLayout());
+
+        act(() => {
+            useWorkflowEditorStore.setState({clusterElementsCanvasOpen: true});
+            useWorkflowNodeDetailsPanelStore.setState({
+                currentNode: {...aiAgentRootNode, clusterRoot: false} as NodeDataType,
+            });
+        });
+
+        expect(useWorkflowEditorStore.getState().rootClusterElementNodeData).toBeUndefined();
+    });
+
+    it('ignores a nested cluster root', () => {
+        renderHook(() => useWorkflowEditorLayout());
+
+        act(() => {
+            useWorkflowEditorStore.setState({clusterElementsCanvasOpen: true});
+            useWorkflowNodeDetailsPanelStore.setState({
+                currentNode: {...aiAgentRootNode, isNestedClusterRoot: true} as NodeDataType,
+            });
+        });
+
+        expect(useWorkflowEditorStore.getState().rootClusterElementNodeData).toBeUndefined();
+    });
+
+    it('clears the cluster element state when the canvas is closed', () => {
+        const {result} = renderHook(() => useWorkflowEditorLayout());
+
+        act(() => {
+            result.current.handleClusterElementsCanvasOpenChange(true);
+            useWorkflowNodeDetailsPanelStore.setState({currentNode: aiAgentRootNode});
+        });
+
+        act(() => {
+            result.current.handleClusterElementsCanvasOpenChange(false);
+        });
+
+        expect(useWorkflowEditorStore.getState().rootClusterElementNodeData).toBeUndefined();
+        expect(useWorkflowEditorStore.getState().clusterElementsCanvasOpen).toBe(false);
+    });
+
+    it('re-seeds when the canvas is reopened on the same cluster root', () => {
+        const {result} = renderHook(() => useWorkflowEditorLayout());
+
+        act(() => {
+            result.current.handleClusterElementsCanvasOpenChange(true);
+            useWorkflowNodeDetailsPanelStore.setState({currentNode: aiAgentRootNode});
+        });
+
+        expect(useWorkflowEditorStore.getState().rootClusterElementNodeData).toEqual(aiAgentRootNode);
+
+        act(() => {
+            result.current.handleClusterElementsCanvasOpenChange(false);
+        });
+
+        expect(useWorkflowEditorStore.getState().rootClusterElementNodeData).toBeUndefined();
+
+        act(() => {
+            result.current.handleClusterElementsCanvasOpenChange(true);
+        });
+
+        expect(useWorkflowEditorStore.getState().rootClusterElementNodeData).toEqual(aiAgentRootNode);
+    });
+});

--- a/client/src/pages/platform/workflow-editor/hooks/useWorkflowEditorLayout.ts
+++ b/client/src/pages/platform/workflow-editor/hooks/useWorkflowEditorLayout.ts
@@ -5,6 +5,7 @@ import {useShallow} from 'zustand/shallow';
 
 const useWorkflowEditorLayout = () => {
     const currentNode = useWorkflowNodeDetailsPanelStore((state) => state.currentNode);
+    const clusterElementsCanvasOpen = useWorkflowEditorStore((state) => state.clusterElementsCanvasOpen);
     const {
         setClusterElementsCanvasOpen,
         setMainClusterRootComponentDefinition,
@@ -35,10 +36,10 @@ const useWorkflowEditorLayout = () => {
     };
 
     useEffect(() => {
-        if (isMainRootClusterElement) {
+        if (clusterElementsCanvasOpen && isMainRootClusterElement) {
             setRootClusterElementNodeData(currentNode);
         }
-    }, [isMainRootClusterElement, setRootClusterElementNodeData, currentNode]);
+    }, [clusterElementsCanvasOpen, isMainRootClusterElement, setRootClusterElementNodeData, currentNode]);
 
     return {
         handleClusterElementsCanvasOpenChange,


### PR DESCRIPTION
Fixes #5553.

## Problem

Reopening the AI Agent editor on an agent that was already open renders it as if the agent were brand new: **Model** shows `Select a model...`, **Instructions** and **User input** are empty, and both lists read `No tools added yet` / `No skills added yet`.

The agent is not actually empty. Switching to the advanced editor in the same dialog shows the full configuration — model, chat memory, RAG with its vector store, and the attached tools — because the canvas renders from the workflow definition rather than from editor state. Nothing is lost on disk; a reload restores the simple editor.

## Steps to reproduce

1. Open a workflow containing an `aiAgent` cluster root that has a model and at least one tool.
2. Click the agent node — the cluster elements canvas dialog opens and the editor hydrates correctly.
3. Close the dialog entirely.
4. Click the same agent node again.

The simple editor is now blank while the advanced canvas still shows everything.

## Cause

Everything in the simple editor hydrates from `rootClusterElementNodeData` in `useWorkflowEditorStore`, seeded by a single effect in `useWorkflowEditorLayout`.

Closing the canvas clears that slot. But the seeding effect was gated only on `isMainRootClusterElement`, and reopening on the *same* agent changes neither that flag nor `currentNode`'s object identity. None of the effect's dependencies moved, so it never re-ran and the slot stayed `undefined`.

The divergence between the two views is exactly this: the advanced canvas reads the workflow definition, the simple editor reads the store slot.

## Fix

Gate the effect on `clusterElementsCanvasOpen`, in both the condition and the dependency array.

It is the honest discriminator — `useNodeClick` is what opens the canvas, and every consumer of the slot is canvas-scoped (`handleDeleteTask` already guards on both flags together). It also keeps the clear intact: the re-run this dependency causes on close returns early, so closing is not undone.

Five lines of production change.

## Tests

The hook had no test file. This adds one covering the regression itself plus the surrounding contract:

- `re-seeds when the canvas is reopened on the same cluster root` — the regression, confirmed failing against unmodified `master` before the fix
- `seeds the root cluster element node data when the canvas opens on a main cluster root`
- `ignores a node that is not a main cluster root`
- `ignores a nested cluster root`
- `clears the cluster element state when the canvas is closed`

`npm run check` passes: prettier, eslint and tsc clean, 353 test files and 3794 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)