### PR TITLE
5558 client - Keep array shaped connections out of saved workflow definitions

### DIFF
--- a/client/src/pages/platform/workflow-editor/components/WorkflowOutputsSheetDialog.tsx
+++ b/client/src/pages/platform/workflow-editor/components/WorkflowOutputsSheetDialog.tsx
@@ -14,7 +14,6 @@ import {
 import {Form, FormControl, FormField, FormItem, FormLabel, FormMessage} from '@/components/ui/form';
 import PropertyMentionsInput from '@/pages/platform/workflow-editor/components/properties/components/property-mentions-input/PropertyMentionsInput';
 import {useWorkflowEditor} from '@/pages/platform/workflow-editor/providers/workflowEditorProvider';
-import {SPACE} from '@/shared/constants';
 import {Workflow, WorkflowInput} from '@/shared/middleware/platform/configuration';
 import {WorkflowDefinitionType} from '@/shared/types';
 import {zodResolver} from '@hookform/resolvers/zod';
@@ -22,6 +21,8 @@ import {Editor} from '@tiptap/react';
 import {ReactNode, useRef, useState} from 'react';
 import {useForm} from 'react-hook-form';
 import {z} from 'zod';
+
+import stringifyWorkflowDefinition from '../utils/stringifyWorkflowDefinition';
 
 const formSchema = z.object({
     name: z.string().min(2, {
@@ -83,14 +84,10 @@ const WorkflowOutputsSheetDialog = ({
             {
                 id: workflow.id!,
                 workflow: {
-                    definition: JSON.stringify(
-                        {
-                            ...workflowDefinition,
-                            outputs,
-                        },
-                        null,
-                        SPACE
-                    ),
+                    definition: stringifyWorkflowDefinition({
+                        ...workflowDefinition,
+                        outputs,
+                    }),
                     version: workflow.version,
                 },
             },

--- a/client/src/pages/platform/workflow-editor/components/WorkflowOutputsSheetTable.tsx
+++ b/client/src/pages/platform/workflow-editor/components/WorkflowOutputsSheetTable.tsx
@@ -12,13 +12,13 @@ import {
 import {Table, TableBody, TableCell, TableHead, TableHeader, TableRow} from '@/components/ui/table';
 import WorkflowOutputsSheetDialog from '@/pages/platform/workflow-editor/components/WorkflowOutputsSheetDialog';
 import {useWorkflowEditor} from '@/pages/platform/workflow-editor/providers/workflowEditorProvider';
-import {SPACE} from '@/shared/constants';
 import {Workflow, WorkflowInput} from '@/shared/middleware/platform/configuration';
 import {WorkflowDefinitionType} from '@/shared/types';
 import {CableIcon, EditIcon, Trash2Icon} from 'lucide-react';
 import {useState} from 'react';
 
 import useWorkflowDataStore from '../stores/useWorkflowDataStore';
+import stringifyWorkflowDefinition from '../utils/stringifyWorkflowDefinition';
 import WorkflowOutputValue from './WorkflowOutputValue';
 
 const WorkflowOutputsSheetTable = ({workflow}: {workflow: Workflow}) => {
@@ -42,14 +42,10 @@ const WorkflowOutputsSheetTable = ({workflow}: {workflow: Workflow}) => {
         updateWorkflowMutation!.mutate({
             id: workflow.id!,
             workflow: {
-                definition: JSON.stringify(
-                    {
-                        ...definitionObject,
-                        outputs,
-                    },
-                    null,
-                    SPACE
-                ),
+                definition: stringifyWorkflowDefinition({
+                    ...definitionObject,
+                    outputs,
+                }),
                 version: workflow.version,
             },
         });

--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-code-editor/property-code-editor-dialog/hooks/usePropertyCodeEditorDialogRightPanelConnections.ts
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-code-editor/property-code-editor-dialog/hooks/usePropertyCodeEditorDialogRightPanelConnections.ts
@@ -4,7 +4,7 @@ import {useConnectionNoteStore} from '@/pages/platform/workflow-editor/stores/us
 import useWorkflowDataStore from '@/pages/platform/workflow-editor/stores/useWorkflowDataStore';
 import useWorkflowEditorStore from '@/pages/platform/workflow-editor/stores/useWorkflowEditorStore';
 import useWorkflowNodeDetailsPanelStore from '@/pages/platform/workflow-editor/stores/useWorkflowNodeDetailsPanelStore';
-import {SPACE} from '@/shared/constants';
+import stringifyWorkflowDefinition from '@/pages/platform/workflow-editor/utils/stringifyWorkflowDefinition';
 import {ComponentConnection, Workflow} from '@/shared/middleware/platform/configuration';
 import {useGetWorkflowTestConfigurationConnectionsQuery} from '@/shared/queries/platform/workflowTestConfigurations.queries';
 import {useEnvironmentStore} from '@/shared/stores/useEnvironmentStore';
@@ -144,7 +144,7 @@ export const usePropertyCodeEditorDialogRightPanelConnections = ({
             };
         }
 
-        const definition = JSON.stringify(workflowDefinition, null, SPACE);
+        const definition = stringifyWorkflowDefinition(workflowDefinition);
 
         updateWorkflowMutation!.mutate(
             {
@@ -249,7 +249,7 @@ export const usePropertyCodeEditorDialogRightPanelConnections = ({
             };
         }
 
-        const definition = JSON.stringify(workflowDefinition, null, SPACE);
+        const definition = stringifyWorkflowDefinition(workflowDefinition);
 
         updateWorkflowMutation!.mutate(
             {

--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-code-editor/property-code-editor-dialog/hooks/usePropertyCodeEditorDialogRightPanelConnections.ts
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-code-editor/property-code-editor-dialog/hooks/usePropertyCodeEditorDialogRightPanelConnections.ts
@@ -62,6 +62,34 @@ export const usePropertyCodeEditorDialogRightPanelConnections = ({
             : workflowNodeName,
     });
 
+    const saveConnections = (workflowDefinition: WorkflowDefinitionType) => {
+        const definition = stringifyWorkflowDefinition(workflowDefinition);
+
+        updateWorkflowMutation!.mutate(
+            {
+                id: workflow.id!,
+                workflow: {
+                    definition,
+                    version: workflow.version,
+                },
+            },
+            {
+                onSuccess: (updatedWorkflow) => {
+                    useWorkflowDataStore.getState().setWorkflow({
+                        ...updatedWorkflow,
+                        definition,
+                    });
+
+                    if (isClusterElement) {
+                        queryClient.invalidateQueries({queryKey: ['clusterElementComponentConnections']});
+                    } else {
+                        queryClient.invalidateQueries({queryKey: ['workflowNodeComponentConnections']});
+                    }
+                },
+            }
+        );
+    };
+
     const handleOnSubmit = (values: z.infer<typeof connectionFormSchema>) => {
         if (!workflow?.definition) {
             return;
@@ -144,31 +172,7 @@ export const usePropertyCodeEditorDialogRightPanelConnections = ({
             };
         }
 
-        const definition = stringifyWorkflowDefinition(workflowDefinition);
-
-        updateWorkflowMutation!.mutate(
-            {
-                id: workflow.id!,
-                workflow: {
-                    definition,
-                    version: workflow.version,
-                },
-            },
-            {
-                onSuccess: (updatedWorkflow) => {
-                    useWorkflowDataStore.getState().setWorkflow({
-                        ...updatedWorkflow,
-                        definition,
-                    });
-
-                    if (isClusterElement) {
-                        queryClient.invalidateQueries({queryKey: ['clusterElementComponentConnections']});
-                    } else {
-                        queryClient.invalidateQueries({queryKey: ['workflowNodeComponentConnections']});
-                    }
-                },
-            }
-        );
+        saveConnections(workflowDefinition);
     };
 
     const handleOnRemoveClick = (workflowConnectionKey: string) => {
@@ -249,31 +253,7 @@ export const usePropertyCodeEditorDialogRightPanelConnections = ({
             };
         }
 
-        const definition = stringifyWorkflowDefinition(workflowDefinition);
-
-        updateWorkflowMutation!.mutate(
-            {
-                id: workflow.id!,
-                workflow: {
-                    definition,
-                    version: workflow.version,
-                },
-            },
-            {
-                onSuccess: (updatedWorkflow) => {
-                    useWorkflowDataStore.getState().setWorkflow({
-                        ...updatedWorkflow,
-                        definition,
-                    });
-
-                    if (isClusterElement) {
-                        queryClient.invalidateQueries({queryKey: ['clusterElementComponentConnections']});
-                    } else {
-                        queryClient.invalidateQueries({queryKey: ['workflowNodeComponentConnections']});
-                    }
-                },
-            }
-        );
+        saveConnections(workflowDefinition);
     };
 
     return {

--- a/client/src/pages/platform/workflow-editor/components/workflow-inputs/hooks/useWorkflowInputs.ts
+++ b/client/src/pages/platform/workflow-editor/components/workflow-inputs/hooks/useWorkflowInputs.ts
@@ -1,5 +1,4 @@
 import {useWorkflowEditor} from '@/pages/platform/workflow-editor/providers/workflowEditorProvider';
-import {SPACE} from '@/shared/constants';
 import {WorkflowInput, WorkflowTestConfiguration} from '@/shared/middleware/platform/configuration';
 import {useSaveWorkflowTestConfigurationInputsMutation} from '@/shared/mutations/platform/workflowTestConfigurations.mutations';
 import {WorkflowTestConfigurationKeys} from '@/shared/queries/platform/workflowTestConfigurations.queries';
@@ -11,6 +10,7 @@ import {useForm} from 'react-hook-form';
 import {useShallow} from 'zustand/react/shallow';
 
 import useWorkflowDataStore from '../../../stores/useWorkflowDataStore';
+import stringifyWorkflowDefinition from '../../../utils/stringifyWorkflowDefinition';
 
 interface UseWorkflowInputsProps {
     invalidateWorkflowQueries: () => void;
@@ -163,14 +163,10 @@ export default function useWorkflowInputs({
             {
                 id: workflow.id!,
                 workflow: {
-                    definition: JSON.stringify(
-                        {
-                            ...workflowDefinition,
-                            inputs,
-                        },
-                        null,
-                        SPACE
-                    ),
+                    definition: stringifyWorkflowDefinition({
+                        ...workflowDefinition,
+                        inputs,
+                    }),
                     version: workflow.version,
                 },
             },
@@ -239,14 +235,10 @@ export default function useWorkflowInputs({
             {
                 id: workflow.id!,
                 workflow: {
-                    definition: JSON.stringify(
-                        {
-                            ...definitionObject,
-                            inputs,
-                        },
-                        null,
-                        SPACE
-                    ),
+                    definition: stringifyWorkflowDefinition({
+                        ...definitionObject,
+                        inputs,
+                    }),
                     version: workflow.version,
                 },
             },

--- a/client/src/pages/platform/workflow-editor/stores/useWorkflowDataStore.ts
+++ b/client/src/pages/platform/workflow-editor/stores/useWorkflowDataStore.ts
@@ -1,5 +1,5 @@
 /* eslint-disable sort-keys */
-import {DEFAULT_CANVAS_WIDTH, SPACE} from '@/shared/constants';
+import {DEFAULT_CANVAS_WIDTH} from '@/shared/constants';
 import {ComponentDefinitionBasic, TaskDispatcherDefinition, Workflow} from '@/shared/middleware/platform/configuration';
 import {DataPillType, WorkflowNodeType} from '@/shared/types';
 import {Edge, Node, OnEdgesChange, OnNodesChange, applyEdgeChanges, applyNodeChanges} from '@xyflow/react';
@@ -8,6 +8,7 @@ import {create, useStore} from 'zustand';
 import {devtools} from 'zustand/middleware';
 
 import {createDefaultEdges, createDefaultNodes} from '../utils/layoutUtils';
+import stringifyWorkflowDefinition from '../utils/stringifyWorkflowDefinition';
 import {forEachNestedTaskGroup} from '../utils/taskTraversalUtils';
 
 export type WorkflowDataType = {
@@ -334,7 +335,7 @@ const useWorkflowDataStore = create<WorkflowDataStateI>()(
                             nodes: updatedNodes,
                             workflow: {
                                 ...workflow,
-                                definition: JSON.stringify(definition, null, SPACE),
+                                definition: stringifyWorkflowDefinition(definition),
                                 tasks: updatedTasks,
                                 triggers: updatedTriggers,
                                 version: version ?? workflow.version,

--- a/client/src/pages/platform/workflow-editor/utils/clearAllNodePositions.ts
+++ b/client/src/pages/platform/workflow-editor/utils/clearAllNodePositions.ts
@@ -1,8 +1,8 @@
-import {SPACE} from '@/shared/constants';
 import {WorkflowTask} from '@/shared/middleware/platform/configuration';
 import {BranchCaseType, UpdateWorkflowMutationType} from '@/shared/types';
 
 import useWorkflowDataStore from '../stores/useWorkflowDataStore';
+import stringifyWorkflowDefinition from './stringifyWorkflowDefinition';
 import {
     drainPendingDefinitionMutation,
     hasPendingDefinition,
@@ -167,7 +167,7 @@ export default function clearAllNodePositions({
 
     // Update the store's definition immediately so the layout effect
     // reads cleared positions when incrementLayoutResetCounter fires.
-    const updatedDefinitionStr = JSON.stringify(workflowDefinition, null, SPACE);
+    const updatedDefinitionStr = stringifyWorkflowDefinition(workflowDefinition);
 
     useWorkflowDataStore.setState((state) => ({
         workflow: {

--- a/client/src/pages/platform/workflow-editor/utils/handleDeleteTask.ts
+++ b/client/src/pages/platform/workflow-editor/utils/handleDeleteTask.ts
@@ -1,10 +1,5 @@
 import useWorkflowTestChatStore from '@/pages/platform/workflow-editor/stores/useWorkflowTestChatStore';
-import {
-    ON_ERROR_MAIN_BRANCH,
-    ON_ERROR_WIRE_KEY_ERROR_BRANCH,
-    ON_ERROR_WIRE_KEY_MAIN_BRANCH,
-    SPACE,
-} from '@/shared/constants';
+import {ON_ERROR_MAIN_BRANCH, ON_ERROR_WIRE_KEY_ERROR_BRANCH, ON_ERROR_WIRE_KEY_MAIN_BRANCH} from '@/shared/constants';
 import {Workflow, WorkflowTask} from '@/shared/middleware/platform/configuration';
 import {invalidatePreviousWorkflowNodeOutputsForWorkflow} from '@/shared/queries/platform/workflowNodeOutputs.queries';
 import {
@@ -21,6 +16,7 @@ import useWorkflowNodeDetailsPanelStore from '../stores/useWorkflowNodeDetailsPa
 import findAndRemoveClusterElement from './findAndRemoveClusterElement';
 import getRecursivelyUpdatedTasks from './getRecursivelyUpdatedTasks';
 import {getTask} from './getTask';
+import stringifyWorkflowDefinition from './stringifyWorkflowDefinition';
 import {TASK_DISPATCHER_CONFIG} from './taskDispatcherConfig';
 import {forEachNestedTaskGroup} from './taskTraversalUtils';
 import {isWorkflowMutating, setWorkflowMutating} from './workflowMutationGuard';
@@ -332,14 +328,10 @@ export default function handleDeleteTask({
     // to prevent stale server data from overwriting the upcoming optimistic update.
     cancelWorkflowQueries();
 
-    const updatedDefinition = JSON.stringify(
-        {
-            ...workflowDefinition,
-            tasks: updatedTasks,
-        },
-        null,
-        SPACE
-    );
+    const updatedDefinition = stringifyWorkflowDefinition({
+        ...workflowDefinition,
+        tasks: updatedTasks,
+    });
 
     const previousWorkflow = workflow;
 

--- a/client/src/pages/platform/workflow-editor/utils/removeWorkflowNodePosition.ts
+++ b/client/src/pages/platform/workflow-editor/utils/removeWorkflowNodePosition.ts
@@ -1,9 +1,9 @@
-import {SPACE} from '@/shared/constants';
 import {WorkflowTask} from '@/shared/middleware/platform/configuration';
 import {BranchCaseType, UpdateWorkflowMutationType} from '@/shared/types';
 
 import useWorkflowDataStore from '../stores/useWorkflowDataStore';
 import {clearTaskPositions} from './clearAllNodePositions';
+import stringifyWorkflowDefinition from './stringifyWorkflowDefinition';
 import {
     drainPendingDefinitionMutation,
     hasPendingDefinition,
@@ -176,7 +176,7 @@ export default function removeWorkflowNodePosition({
 
     // Update the store's definition immediately so the layout effect
     // reads the correct positions when incrementLayoutResetCounter fires.
-    const updatedDefinitionStr = JSON.stringify(workflowDefinition, null, SPACE);
+    const updatedDefinitionStr = stringifyWorkflowDefinition(workflowDefinition);
 
     useWorkflowDataStore.setState((state) => ({
         workflow: {

--- a/client/src/pages/platform/workflow-editor/utils/saveWorkflowDefinition.test.ts
+++ b/client/src/pages/platform/workflow-editor/utils/saveWorkflowDefinition.test.ts
@@ -416,7 +416,14 @@ describe('saveWorkflowDefinition', () => {
 
             const mutateArgs = (mutation.mutate as ReturnType<typeof vi.fn>).mock.calls[0][0];
 
-            expect(mutateArgs.workflow.definition).not.toContain('"connections"');
+            const savedDefinition = JSON.parse(mutateArgs.workflow.definition);
+            const savedConditionTask = savedDefinition.tasks.find(
+                (task: {name: string}) => task.name === 'condition_1'
+            );
+            const savedNestedTask = savedConditionTask.parameters.caseTrue[0];
+
+            expect(savedNestedTask.name).toBe('condition_2');
+            expect(savedNestedTask).not.toHaveProperty('connections');
         });
 
         it('should convert definition connections maps into DTO connections arrays', async () => {

--- a/client/src/pages/platform/workflow-editor/utils/saveWorkflowDefinition.test.ts
+++ b/client/src/pages/platform/workflow-editor/utils/saveWorkflowDefinition.test.ts
@@ -380,6 +380,45 @@ describe('saveWorkflowDefinition', () => {
     });
 
     describe('optimistic update', () => {
+        it('should strip array shaped connections left in the definition by earlier client versions', async () => {
+            mockWorkflowState = makeWorkflowState([
+                {
+                    name: 'condition_1',
+                    parameters: {
+                        caseFalse: [],
+                        caseTrue: [
+                            {
+                                connections: [],
+                                finalize: [],
+                                name: 'condition_2',
+                                parameters: {caseFalse: [], caseTrue: []},
+                                post: [],
+                                pre: [],
+                                type: 'condition/v1',
+                            },
+                        ],
+                    },
+                    type: 'condition/v1',
+                },
+            ]);
+
+            const mutation = makeMutation();
+
+            await saveWorkflowDefinition({
+                nodeData: {
+                    componentName: 'httpClient',
+                    name: 'httpClient_1',
+                    operationName: 'get',
+                    version: 1,
+                } as unknown as NodeDataType,
+                updateWorkflowMutation: mutation,
+            });
+
+            const mutateArgs = (mutation.mutate as ReturnType<typeof vi.fn>).mock.calls[0][0];
+
+            expect(mutateArgs.workflow.definition).not.toContain('"connections"');
+        });
+
         it('should convert definition connections maps into DTO connections arrays', async () => {
             mockWorkflowState = makeWorkflowState([
                 {

--- a/client/src/pages/platform/workflow-editor/utils/saveWorkflowDefinition.ts
+++ b/client/src/pages/platform/workflow-editor/utils/saveWorkflowDefinition.ts
@@ -1,4 +1,3 @@
-import {SPACE} from '@/shared/constants';
 import {Workflow, WorkflowTask, WorkflowTrigger} from '@/shared/middleware/platform/configuration';
 import {
     BranchCaseType,
@@ -14,6 +13,7 @@ import {flattenDefinitionTasks} from './flattenDefinitionTasks';
 import getRecursivelyUpdatedTasks from './getRecursivelyUpdatedTasks';
 import {getTask} from './getTask';
 import insertTaskDispatcherSubtask from './insertTaskDispatcherSubtask';
+import stringifyWorkflowDefinition from './stringifyWorkflowDefinition';
 import {isWorkflowMutating, setWorkflowMutating} from './workflowMutationGuard';
 
 interface SaveWorkflowDefinitionProps {
@@ -294,14 +294,10 @@ function executeWorkflowMutation({
         return;
     }
 
-    const updatedDefinition = JSON.stringify(
-        {
-            ...workflowDefinition,
-            ...definitionUpdate,
-        },
-        null,
-        SPACE
-    );
+    const updatedDefinition = stringifyWorkflowDefinition({
+        ...workflowDefinition,
+        ...definitionUpdate,
+    });
 
     const previousWorkflow = workflow;
 

--- a/client/src/pages/platform/workflow-editor/utils/saveWorkflowNodesPosition.ts
+++ b/client/src/pages/platform/workflow-editor/utils/saveWorkflowNodesPosition.ts
@@ -1,9 +1,9 @@
-import {SPACE} from '@/shared/constants';
 import {WorkflowTask} from '@/shared/middleware/platform/configuration';
 import {BranchCaseType, NodeDataType, UpdateWorkflowMutationType} from '@/shared/types';
 import {Node} from '@xyflow/react';
 
 import useWorkflowDataStore, {runWithoutHistory} from '../stores/useWorkflowDataStore';
+import stringifyWorkflowDefinition from './stringifyWorkflowDefinition';
 import {
     consumePendingDefinition,
     isWorkflowMutating,
@@ -223,7 +223,7 @@ export default function saveWorkflowNodesPosition({
     // can read the latest positions when it re-runs (e.g. on panel toggle).
     // storeTasks uses fingerprint equality that ignores position metadata,
     // so this is the only way to keep positions in sync without a full refetch.
-    const updatedDefinitionStr = JSON.stringify(workflowDefinition, null, SPACE);
+    const updatedDefinitionStr = stringifyWorkflowDefinition(workflowDefinition);
 
     useWorkflowDataStore.setState((state) => ({
         workflow: {

--- a/client/src/pages/platform/workflow-editor/utils/stringifyWorkflowDefinition.test.ts
+++ b/client/src/pages/platform/workflow-editor/utils/stringifyWorkflowDefinition.test.ts
@@ -1,0 +1,106 @@
+import {describe, expect, it} from 'vitest';
+
+import stringifyWorkflowDefinition from './stringifyWorkflowDefinition';
+
+describe('stringifyWorkflowDefinition', () => {
+    it('should keep a map shaped connections declaration', () => {
+        const definition = {
+            tasks: [
+                {
+                    connections: {gm: {componentName: 'googleMail', componentVersion: 1}},
+                    name: 'script_1',
+                    type: 'script/v1/javascript',
+                },
+            ],
+        };
+
+        expect(JSON.parse(stringifyWorkflowDefinition(definition))).toEqual(definition);
+    });
+
+    it('should drop an array shaped connections declaration from a task', () => {
+        const definition = {
+            tasks: [{connections: [], name: 'condition_1', parameters: {}, type: 'condition/v1'}],
+        };
+
+        expect(JSON.parse(stringifyWorkflowDefinition(definition))).toEqual({
+            tasks: [{name: 'condition_1', parameters: {}, type: 'condition/v1'}],
+        });
+    });
+
+    it('should drop an array shaped connections declaration from a nested subtask', () => {
+        const definition = {
+            tasks: [
+                {
+                    name: 'condition_1',
+                    parameters: {
+                        caseTrue: [
+                            {
+                                connections: [],
+                                finalize: [],
+                                name: 'condition_2',
+                                parameters: {caseTrue: []},
+                                post: [],
+                                pre: [],
+                                type: 'condition/v1',
+                            },
+                        ],
+                    },
+                    type: 'condition/v1',
+                },
+            ],
+        };
+
+        const result = JSON.parse(stringifyWorkflowDefinition(definition));
+
+        expect(result.tasks[0].parameters.caseTrue[0]).toEqual({
+            finalize: [],
+            name: 'condition_2',
+            parameters: {caseTrue: []},
+            post: [],
+            pre: [],
+            type: 'condition/v1',
+        });
+    });
+
+    it('should drop a non-empty array shaped connections declaration', () => {
+        const definition = {
+            tasks: [
+                {
+                    connections: [
+                        {
+                            componentName: 'googleMail',
+                            componentVersion: 1,
+                            key: 'gm',
+                            required: false,
+                            workflowNodeName: 'script_1',
+                        },
+                    ],
+                    name: 'script_1',
+                    type: 'script/v1/javascript',
+                },
+            ],
+        };
+
+        expect(JSON.parse(stringifyWorkflowDefinition(definition))).toEqual({
+            tasks: [{name: 'script_1', type: 'script/v1/javascript'}],
+        });
+    });
+
+    it('should leave a connections array that is component parameter data untouched', () => {
+        const definition = {
+            tasks: [
+                {
+                    name: 'httpClient_1',
+                    parameters: {body: {connections: ['a', 'b']}},
+                    type: 'httpClient/v1/post',
+                },
+            ],
+        };
+
+        expect(JSON.parse(stringifyWorkflowDefinition(definition))).toEqual(definition);
+    });
+
+    it('should indent with the shared workflow definition spacing', () => {
+        expect(stringifyWorkflowDefinition({tasks: []})).toBe('{\n    "tasks": []\n}');
+    });
+});

--- a/client/src/pages/platform/workflow-editor/utils/stringifyWorkflowDefinition.ts
+++ b/client/src/pages/platform/workflow-editor/utils/stringifyWorkflowDefinition.ts
@@ -1,0 +1,38 @@
+import {SPACE} from '@/shared/constants';
+
+/**
+ * A task declares its connections as a map keyed by connection name in the workflow definition, but
+ * the REST DTO exposes the same field as an array of ComponentConnection. A DTO shaped task that
+ * reaches the definition therefore writes an array the server cannot read, since
+ * `ComponentConnection.of` parses the field with `MapUtils.getMap`.
+ *
+ * Dropping the array shape while serializing keeps the invalid shape out of saved definitions no
+ * matter which caller assembled the tasks, and heals definitions that already carry it on their next
+ * save.
+ */
+function dropArrayShapedConnections(this: unknown, key: string, value: unknown): unknown {
+    if (key === 'connections' && Array.isArray(value) && isTaskLike(this)) {
+        return undefined;
+    }
+
+    return value;
+}
+
+/**
+ * Only tasks and cluster elements own a `connections` declaration. Component parameters are free to
+ * hold a value under the same name, so the holder has to look like a task before its connections are
+ * dropped. This matches the task detection in flattenDefinitionTasks.
+ */
+function isTaskLike(value: unknown): boolean {
+    if (value === null || typeof value !== 'object') {
+        return false;
+    }
+
+    const {name, type} = value as {name?: unknown; type?: unknown};
+
+    return typeof name === 'string' && typeof type === 'string' && type.includes('/');
+}
+
+export default function stringifyWorkflowDefinition(definition: unknown): string {
+    return JSON.stringify(definition, dropArrayShapedConnections, SPACE);
+}


### PR DESCRIPTION
Closes #5558

A task declares its connections as a map keyed by connection name in the definition, while the REST DTO exposes the same field as an array of `ComponentConnection`. A DTO-shaped task that reaches the definition writes an array the server cannot read, since `ComponentConnection.of` parses the field with `MapUtils.getMap`.

A dev database holds 11 workflows carrying the array shape — always on a `condition` task nested inside another task dispatcher, always with the empty `connections`, `finalize`, `post` and `pre` arrays the generated REST model initializes.

### Fix

No current code path reproduces it, so this enforces the invariant while serializing rather than guarding one caller. `stringifyWorkflowDefinition` drops array-shaped connections through a `JSON.stringify` replacer and is wired into **every** whole-definition write — the structural writers (`saveWorkflowDefinition`, `handleDeleteTask`), the positional ones (`clearAllNodePositions`, `removeWorkflowNodePosition`, `saveWorkflowNodesPosition`), the store's own definition write, and the inputs / outputs / code-editor-connection editors. The `JSON.stringify(..., null, SPACE)` calls that remain serialize sample data and JSON schemas, not definitions.

The replacer receives the holder as `this`, so a task's own `connections` declaration stays distinguishable from a component parameter that merely happens to be named `connections`.

Definitions already carrying the shape heal on their next save — any save, not only a structural one. Verified against all 11 real definitions: the array shape goes to zero and nothing else changes.

### Relationship to #5566 (merged)

Opposite directions of the same seam, and both are needed:

- #5566 normalizes definition map → DTO array on the way **out** of the definition, so the editor's optimistic update stops writing map-shaped connections into `workflow.tasks`
- this change strips DTO array → nothing on the way **in** to the definition, so a DTO-shaped task can never persist an array the server cannot parse

### Verification

- `npm run check` (lint + typecheck + tests) on this branch: **354 files / 3806 tests, 0 failures**
- Checked before routing the code-editor connection writer, since it is the one that *adds* connections: it builds map shape in both branches, so the replacer cannot eat a real connection
- `stringifyWorkflowDefinition.test.ts` + `saveWorkflowDefinition.test.ts` re-run alone: **30 tests, 0 failures**

One note for review: the cherry-pick from the development branch carried an `upsertTrigger` import that does not exist on `master`. It is unrelated to this change and was dropped in the conflict resolution; `SPACE` likewise became unused once `stringifyWorkflowDefinition` took over the serialization. Typecheck confirms neither is referenced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
