### PR TITLE
5557 Resolve nested task data pill references and relax label to a warning

### DIFF
--- a/server/libs/platform/platform-workflow/platform-workflow-validator/platform-workflow-validator-service/build.gradle.kts
+++ b/server/libs/platform/platform-workflow/platform-workflow-validator/platform-workflow-validator-service/build.gradle.kts
@@ -12,4 +12,6 @@ dependencies {
     implementation(project(":server:libs:atlas:atlas-configuration:atlas-configuration-api"))
     implementation(project(":server:libs:platform:platform-component:platform-component-api"))
     implementation(project(":server:libs:platform:platform-workflow:platform-workflow-task-dispatcher:platform-workflow-task-dispatcher-api"))
+
+    testImplementation(project(":server:libs:test:test-support"))
 }

--- a/server/libs/platform/platform-workflow/platform-workflow-validator/platform-workflow-validator-service/src/main/java/com/bytechef/platform/workflow/validator/ArrayPropertyValidator.java
+++ b/server/libs/platform/platform-workflow/platform-workflow-validator/platform-workflow-validator-service/src/main/java/com/bytechef/platform/workflow/validator/ArrayPropertyValidator.java
@@ -63,7 +63,7 @@ class ArrayPropertyValidator {
         }
 
         if (isTaskTypeArray(nestedPropertyInfos)) {
-            TaskValidator.validateTaskArray(valueJsonNode, propertyPath, errors);
+            TaskValidator.validateTaskArray(valueJsonNode, propertyPath, errors, warnings);
 
             return;
         }

--- a/server/libs/platform/platform-workflow/platform-workflow-validator/platform-workflow-validator-service/src/main/java/com/bytechef/platform/workflow/validator/DataPillValidator.java
+++ b/server/libs/platform/platform-workflow/platform-workflow-validator/platform-workflow-validator-service/src/main/java/com/bytechef/platform/workflow/validator/DataPillValidator.java
@@ -286,7 +286,7 @@ class DataPillValidator {
                     warnings, context, text, allTasksMap, taskDefinition, rootParametersJsonNode);
             } else {
                 validateTaskReference(
-                    dataPillExpression, fieldPath, taskOutput, taskNames, taskNameToTypeMap, errors, taskDefinition,
+                    dataPillExpression, fieldPath, taskOutput, allTasksMap, taskNameToTypeMap, errors, taskDefinition,
                     rootParametersJsonNode);
             }
         }
@@ -558,11 +558,11 @@ class DataPillValidator {
     }
 
     private static void validateTaskReference(
-        String dataPillExpression, String fieldPath, Map<String, PropertyInfo> taskOutput, List<String> taskNames,
-        Map<String, String> taskNameToTypeMap, StringBuilder errors, List<PropertyInfo> taskDefinition,
-        JsonNode rootParametersJsonNode) {
+        String dataPillExpression, String fieldPath, Map<String, PropertyInfo> taskOutput,
+        Map<String, JsonNode> allTasksMap, Map<String, String> taskNameToTypeMap, StringBuilder errors,
+        List<PropertyInfo> taskDefinition, JsonNode rootParametersJsonNode) {
 
-        if (!taskNames.contains(dataPillExpression)) {
+        if (!allTasksMap.containsKey(dataPillExpression)) {
             StringUtils.appendWithNewline("Task '" + dataPillExpression + "' doesn't exits.", errors);
 
             return;

--- a/server/libs/platform/platform-workflow/platform-workflow-validator/platform-workflow-validator-service/src/main/java/com/bytechef/platform/workflow/validator/DataPillValidator.java
+++ b/server/libs/platform/platform-workflow/platform-workflow-validator/platform-workflow-validator-service/src/main/java/com/bytechef/platform/workflow/validator/DataPillValidator.java
@@ -563,7 +563,7 @@ class DataPillValidator {
         List<PropertyInfo> taskDefinition, JsonNode rootParametersJsonNode) {
 
         if (!allTasksMap.containsKey(dataPillExpression)) {
-            StringUtils.appendWithNewline("Task '" + dataPillExpression + "' doesn't exits.", errors);
+            StringUtils.appendWithNewline("Task '" + dataPillExpression + "' doesn't exist.", errors);
 
             return;
         }

--- a/server/libs/platform/platform-workflow/platform-workflow-validator/platform-workflow-validator-service/src/main/java/com/bytechef/platform/workflow/validator/FieldValidator.java
+++ b/server/libs/platform/platform-workflow/platform-workflow-validator/platform-workflow-validator-service/src/main/java/com/bytechef/platform/workflow/validator/FieldValidator.java
@@ -30,10 +30,26 @@ class FieldValidator {
     private FieldValidator() {
     }
 
+    public static void validateOptionalStringField(
+        JsonNode jsonNode, String fieldName, StringBuilder errors, StringBuilder warnings) {
+
+        if (!jsonNode.has(fieldName)) {
+            StringUtils.appendWithNewline("Missing recommended field: " + fieldName, warnings);
+
+            return;
+        }
+
+        JsonNode fieldJsonNode = jsonNode.get(fieldName);
+
+        if (!fieldJsonNode.isTextual()) {
+            StringUtils.appendWithNewline("Field '" + fieldName + "' must be a string", errors);
+        }
+    }
+
     /**
      * Validates that a required string field exists and is of correct type.
      */
-    public static void appendErrorRequiredStringField(JsonNode jsonNode, String fieldName, StringBuilder errors) {
+    public static void validateRequiredStringField(JsonNode jsonNode, String fieldName, StringBuilder errors) {
         if (!jsonNode.has(fieldName)) {
             StringUtils.appendWithNewline("Missing required field: " + fieldName, errors);
         } else {

--- a/server/libs/platform/platform-workflow/platform-workflow-validator/platform-workflow-validator-service/src/main/java/com/bytechef/platform/workflow/validator/TaskValidator.java
+++ b/server/libs/platform/platform-workflow/platform-workflow-validator/platform-workflow-validator-service/src/main/java/com/bytechef/platform/workflow/validator/TaskValidator.java
@@ -66,7 +66,7 @@ class TaskValidator {
             int errorsStart = errors.length();
             int warningsStart = warnings.length();
 
-            validateTaskStructureFields(taskJsonNode, errors);
+            validateTaskStructureFields(taskJsonNode, errors, warnings);
 
             List<PropertyInfo> taskDefinition = validateTaskParameters(taskJsonNode, context);
 
@@ -212,8 +212,9 @@ class TaskValidator {
      *
      * @param taskJson the task JSON string to validate
      * @param errors   StringBuilder to collect validation errors
+     * @param warnings StringBuilder to collect validation warnings
      */
-    public static void validateTaskStructure(String taskJson, StringBuilder errors) {
+    public static void validateTaskStructure(String taskJson, StringBuilder errors, StringBuilder warnings) {
         JsonNode taskJsonNode = JsonNodeUtils.parseJsonWithErrorHandling(taskJson, errors);
 
         if (taskJsonNode == null) {
@@ -235,17 +236,21 @@ class TaskValidator {
         }
 
         int errorsStart = errors.length();
+        int warningsStart = warnings.length();
 
-        validateTaskStructureFields(taskJsonNode, errors);
+        validateTaskStructureFields(taskJsonNode, errors, warnings);
 
         if (!taskName.isEmpty()) {
             prefixTaskMessages(errors, errorsStart, taskName);
+            prefixTaskMessages(warnings, warningsStart, taskName);
         }
     }
 
-    private static void validateTaskStructureFields(JsonNode taskJsonNode, StringBuilder errors) {
-        FieldValidator.appendErrorRequiredStringField(taskJsonNode, "label", errors);
-        FieldValidator.appendErrorRequiredStringField(taskJsonNode, "name", errors);
+    private static void validateTaskStructureFields(
+        JsonNode taskJsonNode, StringBuilder errors, StringBuilder warnings) {
+
+        FieldValidator.validateOptionalStringField(taskJsonNode, "label", errors, warnings);
+        FieldValidator.validateRequiredStringField(taskJsonNode, "name", errors);
         appendErrorTaskTypeField(taskJsonNode, errors);
         appendErrorRequiredObjectField(taskJsonNode, errors);
     }
@@ -253,7 +258,9 @@ class TaskValidator {
     /**
      * Validates an array containing TASK objects.
      */
-    public static void validateTaskArray(JsonNode arrayValueJsonNode, String propertyPath, StringBuilder errors) {
+    public static void validateTaskArray(
+        JsonNode arrayValueJsonNode, String propertyPath, StringBuilder errors, StringBuilder warnings) {
+
         for (int i = 0; i < arrayValueJsonNode.size(); i++) {
             JsonNode taskJsonNode = arrayValueJsonNode.get(i);
             String path = propertyPath + "[" + i + "]";
@@ -263,7 +270,7 @@ class TaskValidator {
 
                 StringUtils.appendWithNewline(ValidationErrorUtils.typeError(path, "object", actualType), errors);
             } else {
-                validateTaskStructureFields(taskJsonNode, errors);
+                validateTaskStructureFields(taskJsonNode, errors, warnings);
 
                 if (taskJsonNode.has("parameters") && taskJsonNode.has("type")) {
                     JsonNode parametersJsonNode = taskJsonNode.get("parameters");
@@ -337,12 +344,6 @@ class TaskValidator {
 
             String type = typeJsonNode.asString();
 
-            List<String> taskNames = context.getTaskNames();
-
-            if (!taskNames.contains(name)) {
-                taskNames.add(name);
-            }
-
             Map<String, JsonNode> allTasksMap = context.getAllTasksMap();
 
             allTasksMap.put(name, nestedTaskJsonNode);
@@ -350,6 +351,39 @@ class TaskValidator {
             Map<String, String> taskNameToTypeMap = context.getTaskNameToTypeMap();
 
             taskNameToTypeMap.put(name, type);
+        }
+    }
+
+    private static void appendErrorRequiredObjectField(JsonNode jsonNode, StringBuilder errors) {
+        if (!jsonNode.has("parameters")) {
+            StringUtils.appendWithNewline("Missing required field: " + "parameters", errors);
+        } else {
+            JsonNode fieldJsonNode = jsonNode.get("parameters");
+
+            if (!fieldJsonNode.isObject()) {
+                StringUtils.appendWithNewline("Field '" + "parameters" + "' must be an object", errors);
+            }
+        }
+    }
+
+    private static void appendErrorTaskTypeField(JsonNode taskJsonNode, StringBuilder errors) {
+        if (!taskJsonNode.has("type")) {
+            StringUtils.appendWithNewline("Missing required field: type", errors);
+        } else {
+            JsonNode typeJsonNode = taskJsonNode.get("type");
+
+            if (!typeJsonNode.isString()) {
+                StringUtils.appendWithNewline("Field 'type' must be a string", errors);
+            } else {
+                String typeValue = typeJsonNode.asString();
+
+                Matcher matcher = TYPE_PATTERN.matcher(typeValue);
+
+                if (!matcher.matches()) {
+                    StringUtils.appendWithNewline(
+                        "Field 'type' must match pattern: (alphanumeric|-)+/v(numeric)+(/(alphanumeric)+)?", errors);
+                }
+            }
         }
     }
 
@@ -363,6 +397,23 @@ class TaskValidator {
         for (PropertyInfo propertyInfo : taskDefinition) {
             processTaskArrayProperty(parametersJsonNode, propertyInfo, context);
         }
+    }
+
+    @Nullable
+    private static List<PropertyInfo> getObjectItemProperties(PropertyInfo propertyInfo) {
+        List<PropertyInfo> propertyInfos = propertyInfo.nestedProperties();
+
+        if (!"ARRAY".equalsIgnoreCase(propertyInfo.type()) || propertyInfos == null || propertyInfos.size() != 1) {
+            return null;
+        }
+
+        PropertyInfo propertyInfosFirst = propertyInfos.getFirst();
+
+        if (!"OBJECT".equalsIgnoreCase(propertyInfosFirst.type())) {
+            return null;
+        }
+
+        return propertyInfosFirst.nestedProperties();
     }
 
     /**
@@ -446,18 +497,10 @@ class TaskValidator {
         }
     }
 
-    /**
-     * Processes a single property that might contain nested tasks. Part of Chain of Responsibility pattern.
-     */
     private static void processTaskArrayProperty(
         JsonNode parametersJsonNode, PropertyInfo propertyInfo, ValidationContext context) {
 
         String propertyName = propertyInfo.name();
-
-        // Check if this is a TASK type array
-        if (!isTaskTypeArray(propertyInfo)) {
-            return;
-        }
 
         JsonNode jsonNode = parametersJsonNode.get(propertyName);
 
@@ -465,7 +508,23 @@ class TaskValidator {
             return;
         }
 
-        processNestedTaskArray(jsonNode, context);
+        if (isTaskTypeArray(propertyInfo)) {
+            processNestedTaskArray(jsonNode, context);
+
+            return;
+        }
+
+        List<PropertyInfo> itemPropertyInfos = getObjectItemProperties(propertyInfo);
+
+        if (itemPropertyInfos == null) {
+            return;
+        }
+
+        for (JsonNode itemJsonNode : jsonNode) {
+            if (itemJsonNode.isObject()) {
+                findAndValidateNestedTasks(itemJsonNode, itemPropertyInfos, context);
+            }
+        }
     }
 
     private static void validateDataPills(
@@ -480,7 +539,7 @@ class TaskValidator {
      * Validates the structure of a nested task.
      */
     private static void validateTaskStructure(JsonNode nestedTaskJsonNode, ValidationContext context) {
-        validateTaskStructureFields(nestedTaskJsonNode, context.getErrors());
+        validateTaskStructureFields(nestedTaskJsonNode, context.getErrors(), context.getWarnings());
     }
 
     /**
@@ -524,23 +583,6 @@ class TaskValidator {
             nestedTaskJsonNode, context, nestedTaskDefinition, true);
     }
 
-    /**
-     * Validates that a required object field exists and is of correct type.
-     */
-    private static void
-        appendErrorRequiredObjectField(JsonNode jsonNode, StringBuilder errors) {
-        if (!jsonNode.has("parameters")) {
-            StringUtils.appendWithNewline("Missing required field: " + "parameters", errors);
-        } else {
-            JsonNode fieldJsonNode = jsonNode.get("parameters");
-
-            if (!fieldJsonNode.isObject()) {
-                StringUtils.appendWithNewline(
-                    "Field '" + "parameters" + "' must be an object", errors);
-            }
-        }
-    }
-
     @Nullable
     private static List<PropertyInfo> validateTaskParameters(JsonNode taskJsonNode, ValidationContext context) {
         JsonNode typeJsonNode = taskJsonNode.get("type");
@@ -563,29 +605,5 @@ class TaskValidator {
         }
 
         return taskDefinition;
-    }
-
-    /**
-     * Validates task type field against required pattern.
-     */
-    private static void appendErrorTaskTypeField(JsonNode taskJsonNode, StringBuilder errors) {
-        if (!taskJsonNode.has("type")) {
-            StringUtils.appendWithNewline("Missing required field: type", errors);
-        } else {
-            JsonNode typeJsonNode = taskJsonNode.get("type");
-
-            if (!typeJsonNode.isString()) {
-                StringUtils.appendWithNewline("Field 'type' must be a string", errors);
-            } else {
-                String typeValue = typeJsonNode.asString();
-
-                Matcher matcher = TYPE_PATTERN.matcher(typeValue);
-
-                if (!matcher.matches()) {
-                    StringUtils.appendWithNewline(
-                        "Field 'type' must match pattern: (alphanumeric|-)+/v(numeric)+(/(alphanumeric)+)?", errors);
-                }
-            }
-        }
     }
 }

--- a/server/libs/platform/platform-workflow/platform-workflow-validator/platform-workflow-validator-service/src/main/java/com/bytechef/platform/workflow/validator/WorkflowValidator.java
+++ b/server/libs/platform/platform-workflow/platform-workflow-validator/platform-workflow-validator-service/src/main/java/com/bytechef/platform/workflow/validator/WorkflowValidator.java
@@ -101,7 +101,7 @@ public class WorkflowValidator {
         Map<String, List<String>> clusterTypesMap, StringBuilder errors, StringBuilder warnings) {
 
         try {
-            validateWorkflowStructure(workflow, errors);
+            validateWorkflowStructure(workflow, errors, warnings);
 
             JsonNode workflowJsonNode = com.bytechef.commons.util.JsonUtils.readTree(workflow);
 
@@ -113,7 +113,7 @@ public class WorkflowValidator {
             List<JsonNode> inputJsonNodes = new ArrayList<>();
             List<JsonNode> taskJsonNodes = new ArrayList<>();
 
-            processInputs(taskOutputMap, workflowJsonNode, inputJsonNodes, errors);
+            processInputs(taskOutputMap, workflowJsonNode, inputJsonNodes, errors, warnings);
             processTriggers(
                 taskDefinitionProvider, taskOutputProvider, taskDefinitionMap, taskOutputMap, warnings,
                 workflowJsonNode, taskJsonNodes);
@@ -182,7 +182,7 @@ public class WorkflowValidator {
         String task, TaskDefinitionProvider taskDefinitionProvider, StringBuilder errors, StringBuilder warnings) {
 
         try {
-            TaskValidator.validateTaskStructure(task, errors);
+            TaskValidator.validateTaskStructure(task, errors, warnings);
 
             JsonNode taskJsonNode = com.bytechef.commons.util.JsonUtils.readTree(task);
 
@@ -348,7 +348,7 @@ public class WorkflowValidator {
             taskOutputPropertyInfoMap.put(type, nestedTaskOutput);
         }
 
-        TaskValidator.validateTaskStructure(nestedTaskJsonNode.toString(), errors);
+        TaskValidator.validateTaskStructure(nestedTaskJsonNode.toString(), errors, warnings);
 
         return type;
     }
@@ -474,7 +474,7 @@ public class WorkflowValidator {
 
     private static void processInputs(
         Map<String, @Nullable PropertyInfo> taskOutputMap, JsonNode workflowJsonNode, List<JsonNode> inputJsonNodes,
-        StringBuilder errors) {
+        StringBuilder errors, StringBuilder warnings) {
 
         JsonNode inputsJsonNode = workflowJsonNode.get("inputs");
 
@@ -497,7 +497,7 @@ public class WorkflowValidator {
 
             inputJsonNodes.add(inputJsonNode);
 
-            validateInputFields(inputJsonNode, errors);
+            validateInputFields(inputJsonNode, errors, warnings);
 
             JsonNode typeJsonNode = inputJsonNode.get("type");
             JsonNode nameJsonNode = inputJsonNode.get("name");
@@ -516,7 +516,9 @@ public class WorkflowValidator {
         }
     }
 
-    private static void validateInputFields(JsonNode inputJsonNode, StringBuilder errors) {
+    private static void validateInputFields(
+        JsonNode inputJsonNode, StringBuilder errors, StringBuilder warnings) {
+
         String name = "";
 
         if (inputJsonNode.has("name")) {
@@ -529,8 +531,8 @@ public class WorkflowValidator {
 
         String prefix = name.isEmpty() ? "" : "[" + name + "] ";
 
-        FieldValidator.appendErrorRequiredStringField(inputJsonNode, "name", errors);
-        FieldValidator.appendErrorRequiredStringField(inputJsonNode, "label", errors);
+        FieldValidator.validateRequiredStringField(inputJsonNode, "name", errors);
+        FieldValidator.validateOptionalStringField(inputJsonNode, "label", errors, warnings);
 
         if (!inputJsonNode.has("type")) {
             StringUtils.appendWithNewline(prefix + "Missing required field: type", errors);
@@ -721,8 +723,9 @@ public class WorkflowValidator {
      *
      * @param workflow the workflow JSON string to validate
      * @param errors   StringBuilder to collect validation errors
+     * @param warnings StringBuilder to collect validation warnings
      */
-    static void validateWorkflowStructure(String workflow, StringBuilder errors) {
+    static void validateWorkflowStructure(String workflow, StringBuilder errors, StringBuilder warnings) {
         JsonNode workflowJsonNode = JsonNodeUtils.parseJsonWithErrorHandling(workflow, errors);
 
         if (workflowJsonNode == null) {
@@ -733,8 +736,8 @@ public class WorkflowValidator {
             return;
         }
 
-        FieldValidator.appendErrorRequiredStringField(workflowJsonNode, "label", errors);
-        FieldValidator.appendErrorRequiredStringField(workflowJsonNode, "description", errors);
+        FieldValidator.validateOptionalStringField(workflowJsonNode, "label", errors, warnings);
+        FieldValidator.validateRequiredStringField(workflowJsonNode, "description", errors);
         validateWorkflowTriggerFields(workflowJsonNode, errors);
         validateRequiredArrayField(workflowJsonNode, errors);
 

--- a/server/libs/platform/platform-workflow/platform-workflow-validator/platform-workflow-validator-service/src/test/java/com/bytechef/platform/workflow/validator/WorkflowValidatorDuplicateNodeNamesTest.java
+++ b/server/libs/platform/platform-workflow/platform-workflow-validator/platform-workflow-validator-service/src/test/java/com/bytechef/platform/workflow/validator/WorkflowValidatorDuplicateNodeNamesTest.java
@@ -34,6 +34,8 @@ import tools.jackson.databind.json.JsonMapper;
 /**
  * Covers duplicate node-name detection across the task-dispatcher nesting shapes, complementing the top-level checks in
  * {@link WorkflowValidatorTest}.
+ *
+ * @author Marko Kriskovic
  */
 class WorkflowValidatorDuplicateNodeNamesTest {
 

--- a/server/libs/platform/platform-workflow/platform-workflow-validator/platform-workflow-validator-service/src/test/java/com/bytechef/platform/workflow/validator/WorkflowValidatorInputsTest.java
+++ b/server/libs/platform/platform-workflow/platform-workflow-validator/platform-workflow-validator-service/src/test/java/com/bytechef/platform/workflow/validator/WorkflowValidatorInputsTest.java
@@ -519,7 +519,7 @@ class WorkflowValidatorInputsTest {
         WorkflowValidator.validateWorkflow(workflow, taskDefProvider, taskOutputProvider, clusterTypesProvider,
             new HashMap<>(), new HashMap<>(), new HashMap<>(), errors, warnings);
 
-        assertEquals("[task_1] Task 'doesNotExist' doesn't exits.", errors.toString());
+        assertEquals("[task_1] Task 'doesNotExist' doesn't exist.", errors.toString());
         assertEquals("", warnings.toString());
     }
 

--- a/server/libs/platform/platform-workflow/platform-workflow-validator/platform-workflow-validator-service/src/test/java/com/bytechef/platform/workflow/validator/WorkflowValidatorInputsTest.java
+++ b/server/libs/platform/platform-workflow/platform-workflow-validator/platform-workflow-validator-service/src/test/java/com/bytechef/platform/workflow/validator/WorkflowValidatorInputsTest.java
@@ -341,7 +341,7 @@ class WorkflowValidatorInputsTest {
     }
 
     @Test
-    void validateWorkflowMissingInputLabelHasErrors() {
+    void validateWorkflowMissingInputLabelHasWarnings() {
         String workflow = """
             {
                 "label": "Test Workflow",
@@ -372,8 +372,8 @@ class WorkflowValidatorInputsTest {
         WorkflowValidator.validateWorkflow(workflow, taskDefProvider, taskOutputProvider, clusterTypesProvider,
             new HashMap<>(), new HashMap<>(), new HashMap<>(), errors, warnings);
 
-        assertEquals("Missing required field: label", errors.toString());
-        assertEquals("", warnings.toString());
+        assertEquals("", errors.toString());
+        assertEquals("Missing recommended field: label", warnings.toString());
     }
 
     @Test

--- a/server/libs/platform/platform-workflow/platform-workflow-validator/platform-workflow-validator-service/src/test/java/com/bytechef/platform/workflow/validator/WorkflowValidatorNestedTaskReferenceTest.java
+++ b/server/libs/platform/platform-workflow/platform-workflow-validator/platform-workflow-validator-service/src/test/java/com/bytechef/platform/workflow/validator/WorkflowValidatorNestedTaskReferenceTest.java
@@ -20,18 +20,19 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.bytechef.commons.util.JsonUtils;
 import com.bytechef.platform.workflow.validator.model.PropertyInfo;
+import com.bytechef.test.extension.ObjectMapperSetupExtension;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import tools.jackson.databind.JsonNode;
-import tools.jackson.databind.json.JsonMapper;
 
 /**
  * @author Ivica Cardic
  */
+@ExtendWith(ObjectMapperSetupExtension.class)
 class WorkflowValidatorNestedTaskReferenceTest {
 
     private static final PropertyInfo ACTION_OUTPUT =
@@ -59,13 +60,6 @@ class WorkflowValidatorNestedTaskReferenceTest {
 
     private static final Map<String, PropertyInfo> TASK_OUTPUT_MAP = Map.of(
         "component/v1/action1", ACTION_OUTPUT);
-
-    @BeforeAll
-    public static void beforeAll() {
-        JsonUtils.setObjectMapper(
-            JsonMapper.builder()
-                .build());
-    }
 
     @Test
     void validateWorkflowTasksResolvesBareReferenceToTaskNestedInCondition() {

--- a/server/libs/platform/platform-workflow/platform-workflow-validator/platform-workflow-validator-service/src/test/java/com/bytechef/platform/workflow/validator/WorkflowValidatorNestedTaskReferenceTest.java
+++ b/server/libs/platform/platform-workflow/platform-workflow-validator/platform-workflow-validator-service/src/test/java/com/bytechef/platform/workflow/validator/WorkflowValidatorNestedTaskReferenceTest.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2025 ByteChef
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.bytechef.platform.workflow.validator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.bytechef.commons.util.JsonUtils;
+import com.bytechef.platform.workflow.validator.model.PropertyInfo;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * @author Ivica Cardic
+ */
+class WorkflowValidatorNestedTaskReferenceTest {
+
+    private static final PropertyInfo ACTION_OUTPUT =
+        new PropertyInfo("propString", "STRING", null, false, true, null, null);
+
+    private static final Map<String, List<PropertyInfo>> TASK_DEFINITION_MAP = Map.of(
+        "component/v1/action1", List.of(
+            new PropertyInfo("name", "STRING", null, false, true, null, null)),
+        "condition/v1", List.of(
+            new PropertyInfo("rawExpression", "BOOLEAN", null, false, true, null, null),
+            new PropertyInfo("expression", "STRING", null, false, true, "rawExpression == true", null),
+            new PropertyInfo("caseTrue", "ARRAY", null, false, true, null, List.of(
+                new PropertyInfo(null, "TASK", null, false, false, null, null))),
+            new PropertyInfo("caseFalse", "ARRAY", null, false, true, null, List.of(
+                new PropertyInfo(null, "TASK", null, false, false, null, null)))),
+        "branch/v1", List.of(
+            new PropertyInfo("expression", "STRING", null, false, true, null, null),
+            new PropertyInfo("cases", "ARRAY", null, false, true, null, List.of(
+                new PropertyInfo(null, "OBJECT", null, false, false, null, List.of(
+                    new PropertyInfo("key", "STRING", null, false, true, null, null),
+                    new PropertyInfo("tasks", "ARRAY", null, false, true, null, List.of(
+                        new PropertyInfo(null, "TASK", null, false, false, null, null))))))),
+            new PropertyInfo("default", "ARRAY", null, false, true, null, List.of(
+                new PropertyInfo(null, "TASK", null, false, false, null, null)))));
+
+    private static final Map<String, PropertyInfo> TASK_OUTPUT_MAP = Map.of(
+        "component/v1/action1", ACTION_OUTPUT);
+
+    @BeforeAll
+    public static void beforeAll() {
+        JsonUtils.setObjectMapper(
+            JsonMapper.builder()
+                .build());
+    }
+
+    @Test
+    void validateWorkflowTasksResolvesBareReferenceToTaskNestedInCondition() {
+        String tasksJson = """
+            [
+                {
+                    "label": "Condition",
+                    "name": "condition_1",
+                    "type": "condition/v1",
+                    "parameters": {
+                        "rawExpression": true,
+                        "expression": "true",
+                        "caseTrue": [
+                            {
+                                "label": "Task 1",
+                                "name": "task1",
+                                "type": "component/v1/action1",
+                                "parameters": {
+                                    "name": "John"
+                                }
+                            },
+                            {
+                                "label": "Task 2",
+                                "name": "task2",
+                                "type": "component/v1/action1",
+                                "parameters": {
+                                    "name": "${task1}"
+                                }
+                            }
+                        ],
+                        "caseFalse": []
+                    }
+                }
+            ]
+            """;
+
+        assertNoErrors(tasksJson);
+    }
+
+    @Test
+    void validateWorkflowTasksResolvesBareReferenceToTaskNestedInBranchCase() {
+        String tasksJson = """
+            [
+                {
+                    "label": "Branch",
+                    "name": "branch_1",
+                    "type": "branch/v1",
+                    "parameters": {
+                        "expression": "BOT",
+                        "cases": [
+                            {
+                                "key": "BOT",
+                                "tasks": [
+                                    {
+                                        "label": "Task 1",
+                                        "name": "task1",
+                                        "type": "component/v1/action1",
+                                        "parameters": {
+                                            "name": "John"
+                                        }
+                                    },
+                                    {
+                                        "label": "Task 2",
+                                        "name": "task2",
+                                        "type": "component/v1/action1",
+                                        "parameters": {
+                                            "name": "${task1}"
+                                        }
+                                    }
+                                ]
+                            }
+                        ],
+                        "default": []
+                    }
+                }
+            ]
+            """;
+
+        assertNoErrors(tasksJson);
+    }
+
+    @Test
+    void validateWorkflowTasksValidatesStructureOfTaskNestedInBranchCase() {
+        String tasksJson = """
+            [
+                {
+                    "label": "Branch",
+                    "name": "branch_1",
+                    "type": "branch/v1",
+                    "parameters": {
+                        "expression": "BOT",
+                        "cases": [
+                            {
+                                "key": "BOT",
+                                "tasks": [
+                                    {
+                                        "name": "task1",
+                                        "type": "component/v1/action1",
+                                        "parameters": {
+                                            "name": "John"
+                                        }
+                                    }
+                                ]
+                            }
+                        ],
+                        "default": []
+                    }
+                }
+            ]
+            """;
+
+        StringBuilder errors = new StringBuilder();
+        StringBuilder warnings = new StringBuilder();
+
+        validate(tasksJson, errors, warnings);
+
+        assertEquals("", errors.toString());
+        assertEquals("[branch_1] Missing recommended field: label", warnings.toString());
+    }
+
+    private static void assertNoErrors(String tasksJson) {
+        StringBuilder errors = new StringBuilder();
+        StringBuilder warnings = new StringBuilder();
+
+        validate(tasksJson, errors, warnings);
+
+        assertEquals("", errors.toString());
+    }
+
+    private static void validate(String tasksJson, StringBuilder errors, StringBuilder warnings) {
+        JsonNode tasksJsonNode = JsonUtils.readTree(tasksJson);
+        List<JsonNode> taskJsonNodes = new ArrayList<>();
+
+        for (JsonNode taskJsonNode : tasksJsonNode) {
+            taskJsonNodes.add(taskJsonNode);
+        }
+
+        WorkflowValidator.validateWorkflowTasks(
+            taskJsonNodes, TASK_DEFINITION_MAP, TASK_OUTPUT_MAP, new HashMap<>(), errors, warnings);
+    }
+}

--- a/server/libs/platform/platform-workflow/platform-workflow-validator/platform-workflow-validator-service/src/test/java/com/bytechef/platform/workflow/validator/WorkflowValidatorOptionalLabelTest.java
+++ b/server/libs/platform/platform-workflow/platform-workflow-validator/platform-workflow-validator-service/src/test/java/com/bytechef/platform/workflow/validator/WorkflowValidatorOptionalLabelTest.java
@@ -20,30 +20,24 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.bytechef.commons.util.JsonUtils;
 import com.bytechef.platform.workflow.validator.model.PropertyInfo;
+import com.bytechef.test.extension.ObjectMapperSetupExtension;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import tools.jackson.databind.JsonNode;
-import tools.jackson.databind.json.JsonMapper;
 
 /**
  * @author Ivica Cardic
  */
+@ExtendWith(ObjectMapperSetupExtension.class)
 class WorkflowValidatorOptionalLabelTest {
 
     private static final Map<String, List<PropertyInfo>> TASK_DEFINITION_MAP = Map.of(
         "component/v1/action1", List.of(
             new PropertyInfo("name", "STRING", null, false, true, null, null)));
-
-    @BeforeAll
-    public static void beforeAll() {
-        JsonUtils.setObjectMapper(
-            JsonMapper.builder()
-                .build());
-    }
 
     @Test
     void validateWorkflowTasksMissingTaskLabelAddsWarningNotError() {

--- a/server/libs/platform/platform-workflow/platform-workflow-validator/platform-workflow-validator-service/src/test/java/com/bytechef/platform/workflow/validator/WorkflowValidatorOptionalLabelTest.java
+++ b/server/libs/platform/platform-workflow/platform-workflow-validator/platform-workflow-validator-service/src/test/java/com/bytechef/platform/workflow/validator/WorkflowValidatorOptionalLabelTest.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2025 ByteChef
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.bytechef.platform.workflow.validator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.bytechef.commons.util.JsonUtils;
+import com.bytechef.platform.workflow.validator.model.PropertyInfo;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * @author Ivica Cardic
+ */
+class WorkflowValidatorOptionalLabelTest {
+
+    private static final Map<String, List<PropertyInfo>> TASK_DEFINITION_MAP = Map.of(
+        "component/v1/action1", List.of(
+            new PropertyInfo("name", "STRING", null, false, true, null, null)));
+
+    @BeforeAll
+    public static void beforeAll() {
+        JsonUtils.setObjectMapper(
+            JsonMapper.builder()
+                .build());
+    }
+
+    @Test
+    void validateWorkflowTasksMissingTaskLabelAddsWarningNotError() {
+        String tasksJson = """
+            [
+                {
+                    "name": "testTask",
+                    "type": "component/v1/action1",
+                    "parameters": {
+                        "name": "John"
+                    }
+                }
+            ]
+            """;
+
+        StringBuilder errors = new StringBuilder();
+        StringBuilder warnings = new StringBuilder();
+
+        validateTasks(tasksJson, errors, warnings);
+
+        assertEquals("", errors.toString());
+        assertEquals("[testTask] Missing recommended field: label", warnings.toString());
+    }
+
+    @Test
+    void validateWorkflowTasksNonStringTaskLabelStillAddsError() {
+        String tasksJson = """
+            [
+                {
+                    "label": 42,
+                    "name": "testTask",
+                    "type": "component/v1/action1",
+                    "parameters": {
+                        "name": "John"
+                    }
+                }
+            ]
+            """;
+
+        StringBuilder errors = new StringBuilder();
+        StringBuilder warnings = new StringBuilder();
+
+        validateTasks(tasksJson, errors, warnings);
+
+        assertEquals("[testTask] Field 'label' must be a string", errors.toString());
+        assertEquals("", warnings.toString());
+    }
+
+    @Test
+    void validateWorkflowMissingWorkflowLabelAddsWarningNotError() {
+        String workflow = """
+            {
+                "description": "Test workflow description",
+                "inputs": [],
+                "triggers": [],
+                "tasks": []
+            }
+            """;
+
+        StringBuilder errors = new StringBuilder();
+        StringBuilder warnings = new StringBuilder();
+
+        validateWorkflow(workflow, errors, warnings);
+
+        assertEquals("", errors.toString());
+        assertEquals("Missing recommended field: label", warnings.toString());
+    }
+
+    @Test
+    void validateWorkflowMissingInputLabelAddsWarningNotError() {
+        String workflow = """
+            {
+                "label": "Test Workflow",
+                "description": "Test workflow description",
+                "inputs": [
+                    {
+                        "name": "count",
+                        "type": "integer"
+                    }
+                ],
+                "triggers": [],
+                "tasks": []
+            }
+            """;
+
+        StringBuilder errors = new StringBuilder();
+        StringBuilder warnings = new StringBuilder();
+
+        validateWorkflow(workflow, errors, warnings);
+
+        assertEquals("", errors.toString());
+        assertEquals("Missing recommended field: label", warnings.toString());
+    }
+
+    @Test
+    void validateWorkflowMissingTriggerLabelAddsWarningNotError() {
+        String workflow = """
+            {
+                "label": "Test Workflow",
+                "description": "Test workflow description",
+                "inputs": [],
+                "triggers": [
+                    {
+                        "name": "trigger_1",
+                        "type": "manual/v1/manual",
+                        "parameters": {}
+                    }
+                ],
+                "tasks": []
+            }
+            """;
+
+        StringBuilder errors = new StringBuilder();
+        StringBuilder warnings = new StringBuilder();
+
+        validateWorkflow(workflow, errors, warnings);
+
+        assertEquals("", errors.toString());
+        assertEquals("[trigger_1] Missing recommended field: label", warnings.toString());
+    }
+
+    private static void validateTasks(String tasksJson, StringBuilder errors, StringBuilder warnings) {
+        JsonNode tasksJsonNode = JsonUtils.readTree(tasksJson);
+        List<JsonNode> taskJsonNodes = new ArrayList<>();
+
+        for (JsonNode taskJsonNode : tasksJsonNode) {
+            taskJsonNodes.add(taskJsonNode);
+        }
+
+        WorkflowValidator.validateWorkflowTasks(
+            taskJsonNodes, TASK_DEFINITION_MAP, Map.of(), new HashMap<>(), errors, warnings);
+    }
+
+    private static void validateWorkflow(String workflow, StringBuilder errors, StringBuilder warnings) {
+        WorkflowValidator.TaskDefinitionProvider taskDefinitionProvider =
+            (taskType, kind) -> TASK_DEFINITION_MAP.get(taskType);
+        WorkflowValidator.TaskOutputProvider taskOutputProvider =
+            (taskType, kind, warningsBuilder) -> null;
+        WorkflowValidator.ClusterTypesProvider clusterTypesProvider = taskType -> null;
+
+        WorkflowValidator.validateWorkflow(
+            workflow, taskDefinitionProvider, taskOutputProvider, clusterTypesProvider, new HashMap<>(),
+            new HashMap<>(), new HashMap<>(), errors, warnings);
+    }
+}

--- a/server/libs/platform/platform-workflow/platform-workflow-validator/platform-workflow-validator-service/src/test/java/com/bytechef/platform/workflow/validator/WorkflowValidatorTest.java
+++ b/server/libs/platform/platform-workflow/platform-workflow-validator/platform-workflow-validator-service/src/test/java/com/bytechef/platform/workflow/validator/WorkflowValidatorTest.java
@@ -284,7 +284,7 @@ class WorkflowValidatorTest {
             WorkflowValidator.validateWorkflowTasks(
                 taskJsonNodes, taskDefinitionMap, taskOutputMap, new HashMap<>(), errors, warnings);
 
-            assertEquals("[task2] Task 'invalidformat' doesn't exits.", errors.toString());
+            assertEquals("[task2] Task 'invalidformat' doesn't exist.", errors.toString());
             assertEquals("", warnings.toString());
         } catch (Exception e) {
             fail("Should not throw exception: " + e.getMessage());

--- a/server/libs/platform/platform-workflow/platform-workflow-validator/platform-workflow-validator-service/src/test/java/com/bytechef/platform/workflow/validator/WorkflowValidatorTest.java
+++ b/server/libs/platform/platform-workflow/platform-workflow-validator/platform-workflow-validator-service/src/test/java/com/bytechef/platform/workflow/validator/WorkflowValidatorTest.java
@@ -546,7 +546,7 @@ class WorkflowValidatorTest {
 
         StringBuilder errors = new StringBuilder();
 
-        TaskValidator.validateTaskStructure(invalidTask, errors);
+        TaskValidator.validateTaskStructure(invalidTask, errors, new StringBuilder());
 
         String string = errors.toString();
 
@@ -565,7 +565,7 @@ class WorkflowValidatorTest {
             """;
         StringBuilder errors = new StringBuilder();
 
-        TaskValidator.validateTaskStructure(invalidTask, errors);
+        TaskValidator.validateTaskStructure(invalidTask, errors, new StringBuilder());
 
         String string = errors.toString();
 
@@ -589,7 +589,7 @@ class WorkflowValidatorTest {
 
         StringBuilder errors = new StringBuilder();
 
-        TaskValidator.validateTaskStructure(invalidTask, errors);
+        TaskValidator.validateTaskStructure(invalidTask, errors, new StringBuilder());
 
         String string = errors.toString();
 
@@ -597,7 +597,7 @@ class WorkflowValidatorTest {
     }
 
     @Test
-    void validateTaskStructureMissingLabelAddsError() {
+    void validateTaskStructureMissingLabelAddsWarning() {
         String invalidTask = """
             {
                 "name": "testTask",
@@ -607,10 +607,12 @@ class WorkflowValidatorTest {
             """;
 
         StringBuilder errors = new StringBuilder();
+        StringBuilder warnings = new StringBuilder();
 
-        TaskValidator.validateTaskStructure(invalidTask, errors);
+        TaskValidator.validateTaskStructure(invalidTask, errors, warnings);
 
-        assertEquals("[testTask] Missing required field: label", errors.toString());
+        assertEquals("", errors.toString());
+        assertEquals("[testTask] Missing recommended field: label", warnings.toString());
     }
 
     @Test
@@ -625,7 +627,7 @@ class WorkflowValidatorTest {
 
         StringBuilder errors = new StringBuilder();
 
-        TaskValidator.validateTaskStructure(invalidTask, errors);
+        TaskValidator.validateTaskStructure(invalidTask, errors, new StringBuilder());
 
         assertEquals("[testTask] Missing required field: type", errors.toString());
     }
@@ -642,7 +644,7 @@ class WorkflowValidatorTest {
 
         StringBuilder errors = new StringBuilder();
 
-        TaskValidator.validateTaskStructure(invalidTask, errors);
+        TaskValidator.validateTaskStructure(invalidTask, errors, new StringBuilder());
 
         assertEquals("Missing required field: name", errors.toString());
     }
@@ -660,7 +662,7 @@ class WorkflowValidatorTest {
 
         StringBuilder errors = new StringBuilder();
 
-        TaskValidator.validateTaskStructure(invalidTask, errors);
+        TaskValidator.validateTaskStructure(invalidTask, errors, new StringBuilder());
 
         assertEquals("[testTask] Field 'label' must be a string", errors.toString());
     }
@@ -678,7 +680,7 @@ class WorkflowValidatorTest {
 
         StringBuilder errors = new StringBuilder();
 
-        TaskValidator.validateTaskStructure(invalidTask, errors);
+        TaskValidator.validateTaskStructure(invalidTask, errors, new StringBuilder());
 
         assertEquals("Field 'name' must be a string", errors.toString());
     }
@@ -696,7 +698,7 @@ class WorkflowValidatorTest {
 
         StringBuilder errors = new StringBuilder();
 
-        TaskValidator.validateTaskStructure(invalidTask, errors);
+        TaskValidator.validateTaskStructure(invalidTask, errors, new StringBuilder());
 
         assertEquals("[testTask] Field 'type' must be a string", errors.toString());
     }
@@ -714,7 +716,7 @@ class WorkflowValidatorTest {
 
         StringBuilder errors = new StringBuilder();
 
-        TaskValidator.validateTaskStructure(validTask, errors);
+        TaskValidator.validateTaskStructure(validTask, errors, new StringBuilder());
 
         assertEquals("", errors.toString());
     }
@@ -732,7 +734,7 @@ class WorkflowValidatorTest {
 
         StringBuilder errors = new StringBuilder();
 
-        TaskValidator.validateTaskStructure(validTask, errors);
+        TaskValidator.validateTaskStructure(validTask, errors, new StringBuilder());
 
         assertEquals("", errors.toString());
     }
@@ -757,7 +759,7 @@ class WorkflowValidatorTest {
 
             StringBuilder errors = new StringBuilder();
 
-            TaskValidator.validateTaskStructure(validTask, errors);
+            TaskValidator.validateTaskStructure(validTask, errors, new StringBuilder());
 
             assertEquals("", errors.toString(), "Type should be valid: " + type);
         }
@@ -775,7 +777,7 @@ class WorkflowValidatorTest {
 
         StringBuilder errors = new StringBuilder();
 
-        TaskValidator.validateTaskStructure(invalidTask, errors);
+        TaskValidator.validateTaskStructure(invalidTask, errors, new StringBuilder());
 
         assertEquals("[testTask] Missing required field: parameters", errors.toString());
     }
@@ -793,7 +795,7 @@ class WorkflowValidatorTest {
 
         StringBuilder errors = new StringBuilder();
 
-        TaskValidator.validateTaskStructure(invalidTask, errors);
+        TaskValidator.validateTaskStructure(invalidTask, errors, new StringBuilder());
 
         assertEquals("[testTask] Field 'parameters' must be an object", errors.toString());
     }
@@ -804,7 +806,7 @@ class WorkflowValidatorTest {
 
         StringBuilder errors = new StringBuilder();
 
-        TaskValidator.validateTaskStructure(invalidTask, errors);
+        TaskValidator.validateTaskStructure(invalidTask, errors, new StringBuilder());
 
         assertEquals("Task must be an object", errors.toString());
     }
@@ -2621,7 +2623,7 @@ class WorkflowValidatorTest {
 
         StringBuilder errors = new StringBuilder();
 
-        WorkflowValidator.validateWorkflowStructure(validWorkflow, errors);
+        WorkflowValidator.validateWorkflowStructure(validWorkflow, errors, new StringBuilder());
 
         assertEquals("", errors.toString());
     }
@@ -2646,13 +2648,13 @@ class WorkflowValidatorTest {
 
         StringBuilder errors = new StringBuilder();
 
-        WorkflowValidator.validateWorkflowStructure(validWorkflow, errors);
+        WorkflowValidator.validateWorkflowStructure(validWorkflow, errors, new StringBuilder());
 
         assertEquals("", errors.toString());
     }
 
     @Test
-    void validateWorkflowStructureMissingLabelAddsError() {
+    void validateWorkflowStructureMissingLabelAddsWarning() {
         String invalidWorkflow = """
             {
                 "description": "workflowDescription",
@@ -2669,10 +2671,12 @@ class WorkflowValidatorTest {
             """;
 
         StringBuilder errors = new StringBuilder();
+        StringBuilder warnings = new StringBuilder();
 
-        WorkflowValidator.validateWorkflowStructure(invalidWorkflow, errors);
+        WorkflowValidator.validateWorkflowStructure(invalidWorkflow, errors, warnings);
 
-        assertEquals("Missing required field: label", errors.toString());
+        assertEquals("", errors.toString());
+        assertEquals("Missing recommended field: label", warnings.toString());
     }
 
     @Test
@@ -2695,7 +2699,7 @@ class WorkflowValidatorTest {
 
         StringBuilder errors = new StringBuilder();
 
-        WorkflowValidator.validateWorkflowStructure(invalidWorkflow, errors);
+        WorkflowValidator.validateWorkflowStructure(invalidWorkflow, errors, new StringBuilder());
 
         assertEquals("Field 'label' must be a string", errors.toString());
     }
@@ -2719,7 +2723,7 @@ class WorkflowValidatorTest {
 
         StringBuilder errors = new StringBuilder();
 
-        WorkflowValidator.validateWorkflowStructure(invalidWorkflow, errors);
+        WorkflowValidator.validateWorkflowStructure(invalidWorkflow, errors, new StringBuilder());
 
         assertEquals("Missing required field: description", errors.toString());
     }
@@ -2744,7 +2748,7 @@ class WorkflowValidatorTest {
 
         StringBuilder errors = new StringBuilder();
 
-        WorkflowValidator.validateWorkflowStructure(invalidWorkflow, errors);
+        WorkflowValidator.validateWorkflowStructure(invalidWorkflow, errors, new StringBuilder());
 
         assertEquals("Field 'description' must be a string", errors.toString());
     }
@@ -2762,7 +2766,7 @@ class WorkflowValidatorTest {
 
         StringBuilder errors = new StringBuilder();
 
-        WorkflowValidator.validateWorkflowStructure(invalidWorkflow, errors);
+        WorkflowValidator.validateWorkflowStructure(invalidWorkflow, errors, new StringBuilder());
 
         assertEquals("Missing required field: triggers", errors.toString());
     }
@@ -2781,7 +2785,7 @@ class WorkflowValidatorTest {
 
         StringBuilder errors = new StringBuilder();
 
-        WorkflowValidator.validateWorkflowStructure(invalidWorkflow, errors);
+        WorkflowValidator.validateWorkflowStructure(invalidWorkflow, errors, new StringBuilder());
 
         assertEquals("Field 'triggers' must be an array", errors.toString());
     }
@@ -2811,7 +2815,7 @@ class WorkflowValidatorTest {
 
         StringBuilder errors = new StringBuilder();
 
-        WorkflowValidator.validateWorkflowStructure(workflow, errors);
+        WorkflowValidator.validateWorkflowStructure(workflow, errors, new StringBuilder());
 
         assertEquals("", errors.toString());
     }
@@ -2832,7 +2836,7 @@ class WorkflowValidatorTest {
 
         StringBuilder errors = new StringBuilder();
 
-        WorkflowValidator.validateWorkflowStructure(invalidWorkflow, errors);
+        WorkflowValidator.validateWorkflowStructure(invalidWorkflow, errors, new StringBuilder());
 
         assertEquals("Trigger must be an object", errors.toString());
     }
@@ -2856,7 +2860,7 @@ class WorkflowValidatorTest {
 
         StringBuilder errors = new StringBuilder();
 
-        WorkflowValidator.validateWorkflowStructure(invalidWorkflow, errors);
+        WorkflowValidator.validateWorkflowStructure(invalidWorkflow, errors, new StringBuilder());
 
         assertEquals("Missing required field: tasks", errors.toString());
     }
@@ -2881,7 +2885,7 @@ class WorkflowValidatorTest {
 
         StringBuilder errors = new StringBuilder();
 
-        WorkflowValidator.validateWorkflowStructure(invalidWorkflow, errors);
+        WorkflowValidator.validateWorkflowStructure(invalidWorkflow, errors, new StringBuilder());
 
         assertEquals("Field 'tasks' must be an array", errors.toString());
     }
@@ -2891,7 +2895,7 @@ class WorkflowValidatorTest {
         String invalidWorkflow = "\"not an object\"";
 
         StringBuilder errors = new StringBuilder();
-        WorkflowValidator.validateWorkflowStructure(invalidWorkflow, errors);
+        WorkflowValidator.validateWorkflowStructure(invalidWorkflow, errors, new StringBuilder());
 
         assertTrue(errors.toString()
             .contains("Workflow must be an object"));
@@ -2902,7 +2906,7 @@ class WorkflowValidatorTest {
         String invalidWorkflow = "{invalid json}";
 
         StringBuilder errors = new StringBuilder();
-        WorkflowValidator.validateWorkflowStructure(invalidWorkflow, errors);
+        WorkflowValidator.validateWorkflowStructure(invalidWorkflow, errors, new StringBuilder());
 
         String string = errors.toString();
 
@@ -2967,7 +2971,7 @@ class WorkflowValidatorTest {
     }
 
     @Test
-    void validateWorkflowTasksInvalidTaskStructureAddsError() {
+    void validateWorkflowTasksInvalidTaskStructureAddsWarning() {
         String tasksJson = """
             [
                 {
@@ -2997,8 +3001,8 @@ class WorkflowValidatorTest {
             WorkflowValidator.validateWorkflowTasks(
                 taskJsonNodes, taskDefinitionMap, taskOutputMap, new HashMap<>(), errors, warnings);
 
-            assertEquals("[testTask1] Missing required field: label", errors.toString());
-            assertEquals("", warnings.toString());
+            assertEquals("", errors.toString());
+            assertEquals("[testTask1] Missing recommended field: label", warnings.toString());
         } catch (Exception e) {
             fail("Should not throw exception: " + e.getMessage());
         }
@@ -3331,11 +3335,10 @@ class WorkflowValidatorTest {
             WorkflowValidator.validateWorkflowTasks(
                 taskJsonNodes, taskDefinitionMap, taskOutputMap, new HashMap<>(), errors, warnings);
 
-            assertEquals("""
-                [invalidTask] Missing required field: label
-                [invalidTask] Property 'age' has incorrect type. Expected: integer, but got: string""",
+            assertEquals(
+                "[invalidTask] Property 'age' has incorrect type. Expected: integer, but got: string",
                 errors.toString());
-            assertEquals("", warnings.toString());
+            assertEquals("[invalidTask] Missing recommended field: label", warnings.toString());
         } catch (Exception e) {
             fail("Should not throw exception: " + e.getMessage());
         }
@@ -3896,7 +3899,7 @@ class WorkflowValidatorTest {
     }
 
     @Test
-    void validateWorkflowInvalidStructureHasErrors() {
+    void validateWorkflowInvalidStructureHasWarnings() {
         String workflow = """
             {
                 "description": "Missing label",
@@ -3920,8 +3923,8 @@ class WorkflowValidatorTest {
         WorkflowValidator.validateWorkflow(workflow, taskDefProvider, taskOutputProvider, clusterTypesProvider,
             new HashMap<>(), new HashMap<>(), new HashMap<>(), errors, warnings);
 
-        assertEquals("Missing required field: label", errors.toString());
-        assertEquals("", warnings.toString());
+        assertEquals("", errors.toString());
+        assertEquals("Missing recommended field: label", warnings.toString());
     }
 
     @Test
@@ -4327,7 +4330,7 @@ class WorkflowValidatorTest {
     }
 
     @Test
-    void validateSingleTaskInvalidStructureHasErrors() {
+    void validateSingleTaskInvalidStructureHasWarnings() {
         String task = """
             {
                 "name": "test_task",
@@ -4343,8 +4346,8 @@ class WorkflowValidatorTest {
 
         WorkflowValidator.validateSingleTask(task, taskDefProvider, errors, warnings);
 
-        assertEquals("[test_task] Missing required field: label", errors.toString());
-        assertEquals("", warnings.toString());
+        assertEquals("", errors.toString());
+        assertEquals("[test_task] Missing recommended field: label", warnings.toString());
     }
 
     @Test


### PR DESCRIPTION
Closes #5557

Three related defects in `platform-workflow-validator`, all reachable from one workflow whose `branch/v1` cases contain an `aiAgent` task referenced as `${aiAgent_1}`.

### 1. Bare references to nested tasks reported as non-existent

`DataPillValidator.validateTaskReference` resolved a pathless data pill (`${aiAgent_1}`) against `ValidationContext.getTaskNames()`, which returns a **defensive copy** — unlike its siblings `getAllTasksMap` / `getTaskNameToTypeMap`, which return the live collections. `TaskValidator.addNestedTaskToContext` was therefore writing every nested task name into a throwaway list, and the registration silently no-opped.

Property references (`${aiAgent_1.someField}`) were unaffected because they resolve through the live `taskNameToTypeMap` — which is why only bare references ever showed the error.

Existence now resolves against `allTasksMap`. The ordered name list is deliberately left alone: it also backs the task-order check via `indexOf`, and appending nested names there would produce bogus "Wrong task order" errors for a top-level task legitimately referencing a task nested in an earlier dispatcher.

### 2. Tasks nested in `branch/v1` cases were never validated

`TaskValidator.processTaskArrayProperty` only recognised `ARRAY`-of-`TASK`. `branch/v1` declares `cases` as `ARRAY`-of-`OBJECT{key, tasks: ARRAY-of-TASK}`, and that one extra object level made everything inside `cases[].tasks` invisible to structure, parameter and cluster-element validation. (`default` worked, being a flat `ARRAY`-of-`TASK`.) It now descends one object level and recurses into `findAndValidateNestedTasks`.

### 3. `label` was a hard error though the engine treats it as optional

A missing `label` blocked saving from the workflow code editor (`WorkflowCodeEditorSheet` disables Save on `hasErrors`), even though every domain model serialises it only when non-null — `WorkflowTask` / `WorkflowTrigger` guard on `label != null`, and `Workflow` root / `Workflow.Input` read it via `MapUtils.getString`. A missing `label` on the workflow, its inputs, its triggers and its tasks is now a warning (`Missing recommended field: label`); a `label` of the wrong type stays an error, via a new `FieldValidator.appendWarningOptionalStringField`.

### Known gap, not addressed here

`WorkflowCodeEditorSheet` and `WorkflowNodeDetailsPanel` render `errors` only, so validator **warnings** are not surfaced anywhere in the editor. With `label` downgraded, that signal is now invisible rather than soft. Surfacing warnings in both panels is worth a separate change.

### Tests

- `WorkflowValidatorNestedTaskReferenceTest` — bare reference inside a condition, bare reference inside a branch case, structure validation reaching a branch-nested task
- `WorkflowValidatorOptionalLabelTest` — workflow / input / trigger / task missing label yields a warning and no error; a non-string label still errors

`:platform-workflow-validator-service:check` on this branch: **156 tests, 0 failures**, spotless / checkstyle / PMD / SpotBugs clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
