### PR TITLE
5555 Stub the lenient evaluator overload in the output facade test

### DIFF
--- a/server/libs/platform/platform-configuration/platform-configuration-service/src/test/java/com/bytechef/platform/configuration/facade/WorkflowNodeOutputFacadeTest.java
+++ b/server/libs/platform/platform-configuration/platform-configuration-service/src/test/java/com/bytechef/platform/configuration/facade/WorkflowNodeOutputFacadeTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -268,7 +269,7 @@ class WorkflowNodeOutputFacadeTest {
             WORKFLOW_ID, "action2", ENVIRONMENT_ID))
                 .thenReturn(List.of());
 
-        when(evaluator.evaluate(any(), any()))
+        when(evaluator.evaluate(any(), any(), anyBoolean()))
             .thenAnswer(invocation -> invocation.getArgument(0));
 
         OutputResponse dynamicOutput = new OutputResponse(null, Map.of("dynamic", "result"), null);
@@ -346,7 +347,7 @@ class WorkflowNodeOutputFacadeTest {
             eq(WORKFLOW_ID), anyString(), eq(ENVIRONMENT_ID)))
                 .thenReturn(List.of());
 
-        when(evaluator.evaluate(any(), any()))
+        when(evaluator.evaluate(any(), any(), anyBoolean()))
             .thenAnswer(invocation -> invocation.getArgument(0));
 
         OutputResponse dynamic2Output = new OutputResponse(null, Map.of("d2", "r2"), null);
@@ -436,7 +437,7 @@ class WorkflowNodeOutputFacadeTest {
         when(actionDefinitionService.isDynamicOutputDefined("component", 1, "action1")).thenReturn(true);
         when(workflowTestConfigurationService.getWorkflowTestConfigurationInputs(WORKFLOW_ID, ENVIRONMENT_ID))
             .thenReturn(Map.of());
-        when(evaluator.evaluate(any(), any())).thenThrow(new RuntimeException("evaluation error"));
+        when(evaluator.evaluate(any(), any(), anyBoolean())).thenThrow(new RuntimeException("evaluation error"));
 
         try (MockedStatic<WorkflowTrigger> workflowTriggerStatic = mockStatic(WorkflowTrigger.class)) {
             workflowTriggerStatic.when(() -> WorkflowTrigger.of(workflow))


### PR DESCRIPTION
Fixes the `server` check on `master`, red since #5562 (`4bf68bfd7ee`).

`WorkflowNodeOutputFacadeTest` failed on two tests:

```
WorkflowNodeOutputFacadeTest > testSampleOutputsCacheDeduplicatesAcrossMultipleDynamicNodes() FAILED
WorkflowNodeOutputFacadeTest > testSampleOutputsCachePreventsDuplicateComputation() FAILED
    org.springframework.expression.EvaluationException: Couldn't evaluate expression with sample output
    Caused by: org.mockito.exceptions.misusing.PotentialStubbingProblem
```

#5562 made `WorkflowTask.evaluateParameters(context, evaluator)` delegate to the new lenient overload with
`false`. Against a real `SpelEvaluator` that is a no-op — both overloads run the same `evaluateInternal`
with the same flag — but a **mocked** `Evaluator` now sees `evaluate(map, context, false)` where this test
stubbed `evaluate(map, context)`, and strict stubbing turns that mismatch into a failure. This test exercises
a real `WorkflowTask` against a mock evaluator, which is why it noticed and the facade's own tests did not.

The three stubs move to `evaluate(any(), any(), anyBoolean())`, matching how `0_732` already stubs this file.

The third stub is moved for a different reason worth calling out:
`testGetWorkflowNodeOutputThrowsEvaluationExceptionOnParameterEvaluationFailure` was **passing on the
stubbing exception** rather than on its own `thenThrow` — it asserts that an `EvaluationException` surfaces,
and `PotentialStubbingProblem` was being wrapped into one. It now passes for the intended reason.

## Test

Full `platform-configuration-service` suite: 122/122 (reproduced the 2 failures first, on `4bf68bfd7ee`).
`spotlessCheck` clean. Also ran `platform-workflow-test-service` and `atlas-configuration-api`, the other
modules whose tests stub a mocked evaluator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)