### PR TITLE
5555 Evaluate cluster element parameters leniently for dynamic properties

### DIFF
--- a/server/libs/atlas/atlas-configuration/atlas-configuration-api/src/main/java/com/bytechef/atlas/configuration/domain/WorkflowTask.java
+++ b/server/libs/atlas/atlas-configuration/atlas-configuration-api/src/main/java/com/bytechef/atlas/configuration/domain/WorkflowTask.java
@@ -108,7 +108,11 @@ public class WorkflowTask implements Task, Serializable {
     }
 
     public Map<String, ?> evaluateParameters(Map<String, ?> context, Evaluator evaluator) {
-        WorkflowTask workflowTask = new WorkflowTask(evaluator.evaluate(toMap(), context));
+        return evaluateParameters(context, evaluator, false);
+    }
+
+    public Map<String, ?> evaluateParameters(Map<String, ?> context, Evaluator evaluator, boolean lenient) {
+        WorkflowTask workflowTask = new WorkflowTask(evaluator.evaluate(toMap(), context, lenient));
 
         return workflowTask.getParameters();
     }

--- a/server/libs/platform/platform-configuration/platform-configuration-api/src/main/java/com/bytechef/platform/configuration/domain/WorkflowTrigger.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-api/src/main/java/com/bytechef/platform/configuration/domain/WorkflowTrigger.java
@@ -94,7 +94,11 @@ public class WorkflowTrigger implements Serializable, Trigger {
     }
 
     public Map<String, ?> evaluateParameters(Map<String, ?> context, Evaluator evaluator) {
-        WorkflowTrigger workflowTrigger = new WorkflowTrigger(evaluator.evaluate(toMap(), context));
+        return evaluateParameters(context, evaluator, false);
+    }
+
+    public Map<String, ?> evaluateParameters(Map<String, ?> context, Evaluator evaluator, boolean lenient) {
+        WorkflowTrigger workflowTrigger = new WorkflowTrigger(evaluator.evaluate(toMap(), context, lenient));
 
         return workflowTrigger.getParameters();
     }

--- a/server/libs/platform/platform-configuration/platform-configuration-service/src/main/java/com/bytechef/platform/configuration/facade/WorkflowNodeDynamicPropertiesFacadeImpl.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-service/src/main/java/com/bytechef/platform/configuration/facade/WorkflowNodeDynamicPropertiesFacadeImpl.java
@@ -183,8 +183,8 @@ public class WorkflowNodeDynamicPropertiesFacadeImpl implements WorkflowNodeDyna
 
                 return triggerDefinitionFacade.executeDynamicProperties(
                     workflowNodeType.name(), workflowNodeType.version(),
-                    workflowNodeType.operation(), propertyName, workflowTrigger.evaluateParameters(inputs, evaluator),
-                    lookupDependsOnPaths, connectionId);
+                    workflowNodeType.operation(), propertyName,
+                    workflowTrigger.evaluateParameters(inputs, evaluator, true), lookupDependsOnPaths, connectionId);
             })
             .orElseGet(() -> {
                 WorkflowTask workflowTask = workflow.getTask(workflowNodeName);
@@ -196,7 +196,7 @@ public class WorkflowNodeDynamicPropertiesFacadeImpl implements WorkflowNodeDyna
                         taskDispatcherDefinitionService.executeDynamicProperties(
                             workflowNodeType.name(), workflowNodeType.version(), propertyName,
                             workflowTask.evaluateParameters(
-                                (Map<String, Object>) inputs, evaluator)));
+                                (Map<String, Object>) inputs, evaluator, true)));
                 }
 
                 Map<String, ?> outputs = workflowNodeOutputFacade.getPreviousWorkflowNodeSampleOutputs(
@@ -205,7 +205,7 @@ public class WorkflowNodeDynamicPropertiesFacadeImpl implements WorkflowNodeDyna
                 return actionDefinitionFacade.executeDynamicProperties(
                     workflowNodeType.name(), workflowNodeType.version(), workflowNodeType.operation(), propertyName,
                     workflowTask.evaluateParameters(
-                        MapUtils.concat((Map<String, Object>) inputs, (Map<String, Object>) outputs), evaluator),
+                        MapUtils.concat((Map<String, Object>) inputs, (Map<String, Object>) outputs), evaluator, true),
                     lookupDependsOnPaths, workflowId, connectionId);
             });
     }

--- a/server/libs/platform/platform-configuration/platform-configuration-service/src/main/java/com/bytechef/platform/configuration/facade/WorkflowNodeDynamicPropertiesFacadeImpl.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-service/src/main/java/com/bytechef/platform/configuration/facade/WorkflowNodeDynamicPropertiesFacadeImpl.java
@@ -134,7 +134,7 @@ public class WorkflowNodeDynamicPropertiesFacadeImpl implements WorkflowNodeDyna
         return clusterElementDefinitionFacade.executeDynamicProperties(
             clusterElementWorkflowNodeType.name(), clusterElementWorkflowNodeType.version(),
             clusterElementWorkflowNodeType.operation(), propertyName,
-            evaluator.evaluate(clusterElement.getParameters(), context),
+            evaluator.evaluate(clusterElement.getParameters(), context, true),
             workflowTask.getExtensions(), lookupDependsOnPaths, connectionId, clusterElementConnectionIds,
             clusterElementInputParameters);
     }
@@ -149,13 +149,14 @@ public class WorkflowNodeDynamicPropertiesFacadeImpl implements WorkflowNodeDyna
 
             if (value instanceof ClusterElement clusterElement) {
                 result.put(
-                    clusterElement.getWorkflowNodeName(), evaluator.evaluate(clusterElement.getParameters(), context));
+                    clusterElement.getWorkflowNodeName(),
+                    evaluator.evaluate(clusterElement.getParameters(), context, true));
             } else if (value instanceof List<?> list) {
                 for (Object item : list) {
                     if (item instanceof ClusterElement clusterElement) {
                         result.put(
                             clusterElement.getWorkflowNodeName(),
-                            evaluator.evaluate(clusterElement.getParameters(), context));
+                            evaluator.evaluate(clusterElement.getParameters(), context, true));
                     }
                 }
             }

--- a/server/libs/platform/platform-configuration/platform-configuration-service/src/test/java/com/bytechef/platform/configuration/facade/WorkflowNodeDynamicPropertiesFacadeTest.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-service/src/test/java/com/bytechef/platform/configuration/facade/WorkflowNodeDynamicPropertiesFacadeTest.java
@@ -430,7 +430,7 @@ class WorkflowNodeDynamicPropertiesFacadeTest {
         when(workflowTask.getType()).thenReturn("httpClient/v1/get");
         when(workflowTask.getName()).thenReturn(workflowNodeName);
         doReturn(Map.of()).when(workflowTask)
-            .evaluateParameters(anyMap(), any(Evaluator.class));
+            .evaluateParameters(anyMap(), any(Evaluator.class), anyBoolean());
 
         doReturn(Map.of()).when(workflowNodeOutputFacade)
             .getPreviousWorkflowNodeSampleOutputs(eq(workflowId), eq(workflowNodeName), eq(environmentId));
@@ -454,6 +454,8 @@ class WorkflowNodeDynamicPropertiesFacadeTest {
             verify(actionDefinitionFacade).executeDynamicProperties(
                 eq("httpClient"), eq(1), eq("get"), eq(propertyName), anyMap(), anyList(), eq(workflowId),
                 eq(connectionId));
+
+            verify(workflowTask).evaluateParameters(anyMap(), any(Evaluator.class), eq(true));
         }
     }
 
@@ -479,7 +481,7 @@ class WorkflowNodeDynamicPropertiesFacadeTest {
 
         when(workflowTrigger.getType()).thenReturn("github/v1/newIssue");
         doReturn(Map.of()).when(workflowTrigger)
-            .evaluateParameters(anyMap(), any(Evaluator.class));
+            .evaluateParameters(anyMap(), any(Evaluator.class), anyBoolean());
 
         List<Property> expectedProperties = List.of(mock(Property.class));
 
@@ -521,7 +523,7 @@ class WorkflowNodeDynamicPropertiesFacadeTest {
         when(workflow.getTask(workflowNodeName)).thenReturn(workflowTask);
         when(workflowTask.getType()).thenReturn("subflow/v1");
         doReturn(Map.of()).when(workflowTask)
-            .evaluateParameters(anyMap(), any(Evaluator.class));
+            .evaluateParameters(anyMap(), any(Evaluator.class), anyBoolean());
 
         List<com.bytechef.platform.workflow.task.dispatcher.domain.Property> expectedProperties = List.of();
 

--- a/server/libs/platform/platform-configuration/platform-configuration-service/src/test/java/com/bytechef/platform/configuration/facade/WorkflowNodeDynamicPropertiesFacadeTest.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-service/src/test/java/com/bytechef/platform/configuration/facade/WorkflowNodeDynamicPropertiesFacadeTest.java
@@ -18,6 +18,7 @@ package com.bytechef.platform.configuration.facade;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
@@ -25,6 +26,7 @@ import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -164,7 +166,7 @@ class WorkflowNodeDynamicPropertiesFacadeTest {
             clusterElementWorkflowNodeName, expectedConnectionId, "otherElement", 200L);
 
         doReturn(clusterElementParameters).when(evaluator)
-            .evaluate(anyMap(), anyMap());
+            .evaluate(anyMap(), anyMap(), anyBoolean());
         when(clusterElementDefinitionFacade.executeDynamicProperties(
             eq("openai"), eq(1), eq("chat"), eq(propertyName), anyMap(), anyMap(), eq(lookupDependsOnPaths),
             eq(expectedConnectionId), eq(expectedConnectionIds), anyMap()))
@@ -238,7 +240,7 @@ class WorkflowNodeDynamicPropertiesFacadeTest {
         List<Property> expectedProperties = List.of(mock(Property.class));
 
         doReturn(Map.of()).when(evaluator)
-            .evaluate(anyMap(), anyMap());
+            .evaluate(anyMap(), anyMap(), anyBoolean());
         when(clusterElementDefinitionFacade.executeDynamicProperties(
             eq("openai"), eq(1), eq("chat"), eq(propertyName), anyMap(), anyMap(), anyList(), isNull(), anyMap(),
             anyMap()))
@@ -311,7 +313,7 @@ class WorkflowNodeDynamicPropertiesFacadeTest {
         List<Property> expectedProperties = List.of(mock(Property.class));
 
         doReturn(Map.of()).when(evaluator)
-            .evaluate(anyMap(), anyMap());
+            .evaluate(anyMap(), anyMap(), anyBoolean());
         when(clusterElementDefinitionFacade.executeDynamicProperties(
             eq("fieldMapper"), eq(1), eq("map"), eq(propertyName), anyMap(), anyMap(), anyList(), isNull(), anyMap(),
             anyMap()))
@@ -329,6 +331,80 @@ class WorkflowNodeDynamicPropertiesFacadeTest {
 
             verify(workflowNodeOutputFacade).getPreviousWorkflowNodeSampleOutputs(
                 workflowId, workflowNodeName, environmentId);
+        }
+    }
+
+    @Test
+    void testGetClusterElementDynamicPropertiesEvaluatesParametersLeniently() {
+        String workflowId = "workflow1";
+        String workflowNodeName = "aiAgent_1";
+        String clusterElementTypeName = "tools";
+        String clusterElementWorkflowNodeName = "dataTable_5";
+        String propertyName = "values";
+        long environmentId = 1L;
+
+        when(workflowTestConfigurationService.fetchWorkflowTestConfiguration(workflowId, environmentId))
+            .thenReturn(Optional.empty());
+        doReturn(Map.of()).when(workflowTestConfigurationService)
+            .getWorkflowTestConfigurationInputs(workflowId, environmentId);
+
+        Workflow workflow = mock(Workflow.class);
+        WorkflowTask workflowTask = mock(WorkflowTask.class);
+
+        when(workflowService.getWorkflow(workflowId)).thenReturn(workflow);
+        when(workflow.getTask(workflowNodeName)).thenReturn(workflowTask);
+        when(workflowTask.getType()).thenReturn("aiAgent/v1/chat");
+        when(workflowTask.getName()).thenReturn(workflowNodeName);
+
+        doReturn(Map.of()).when(workflowNodeOutputFacade)
+            .getPreviousWorkflowNodeSampleOutputs(eq(workflowId), eq(workflowNodeName), eq(environmentId));
+
+        ClusterElementType clusterElementType = new ClusterElementType("tools", "tools", "Tools");
+
+        when(clusterElementDefinitionService.getClusterElementType("aiAgent", 1, clusterElementTypeName))
+            .thenReturn(clusterElementType);
+
+        ClusterElement clusterElement = mock(ClusterElement.class);
+
+        Map<String, Object> clusterElementParameters = Map.of("values", Map.of("handover_reason", "=fromAi()"));
+
+        when(clusterElement.getType()).thenReturn("dataTable/v1/updateRecord");
+        doReturn(clusterElementParameters).when(clusterElement)
+            .getParameters();
+
+        ClusterElementMap clusterElementMap = mock(ClusterElementMap.class);
+
+        when(clusterElementMap.getClusterElement(clusterElementType, clusterElementWorkflowNodeName))
+            .thenReturn(clusterElement);
+        doReturn(Map.of()).when(workflowTask)
+            .getExtensions();
+
+        Map<String, ClusterElement> tools = Map.of("tools", clusterElement);
+
+        doReturn(tools.entrySet()).when(clusterElementMap)
+            .entrySet();
+
+        List<Property> expectedProperties = List.of(mock(Property.class));
+
+        doReturn(clusterElementParameters).when(evaluator)
+            .evaluate(anyMap(), anyMap(), eq(true));
+
+        when(clusterElementDefinitionFacade.executeDynamicProperties(
+            eq("dataTable"), eq(1), eq("updateRecord"), eq(propertyName), anyMap(), anyMap(), anyList(), isNull(),
+            anyMap(), anyMap()))
+                .thenReturn(expectedProperties);
+
+        try (MockedStatic<ClusterElementMap> mockedClusterElementMap = mockStatic(ClusterElementMap.class)) {
+            mockedClusterElementMap.when(() -> ClusterElementMap.of(anyMap()))
+                .thenReturn(clusterElementMap);
+
+            List<Property> result = workflowNodeDynamicPropertiesFacade.getClusterElementDynamicProperties(
+                workflowId, workflowNodeName, clusterElementTypeName, clusterElementWorkflowNodeName,
+                propertyName, List.of(), environmentId);
+
+            assertEquals(expectedProperties, result);
+
+            verify(evaluator, never()).evaluate(anyMap(), anyMap());
         }
     }
 


### PR DESCRIPTION
Closes #5555

Editing a property of an AI agent tool popped a red `Bad Request` toast echoing the raw parameter value
(`fromAi requires at least a name argument.`, `Invalid formula expression: ...`) while a formula was being
typed.

The toast does not come from the save — it comes from the refetch the save triggers. Every parameter write
invalidates the dynamic properties query, and `WorkflowNodeDynamicPropertiesFacadeImpl` evaluated parameters
through the **strict** evaluator overload, so a parameter that cannot be evaluated at design time threw out
of the facade → HTTP 400 → toast. This is not limited to half-typed input: a *finished* `=fromAi(...)` is a
runtime placeholder the model fills in, and is not meaningfully evaluable while editing.

Every design-time branch of this facade now evaluates leniently, so an unevaluable parameter is passed
through as its raw string instead of failing the whole request:

1. **Cluster elements** — the three `evaluator.evaluate(clusterElement.getParameters(), context)` call sites
   now pass `lenient = true`. This is the path that produced the reported bug (an AI agent tool).
2. **Action, task dispatcher and trigger** — these went through the strict two-argument
   `evaluateParameters`, so a plain node hit the same 400. `WorkflowTask` and `WorkflowTrigger` gain a
   lenient overload and the three design-time branches pass `true`.

The existing two-argument `evaluateParameters` keeps its strict behaviour by delegating with `false`, so
workflow **execution** still fails loudly on an invalid expression — leniency is scoped to editor preview.

## Test

`WorkflowNodeDynamicPropertiesFacadeTest.testGetClusterElementDynamicPropertiesEvaluatesParametersLeniently`
reproduces the original stack (`IllegalArgumentException` escaping `getClusterElementDynamicProperties`)
before the change and passes after it. The existing cluster element tests move their evaluator stubs to the
lenient overload, and the action path asserts `evaluateParameters(..., true)`.

## Not covered here

`WorkflowNodeOptionFacadeImpl` has the same defect in its own right — all of its paths evaluate strictly, so
an options lookup can 400 the same way. Left out to keep this PR to the dynamic properties path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)