### PR TITLE
5559 Keep an AI agent nested in a task dispatcher intact

### DIFF
--- a/client/src/pages/platform/workflow-editor/components/WorkflowNodesPopoverMenuOperationList.tsx
+++ b/client/src/pages/platform/workflow-editor/components/WorkflowNodesPopoverMenuOperationList.tsx
@@ -390,6 +390,7 @@ const WorkflowNodesPopoverMenuOperationList = ({
 
                     if (taskDispatcherContext?.taskDispatcherId) {
                         handleTaskDispatcherSubtaskOperationClick({
+                            clusterRoot,
                             operation: clickedOperation,
                             operationDefinition: clickedComponentActionDefinition,
                             queryClient,
@@ -415,6 +416,7 @@ const WorkflowNodesPopoverMenuOperationList = ({
 
                     if (taskDispatcherContext?.taskDispatcherId) {
                         handleTaskDispatcherSubtaskOperationClick({
+                            clusterRoot,
                             operation: clickedOperation,
                             operationDefinition: clickedComponentActionDefinition,
                             placeholderId: sourceNodeId,
@@ -460,6 +462,7 @@ const WorkflowNodesPopoverMenuOperationList = ({
             }
         },
         [
+            clusterRoot,
             componentDefinition,
             loadingOperationName,
             setLatestComponentDefinition,

--- a/client/src/pages/platform/workflow-editor/utils/handleTaskDispatcherSubtaskOperationClick.tsx
+++ b/client/src/pages/platform/workflow-editor/utils/handleTaskDispatcherSubtaskOperationClick.tsx
@@ -18,6 +18,7 @@ import saveWorkflowDefinition from './saveWorkflowDefinition';
 import {TASK_DISPATCHER_CONFIG} from './taskDispatcherConfig';
 
 interface HandleTaskDispatcherSubtaskOperationClickProps {
+    clusterRoot?: boolean;
     operation: ClickedOperationType;
     operationDefinition: ActionDefinition;
     placeholderId?: string;
@@ -28,6 +29,7 @@ interface HandleTaskDispatcherSubtaskOperationClickProps {
 }
 
 export default function handleTaskDispatcherSubtaskOperationClick({
+    clusterRoot,
     operation,
     operationDefinition,
     placeholderId,
@@ -59,6 +61,7 @@ export default function handleTaskDispatcherSubtaskOperationClick({
     const workflowNodeName = getFormattedName(operation.componentName!);
 
     const baseNodeData: NodeDataType = {
+        ...(clusterRoot ? {clusterElements: {}} : {}),
         componentName: operation.componentName,
         icon: icon && <InlineSVG className="size-9" loader={<ComponentIcon className="size-9" />} src={icon} />,
         label: componentLabel,

--- a/client/src/pages/platform/workflow-editor/utils/tests/handleTaskDispatcherSubtaskOperationClick.test.tsx
+++ b/client/src/pages/platform/workflow-editor/utils/tests/handleTaskDispatcherSubtaskOperationClick.test.tsx
@@ -1,0 +1,91 @@
+import useWorkflowDataStore, {WorkflowDataType} from '@/pages/platform/workflow-editor/stores/useWorkflowDataStore';
+import useWorkflowNodeDetailsPanelStore from '@/pages/platform/workflow-editor/stores/useWorkflowNodeDetailsPanelStore';
+import {ActionDefinition, Workflow} from '@/shared/middleware/platform/configuration';
+import {
+    ClickedOperationType,
+    NodeDataType,
+    TaskDispatcherContextType,
+    UpdateWorkflowMutationType,
+} from '@/shared/types';
+import {QueryClient} from '@tanstack/react-query';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+
+import handleTaskDispatcherSubtaskOperationClick from '../handleTaskDispatcherSubtaskOperationClick';
+
+const saveWorkflowDefinitionMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../saveWorkflowDefinition', () => ({
+    default: saveWorkflowDefinitionMock,
+}));
+
+const OPERATION: ClickedOperationType = {
+    componentLabel: 'AI Agent',
+    componentName: 'aiAgent',
+    operationName: 'chat',
+    type: 'aiAgent/v1/chat',
+    version: 1,
+};
+
+const TASK_DISPATCHER_CONTEXT: TaskDispatcherContextType = {
+    conditionCase: 'caseTrue',
+    conditionId: 'condition_1',
+    index: 0,
+    taskDispatcherId: 'condition_1',
+};
+
+const callHandler = (clusterRoot?: boolean) =>
+    handleTaskDispatcherSubtaskOperationClick({
+        clusterRoot,
+        operation: OPERATION,
+        operationDefinition: {properties: []} as unknown as ActionDefinition,
+        queryClient: new QueryClient(),
+        taskDispatcherContext: TASK_DISPATCHER_CONTEXT,
+        updateWorkflowMutation: {mutate: vi.fn()} as unknown as UpdateWorkflowMutationType,
+        workflow: {
+            definition: JSON.stringify({tasks: []}),
+            id: 'workflow_1',
+            tasks: [],
+        } as unknown as Workflow & WorkflowDataType,
+    });
+
+describe('handleTaskDispatcherSubtaskOperationClick', () => {
+    beforeEach(() => {
+        saveWorkflowDefinitionMock.mockClear();
+
+        useWorkflowDataStore.setState({
+            nodes: [],
+            workflow: {
+                definition: JSON.stringify({tasks: []}),
+                id: 'workflow_1',
+            } as unknown as Workflow & WorkflowDataType,
+        });
+
+        useWorkflowNodeDetailsPanelStore.setState({
+            activeTab: 'description',
+            currentNode: undefined,
+            pendingSaveNodeName: undefined,
+            workflowNodeDetailsPanelOpen: false,
+        });
+    });
+
+    it('should open the node details panel for a regular component added inside a task dispatcher', () => {
+        callHandler(false);
+
+        expect(useWorkflowNodeDetailsPanelStore.getState().workflowNodeDetailsPanelOpen).toBe(true);
+    });
+
+    it('should not open the node details panel for a cluster root added inside a task dispatcher', () => {
+        callHandler(true);
+
+        expect(useWorkflowNodeDetailsPanelStore.getState().workflowNodeDetailsPanelOpen).toBe(false);
+        expect(useWorkflowNodeDetailsPanelStore.getState().currentNode).toBeUndefined();
+    });
+
+    it('should persist an empty clusterElements map for a cluster root added inside a task dispatcher', () => {
+        callHandler(true);
+
+        const {nodeData} = saveWorkflowDefinitionMock.mock.calls[0][0] as {nodeData: NodeDataType};
+
+        expect(nodeData.clusterElements).toEqual({});
+    });
+});

--- a/server/libs/atlas/atlas-configuration/atlas-configuration-api/src/main/java/com/bytechef/atlas/configuration/util/WorkflowTaskUtils.java
+++ b/server/libs/atlas/atlas-configuration/atlas-configuration-api/src/main/java/com/bytechef/atlas/configuration/util/WorkflowTaskUtils.java
@@ -67,8 +67,11 @@ public class WorkflowTaskUtils {
                             for (Object curItem : curList) {
                                 Map<String, ?> curMap = (Map<String, ?>) curItem;
 
-                                List<WorkflowTask> curWorkflowTasks = MapUtils.getList(
-                                    curMap, WorkflowConstants.TASKS, WorkflowTask.class, List.of());
+                                List<WorkflowTask> curWorkflowTasks = MapUtils
+                                    .getList(curMap, WorkflowConstants.TASKS, List.of())
+                                    .stream()
+                                    .map(WorkflowTaskUtils::toWorkflowTask)
+                                    .toList();
 
                                 returnedWorkflowTasks.addAll(getTasks(curWorkflowTasks, lastWorkflowNodeName));
                             }
@@ -119,6 +122,15 @@ public class WorkflowTaskUtils {
         }
 
         return resultWorkflowTasks;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static WorkflowTask toWorkflowTask(Object item) {
+        if (item instanceof WorkflowTask workflowTask) {
+            return workflowTask;
+        }
+
+        return new WorkflowTask((Map<String, ?>) item);
     }
 
     private static boolean isWorkflowTaskMap(Map<?, ?> map) {

--- a/server/libs/atlas/atlas-configuration/atlas-configuration-api/src/test/java/com/bytechef/atlas/configuration/util/WorkflowTaskUtilsTest.java
+++ b/server/libs/atlas/atlas-configuration/atlas-configuration-api/src/test/java/com/bytechef/atlas/configuration/util/WorkflowTaskUtilsTest.java
@@ -22,6 +22,7 @@ import com.bytechef.atlas.configuration.domain.WorkflowTask;
 import com.bytechef.test.extension.ObjectMapperSetupExtension;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
@@ -183,5 +184,70 @@ class WorkflowTaskUtilsTest {
             .collect(Collectors.toSet());
 
         assertEquals(Set.of("loop_1", "logger_1", "dataStorage_1"), names);
+    }
+
+    @Test
+    void testFlattenBranchCaseTaskRetainsClusterElements() {
+        WorkflowTask branch = new WorkflowTask(Map.of(
+            "name", "branch_1",
+            "type", "branch/v1",
+            "parameters", Map.of(
+                "expression", "1",
+                "cases", List.of(
+                    Map.of(
+                        "key", "1",
+                        "tasks", List.of(
+                            Map.of(
+                                "name", "aiAgent_1",
+                                "type", "aiAgent/v1/chat",
+                                "parameters", Map.of("messages", List.of()),
+                                "clusterElements", Map.of(
+                                    "model", Map.of("name", "openAi_1", "type", "openAi/v1/model")))))))));
+
+        WorkflowTask aiAgentWorkflowTask = WorkflowTaskUtils.getTasks(List.of(branch), null)
+            .stream()
+            .filter(workflowTask -> Objects.equals(workflowTask.getName(), "aiAgent_1"))
+            .findFirst()
+            .orElseThrow();
+
+        assertEquals(
+            Map.of("model", Map.of("name", "openAi_1", "type", "openAi/v1/model")),
+            aiAgentWorkflowTask.getExtensions()
+                .get("clusterElements"));
+    }
+
+    @Test
+    void testFlattenBranchCaseTaskRetainsMultipleElementClusterElements() {
+        WorkflowTask branch = new WorkflowTask(Map.of(
+            "name", "branch_1",
+            "type", "branch/v1",
+            "parameters", Map.of(
+                "expression", "1",
+                "cases", List.of(
+                    Map.of(
+                        "key", "1",
+                        "tasks", List.of(
+                            Map.of(
+                                "name", "aiAgent_1",
+                                "type", "aiAgent/v1/chat",
+                                "parameters", Map.of("messages", List.of()),
+                                "clusterElements", Map.of(
+                                    "tools", List.of(
+                                        Map.of("name", "dataTable_5", "type", "dataTable/v1/updateRecord"),
+                                        Map.of("name", "dataTable_6", "type", "dataTable/v1/findRecords"))))))))));
+
+        WorkflowTask aiAgentWorkflowTask = WorkflowTaskUtils.getTasks(List.of(branch), null)
+            .stream()
+            .filter(workflowTask -> Objects.equals(workflowTask.getName(), "aiAgent_1"))
+            .findFirst()
+            .orElseThrow();
+
+        assertEquals(
+            Map.of(
+                "tools", List.of(
+                    Map.of("name", "dataTable_5", "type", "dataTable/v1/updateRecord"),
+                    Map.of("name", "dataTable_6", "type", "dataTable/v1/findRecords"))),
+            aiAgentWorkflowTask.getExtensions()
+                .get("clusterElements"));
     }
 }


### PR DESCRIPTION
Closes #5559

An AI agent (cluster root) placed **inside** a task dispatcher was broken at two layers.

## Server — the agent lost its cluster elements

`WorkflowTaskUtils.getTasks` flattened the tasks nested in a branch case with
`MapUtils.getList(curMap, TASKS, WorkflowTask.class, List.of())`, which rebuilds each task through Jackson.
`clusterElements` is not a declared `WorkflowTask` field — it is an extension — so it was silently dropped:
an agent nested in a branch lost its model, memory and tools as soon as the definition was flattened.

Each nested task is now built with the `WorkflowTask(Map)` constructor, which preserves the extensions.

## Client — the wrong panel opened

A cluster root is recognised by the `clusterElements` map it carries. A node added through the task
dispatcher path arrived without one and was treated as a plain component, so the properties panel opened
instead of staying closed for the cluster element editor. `clusterRoot` is threaded through to the new node
data, seeding an empty `clusterElements` map.

## Test

`WorkflowTaskUtilsTest` gains two cases covering a single-element (`model`) and a multi-element (`tools`)
cluster surviving the flatten; both fail without the production change (verified by reverting it).
`handleTaskDispatcherSubtaskOperationClick.test.tsx` covers the panel staying closed for a cluster root,
opening for a regular component, and the empty `clusterElements` map reaching the saved definition.

Verified on top of `master`: `atlas-configuration-api` 20/20 + spotless clean; full client gate green
(354 files / 3797 tests, lint + typecheck), with the new test file confirmed running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)