### PR TITLE
5556 client - Convert definition connections maps to DTO arrays when flattening tasks

### DIFF
--- a/client/src/pages/platform/workflow-editor/utils/flattenDefinitionTasks.test.ts
+++ b/client/src/pages/platform/workflow-editor/utils/flattenDefinitionTasks.test.ts
@@ -140,4 +140,67 @@ describe('flattenDefinitionTasks', () => {
         expect(result).toHaveLength(1);
         expect(result[0].name).toBe('postgresql_1');
     });
+    it('should convert a definition connections map into the DTO connections array', () => {
+        const taskWithConnections = {
+            ...task('script_1', 'script/v1/javascript'),
+            connections: {
+                aiee: {componentName: 'airtable', componentVersion: 1},
+                gm: {componentName: 'googleMail', componentVersion: 1},
+            },
+        } as unknown as WorkflowTask;
+
+        const result = flattenDefinitionTasks([taskWithConnections]);
+
+        expect(result[0].connections).toEqual([
+            {
+                componentName: 'airtable',
+                componentVersion: 1,
+                key: 'aiee',
+                required: false,
+                workflowNodeName: 'script_1',
+            },
+            {
+                componentName: 'googleMail',
+                componentVersion: 1,
+                key: 'gm',
+                required: false,
+                workflowNodeName: 'script_1',
+            },
+        ]);
+    });
+
+    it('should convert definition connections maps on nested subtasks', () => {
+        const nestedTask = {
+            ...task('openAi_1'),
+            connections: {openAi_1: {authorizationRequired: true, componentName: 'openAi', componentVersion: 1}},
+        } as unknown as WorkflowTask;
+
+        const result = flattenDefinitionTasks([task('loop_1', 'loop/v1', {iteratee: [nestedTask]})]);
+
+        expect(result[1].connections).toEqual([
+            {
+                componentName: 'openAi',
+                componentVersion: 1,
+                key: 'openAi_1',
+                required: true,
+                workflowNodeName: 'openAi_1',
+            },
+        ]);
+    });
+
+    it('should leave an already converted connections array untouched', () => {
+        const connections = [
+            {
+                componentName: 'openAi',
+                componentVersion: 1,
+                key: 'openAi_1',
+                required: true,
+                workflowNodeName: 'openAi_1',
+            },
+        ];
+
+        const result = flattenDefinitionTasks([{...task('openAi_1'), connections}]);
+
+        expect(result[0].connections).toBe(connections);
+    });
 });

--- a/client/src/pages/platform/workflow-editor/utils/flattenDefinitionTasks.ts
+++ b/client/src/pages/platform/workflow-editor/utils/flattenDefinitionTasks.ts
@@ -1,5 +1,5 @@
-import {WorkflowTask} from '@/shared/middleware/platform/configuration';
-import {BranchCaseType} from '@/shared/types';
+import {ComponentConnection, WorkflowTask} from '@/shared/middleware/platform/configuration';
+import {BranchCaseType, ComponentConnectionType} from '@/shared/types';
 
 /**
  * Flattens hierarchical definition tasks into a flat array matching the server's
@@ -10,7 +10,7 @@ export function flattenDefinitionTasks(tasks: Array<WorkflowTask>): Array<Workfl
     const result: Array<WorkflowTask> = [];
 
     for (const task of tasks) {
-        result.push(task);
+        result.push(normalizeConnections(task));
 
         if (task.parameters) {
             result.push(...extractNestedTasks(task.parameters));
@@ -18,6 +18,39 @@ export function flattenDefinitionTasks(tasks: Array<WorkflowTask>): Array<Workfl
     }
 
     return result;
+}
+
+type DefinitionComponentConnectionType = ComponentConnectionType & {
+    authorizationRequired?: boolean;
+};
+
+/**
+ * Workflow definitions declare task connections as a map keyed by the connection name, while the
+ * REST DTO exposes them as an array of ComponentConnection. Flattened tasks are written to
+ * `workflow.tasks`, which holds DTOs, so the definition shape has to be converted first.
+ *
+ * `required` is only derived from the definition here. The server additionally ORs in the component
+ * definition's `connectionRequired` flag, so an optimistically flattened task can under-report a
+ * required connection until the update mutation responds with the authoritative task.
+ */
+function normalizeConnections(task: WorkflowTask): WorkflowTask {
+    if (!task.connections || Array.isArray(task.connections)) {
+        return task;
+    }
+
+    const definitionConnections = task.connections as unknown as Record<string, DefinitionComponentConnectionType>;
+
+    const connections: Array<ComponentConnection> = Object.entries(definitionConnections).map(
+        ([key, definitionConnection]) => ({
+            componentName: definitionConnection.componentName,
+            componentVersion: definitionConnection.componentVersion,
+            key,
+            required: definitionConnection.authorizationRequired ?? false,
+            workflowNodeName: task.name,
+        })
+    );
+
+    return {...task, connections};
 }
 
 function extractNestedTasks(parameters: Record<string, unknown>): Array<WorkflowTask> {

--- a/client/src/pages/platform/workflow-editor/utils/saveWorkflowDefinition.test.ts
+++ b/client/src/pages/platform/workflow-editor/utils/saveWorkflowDefinition.test.ts
@@ -380,6 +380,75 @@ describe('saveWorkflowDefinition', () => {
     });
 
     describe('optimistic update', () => {
+        it('should convert definition connections maps into DTO connections arrays', async () => {
+            mockWorkflowState = makeWorkflowState([
+                {
+                    connections: {javascript01: {componentName: 'googleMail', componentVersion: 1}},
+                    name: 'script_1',
+                    parameters: {},
+                    type: 'script/v1/javascript',
+                },
+            ]);
+
+            const mutation = makeMutation();
+
+            await saveWorkflowDefinition({
+                nodeData: {
+                    componentName: 'httpClient',
+                    name: 'httpClient_1',
+                    operationName: 'get',
+                    version: 1,
+                } as unknown as NodeDataType,
+                updateWorkflowMutation: mutation,
+            });
+
+            const optimisticWorkflow = mockWorkflowState.setWorkflow.mock.calls[0][0];
+
+            const scriptTask = optimisticWorkflow.tasks.find((task: {name: string}) => task.name === 'script_1');
+
+            expect(scriptTask.connections).toEqual([
+                {
+                    componentName: 'googleMail',
+                    componentVersion: 1,
+                    key: 'javascript01',
+                    required: false,
+                    workflowNodeName: 'script_1',
+                },
+            ]);
+        });
+
+        it('should keep the definition connections map in the saved definition', async () => {
+            mockWorkflowState = makeWorkflowState([
+                {
+                    connections: {javascript01: {componentName: 'googleMail', componentVersion: 1}},
+                    name: 'script_1',
+                    parameters: {},
+                    type: 'script/v1/javascript',
+                },
+            ]);
+
+            const mutation = makeMutation();
+
+            await saveWorkflowDefinition({
+                nodeData: {
+                    componentName: 'httpClient',
+                    name: 'httpClient_1',
+                    operationName: 'get',
+                    version: 1,
+                } as unknown as NodeDataType,
+                updateWorkflowMutation: mutation,
+            });
+
+            const mutateArgs = (mutation.mutate as ReturnType<typeof vi.fn>).mock.calls[0][0];
+            const savedDefinition = JSON.parse(mutateArgs.workflow.definition);
+
+            const scriptTask = savedDefinition.tasks.find((task: {name: string}) => task.name === 'script_1');
+
+            expect(scriptTask.connections).toEqual({
+                javascript01: {componentName: 'googleMail', componentVersion: 1},
+            });
+        });
+
         it('should update the store with new definition before calling mutate', async () => {
             mockWorkflowState = makeWorkflowState();
             const mutation = makeMutation();


### PR DESCRIPTION
Closes #5556

Opening the **Connection** tab in the workflow editor's node details panel crashed the panel into its error boundary:

```
TypeError: componentConnections.map is not a function
    at ConnectionTab (ConnectionTab.tsx:131:35)
```

### Root cause

`connections` on a workflow task exists in two incompatible shapes, and the client mixed them:

| Where | Shape |
| --- | --- |
| Stored workflow **definition** | map keyed by connection name — `{"gm": {"componentName": "googleMail", "componentVersion": 1}}` |
| REST **DTO** `WorkflowTask.connections` | derived read-only `Array<ComponentConnection>` with `key` / `workflowNodeName` / `required` |

The server treats the DTO array as derived and read-only: `WorkflowTaskMapper` carries `@Mapping(target = "connections", ignore = true)`, and `ComponentConnection.of(extensions, ...)` builds the array by reading the definition map through `MapUtils.getMap`.

The leak is the optimistic update in `saveWorkflowDefinition.ts`, which ran raw **definition** tasks through `flattenDefinitionTasks` and wrote them into `workflow.tasks` — a field typed as DTOs. `ConnectionTab` then called `.map()` on a plain object.

That is also why the tab rendered at all despite its `currentWorkflowNodeConnections.length > 0` guard: an object's `.length` is `undefined`, so the guard fell through to the `currentComponentDefinition?.connection !== undefined` branch.

TypeScript never caught it because `WorkflowTaskType.connections` in `client/src/shared/types.ts` is typed `[{...}] & {[key: string]: ComponentConnectionType}` — an intersection that is simultaneously a tuple and an index map, so it satisfies both worlds.

The map shape is present in real data: a survey of stored definitions found 58 occurrences of task-level `connections` as a map.

### Fix

Normalize at the seam, in `flattenDefinitionTasks` — convert the definition map into the DTO array before anything reaches `workflow.tasks`.

Fixed there rather than guarding `ConnectionTab` with `Array.isArray`, because three other consumers read the same field and would have gone silently wrong instead of crashing loudly:

- `useRun`'s `runDisabled`
- `resolveNodeConnectionFields`
- the cluster-root `mainClusterRootTask.connections.filter(...)` in `useWorkflowNodeDetailsPanel`

Normalization deliberately does **not** run on the way back into the saved definition, so definitions keep persisting the map shape.

### Known tradeoff

`required` is derived only from the definition's `authorizationRequired`, while the server additionally ORs in the component definition's `connectionRequired`. A required connection can therefore be under-reported during the brief optimistic window, until the update mutation responds with the authoritative task.

### Verification

- `npm run check` (lint + typecheck + tests) on this branch: **353 files / 3799 tests, 0 failures**
- `flattenDefinitionTasks.test.ts` and `saveWorkflowDefinition.test.ts` re-run alone: **37 tests, 0 failures**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
