### PR TITLE
5561 client - Add Stream response toggle to the simple AI Agent editor

### DIFF
--- a/client/src/pages/platform/cluster-element-editor/ai-agent-editor/components/ai-agent-configuration-panel/AiAgentConfigurationPanel.tsx
+++ b/client/src/pages/platform/cluster-element-editor/ai-agent-editor/components/ai-agent-configuration-panel/AiAgentConfigurationPanel.tsx
@@ -1,5 +1,6 @@
 import AiAgentModelSelectField from '@/pages/platform/cluster-element-editor/ai-agent-editor/components/ai-agent-configuration-panel/components/AiAgentModelSelectField';
 import AiAgentPromptField from '@/pages/platform/cluster-element-editor/ai-agent-editor/components/ai-agent-configuration-panel/components/AiAgentPromptField';
+import AiAgentStreamResponseField from '@/pages/platform/cluster-element-editor/ai-agent-editor/components/ai-agent-configuration-panel/components/AiAgentStreamResponseField';
 import AiAgentTools from '@/pages/platform/cluster-element-editor/ai-agent-editor/components/ai-agent-configuration-panel/components/AiAgentTools';
 import useWorkflowDataStore from '@/pages/platform/workflow-editor/stores/useWorkflowDataStore';
 import {useShallow} from 'zustand/shallow';
@@ -42,6 +43,8 @@ export function AiAgentConfigurationPanel() {
             <h2 className="font-medium">Configuration</h2>
 
             <AiAgentModelSelectField />
+
+            <AiAgentStreamResponseField />
 
             {PROMPT_FIELDS.map((field) => (
                 <AiAgentPromptField

--- a/client/src/pages/platform/cluster-element-editor/ai-agent-editor/components/ai-agent-configuration-panel/components/AiAgentStreamResponseField.test.tsx
+++ b/client/src/pages/platform/cluster-element-editor/ai-agent-editor/components/ai-agent-configuration-panel/components/AiAgentStreamResponseField.test.tsx
@@ -1,0 +1,61 @@
+import {render, screen, userEvent} from '@/shared/util/test-utils';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+
+const {updateStreamingMock, useAiAgentStreamResponseMock} = vi.hoisted(() => ({
+    updateStreamingMock: vi.fn(),
+    useAiAgentStreamResponseMock: vi.fn(),
+}));
+
+vi.mock('./hooks/useAiAgentStreamResponse', () => ({
+    default: useAiAgentStreamResponseMock,
+}));
+
+import AiAgentStreamResponseField from './AiAgentStreamResponseField';
+
+const mockHook = (isStreaming: boolean, isStreamingSupported: boolean) => {
+    useAiAgentStreamResponseMock.mockReturnValue({
+        isStreaming,
+        isStreamingSupported,
+        updateStreaming: updateStreamingMock,
+    });
+};
+
+describe('AiAgentStreamResponseField', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('renders nothing for an action that does not support streaming', () => {
+        mockHook(false, false);
+
+        const {container} = render(<AiAgentStreamResponseField />);
+
+        expect(container).toBeEmptyDOMElement();
+    });
+
+    it('renders an unchecked switch for the chat action', () => {
+        mockHook(false, true);
+
+        render(<AiAgentStreamResponseField />);
+
+        expect(screen.getByRole('switch', {name: /stream response/i})).not.toBeChecked();
+    });
+
+    it('renders a checked switch for the streamChat action', () => {
+        mockHook(true, true);
+
+        render(<AiAgentStreamResponseField />);
+
+        expect(screen.getByRole('switch', {name: /stream response/i})).toBeChecked();
+    });
+
+    it('turns streaming on when the switch is toggled', async () => {
+        mockHook(false, true);
+
+        render(<AiAgentStreamResponseField />);
+
+        await userEvent.click(screen.getByRole('switch', {name: /stream response/i}));
+
+        expect(updateStreamingMock).toHaveBeenCalledWith(true);
+    });
+});

--- a/client/src/pages/platform/cluster-element-editor/ai-agent-editor/components/ai-agent-configuration-panel/components/AiAgentStreamResponseField.tsx
+++ b/client/src/pages/platform/cluster-element-editor/ai-agent-editor/components/ai-agent-configuration-panel/components/AiAgentStreamResponseField.tsx
@@ -1,0 +1,20 @@
+import Switch from '@/components/Switch/Switch';
+
+import useAiAgentStreamResponse from './hooks/useAiAgentStreamResponse';
+
+export default function AiAgentStreamResponseField() {
+    const {isStreaming, isStreamingSupported, updateStreaming} = useAiAgentStreamResponse();
+
+    if (!isStreamingSupported) {
+        return null;
+    }
+
+    return (
+        <Switch
+            checked={isStreaming}
+            description="Send the response back token by token instead of once it is complete."
+            label="Stream response"
+            onCheckedChange={updateStreaming}
+        />
+    );
+}

--- a/client/src/pages/platform/cluster-element-editor/ai-agent-editor/components/ai-agent-configuration-panel/components/hooks/useAiAgentStreamResponse.test.ts
+++ b/client/src/pages/platform/cluster-element-editor/ai-agent-editor/components/ai-agent-configuration-panel/components/hooks/useAiAgentStreamResponse.test.ts
@@ -116,6 +116,52 @@ describe('useAiAgentStreamResponse', () => {
         expect(setRootClusterElementNodeDataMock).toHaveBeenCalledWith(nodeData);
     });
 
+    it('falls back to the node data operation when the workflow has no definition', () => {
+        useWorkflowDataStoreMock.mockImplementation((selector: (state: unknown) => unknown) =>
+            selector({workflow: {id: 'workflow-1'}})
+        );
+
+        const {result} = renderHook(() => useAiAgentStreamResponse());
+
+        expect(result.current.isStreamingSupported).toBe(true);
+        expect(result.current.isStreaming).toBe(false);
+    });
+
+    it('falls back to the node data operation when the definition cannot be parsed', () => {
+        useWorkflowDataStoreMock.mockImplementation((selector: (state: unknown) => unknown) =>
+            selector({workflow: {definition: '{not json', id: 'workflow-1'}})
+        );
+
+        const {result} = renderHook(() => useAiAgentStreamResponse());
+
+        expect(result.current.isStreamingSupported).toBe(true);
+
+        result.current.updateStreaming(true);
+
+        const [{nodeData}] = saveWorkflowDefinitionMock.mock.calls[0];
+
+        expect(nodeData.parameters).toEqual({});
+    });
+
+    it('does not save when the root node data carries no component name', () => {
+        useWorkflowEditorStoreMock.mockImplementation((selector: (state: unknown) => unknown) =>
+            selector({
+                rootClusterElementNodeData: {
+                    ...rootClusterElementNodeData,
+                    componentName: undefined,
+                },
+                setRootClusterElementNodeData: setRootClusterElementNodeDataMock,
+            })
+        );
+
+        const {result} = renderHook(() => useAiAgentStreamResponse());
+
+        result.current.updateStreaming(true);
+
+        expect(saveWorkflowDefinitionMock).not.toHaveBeenCalled();
+        expect(setRootClusterElementNodeDataMock).not.toHaveBeenCalled();
+    });
+
     it('switches the root task back to chat', () => {
         mockStores('streamChat');
 

--- a/client/src/pages/platform/cluster-element-editor/ai-agent-editor/components/ai-agent-configuration-panel/components/hooks/useAiAgentStreamResponse.test.ts
+++ b/client/src/pages/platform/cluster-element-editor/ai-agent-editor/components/ai-agent-configuration-panel/components/hooks/useAiAgentStreamResponse.test.ts
@@ -1,0 +1,132 @@
+import {renderHook} from '@testing-library/react';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+
+const {
+    saveWorkflowDefinitionMock,
+    setRootClusterElementNodeDataMock,
+    useWorkflowDataStoreMock,
+    useWorkflowEditorStoreMock,
+} = vi.hoisted(() => ({
+    saveWorkflowDefinitionMock: vi.fn(),
+    setRootClusterElementNodeDataMock: vi.fn(),
+    useWorkflowDataStoreMock: vi.fn(),
+    useWorkflowEditorStoreMock: vi.fn(),
+}));
+
+vi.mock('@/pages/platform/workflow-editor/providers/workflowEditorProvider', () => ({
+    useWorkflowEditor: () => ({updateWorkflowMutation: {mutate: vi.fn()}}),
+}));
+
+vi.mock('@/pages/platform/workflow-editor/stores/useWorkflowDataStore', () => ({
+    default: useWorkflowDataStoreMock,
+}));
+
+vi.mock('@/pages/platform/workflow-editor/stores/useWorkflowEditorStore', () => ({
+    default: useWorkflowEditorStoreMock,
+}));
+
+vi.mock('@/pages/platform/workflow-editor/utils/saveWorkflowDefinition', () => ({
+    default: saveWorkflowDefinitionMock,
+}));
+
+import useAiAgentStreamResponse from './useAiAgentStreamResponse';
+
+const rootClusterElementNodeData = {
+    clusterElements: {model: [{name: 'anthropic_1', type: 'anthropic/v1/model'}], tools: []},
+    componentName: 'aiAgent',
+    name: 'aiAgent_1',
+    operationName: 'chat',
+    type: 'aiAgent/v1/chat',
+    workflowNodeName: 'aiAgent_1',
+};
+
+const buildDefinition = (operationName: string) =>
+    JSON.stringify({
+        tasks: [
+            {
+                name: 'aiAgent_1',
+                parameters: {
+                    response: {responseFormat: 'JSON'},
+                    systemPrompt: 'Be helpful',
+                    userPrompt: 'Hello',
+                },
+                type: `aiAgent/v1/${operationName}`,
+            },
+        ],
+    });
+
+const mockStores = (operationName: string) => {
+    useWorkflowEditorStoreMock.mockImplementation((selector: (state: unknown) => unknown) =>
+        selector({
+            rootClusterElementNodeData: {
+                ...rootClusterElementNodeData,
+                operationName,
+                type: `aiAgent/v1/${operationName}`,
+            },
+            setRootClusterElementNodeData: setRootClusterElementNodeDataMock,
+        })
+    );
+
+    useWorkflowDataStoreMock.mockImplementation((selector: (state: unknown) => unknown) =>
+        selector({workflow: {definition: buildDefinition(operationName), id: 'workflow-1'}})
+    );
+};
+
+describe('useAiAgentStreamResponse', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+
+        mockStores('chat');
+    });
+
+    it('reports the chat action as not streaming', () => {
+        const {result} = renderHook(() => useAiAgentStreamResponse());
+
+        expect(result.current.isStreaming).toBe(false);
+        expect(result.current.isStreamingSupported).toBe(true);
+    });
+
+    it('reports the streamChat action as streaming', () => {
+        mockStores('streamChat');
+
+        const {result} = renderHook(() => useAiAgentStreamResponse());
+
+        expect(result.current.isStreaming).toBe(true);
+    });
+
+    it('hides the toggle for an action that is neither chat nor streamChat', () => {
+        mockStores('realtimeChat');
+
+        const {result} = renderHook(() => useAiAgentStreamResponse());
+
+        expect(result.current.isStreamingSupported).toBe(false);
+    });
+
+    it('switches the root task to streamChat, keeping the prompts and dropping the response format', () => {
+        const {result} = renderHook(() => useAiAgentStreamResponse());
+
+        result.current.updateStreaming(true);
+
+        const [{nodeData}] = saveWorkflowDefinitionMock.mock.calls[0];
+
+        expect(nodeData.type).toBe('aiAgent/v1/streamChat');
+        expect(nodeData.operationName).toBe('streamChat');
+        expect(nodeData.parameters).toEqual({systemPrompt: 'Be helpful', userPrompt: 'Hello'});
+        expect(nodeData.clusterElements).toEqual(rootClusterElementNodeData.clusterElements);
+        expect(setRootClusterElementNodeDataMock).toHaveBeenCalledWith(nodeData);
+    });
+
+    it('switches the root task back to chat', () => {
+        mockStores('streamChat');
+
+        const {result} = renderHook(() => useAiAgentStreamResponse());
+
+        result.current.updateStreaming(false);
+
+        const [{nodeData}] = saveWorkflowDefinitionMock.mock.calls[0];
+
+        expect(nodeData.type).toBe('aiAgent/v1/chat');
+        expect(nodeData.operationName).toBe('chat');
+        expect(nodeData.parameters.response).toEqual({responseFormat: 'JSON'});
+    });
+});

--- a/client/src/pages/platform/cluster-element-editor/ai-agent-editor/components/ai-agent-configuration-panel/components/hooks/useAiAgentStreamResponse.test.ts
+++ b/client/src/pages/platform/cluster-element-editor/ai-agent-editor/components/ai-agent-configuration-panel/components/hooks/useAiAgentStreamResponse.test.ts
@@ -102,7 +102,7 @@ describe('useAiAgentStreamResponse', () => {
         expect(result.current.isStreamingSupported).toBe(false);
     });
 
-    it('switches the root task to streamChat, keeping the prompts and dropping the response format', () => {
+    it('switches the root task to streamChat, keeping every parameter', () => {
         const {result} = renderHook(() => useAiAgentStreamResponse());
 
         result.current.updateStreaming(true);
@@ -111,7 +111,11 @@ describe('useAiAgentStreamResponse', () => {
 
         expect(nodeData.type).toBe('aiAgent/v1/streamChat');
         expect(nodeData.operationName).toBe('streamChat');
-        expect(nodeData.parameters).toEqual({systemPrompt: 'Be helpful', userPrompt: 'Hello'});
+        expect(nodeData.parameters).toEqual({
+            response: {responseFormat: 'JSON'},
+            systemPrompt: 'Be helpful',
+            userPrompt: 'Hello',
+        });
         expect(nodeData.clusterElements).toEqual(rootClusterElementNodeData.clusterElements);
         expect(setRootClusterElementNodeDataMock).toHaveBeenCalledWith(nodeData);
     });
@@ -125,9 +129,13 @@ describe('useAiAgentStreamResponse', () => {
 
         expect(result.current.isStreamingSupported).toBe(true);
         expect(result.current.isStreaming).toBe(false);
+
+        result.current.updateStreaming(true);
+
+        expect(saveWorkflowDefinitionMock).not.toHaveBeenCalled();
     });
 
-    it('falls back to the node data operation when the definition cannot be parsed', () => {
+    it('does not save when the definition cannot be parsed, so the prompts survive', () => {
         useWorkflowDataStoreMock.mockImplementation((selector: (state: unknown) => unknown) =>
             selector({workflow: {definition: '{not json', id: 'workflow-1'}})
         );
@@ -138,9 +146,8 @@ describe('useAiAgentStreamResponse', () => {
 
         result.current.updateStreaming(true);
 
-        const [{nodeData}] = saveWorkflowDefinitionMock.mock.calls[0];
-
-        expect(nodeData.parameters).toEqual({});
+        expect(saveWorkflowDefinitionMock).not.toHaveBeenCalled();
+        expect(setRootClusterElementNodeDataMock).not.toHaveBeenCalled();
     });
 
     it('does not save when the root node data carries no component name', () => {

--- a/client/src/pages/platform/cluster-element-editor/ai-agent-editor/components/ai-agent-configuration-panel/components/hooks/useAiAgentStreamResponse.ts
+++ b/client/src/pages/platform/cluster-element-editor/ai-agent-editor/components/ai-agent-configuration-panel/components/hooks/useAiAgentStreamResponse.ts
@@ -1,0 +1,96 @@
+import {useWorkflowEditor} from '@/pages/platform/workflow-editor/providers/workflowEditorProvider';
+import useWorkflowDataStore from '@/pages/platform/workflow-editor/stores/useWorkflowDataStore';
+import useWorkflowEditorStore from '@/pages/platform/workflow-editor/stores/useWorkflowEditorStore';
+import {getTask} from '@/pages/platform/workflow-editor/utils/getTask';
+import saveWorkflowDefinition from '@/pages/platform/workflow-editor/utils/saveWorkflowDefinition';
+import {useCallback, useMemo} from 'react';
+
+export const CHAT_OPERATION_NAME = 'chat';
+export const STREAM_CHAT_OPERATION_NAME = 'streamChat';
+
+// A streamed response cannot be validated against a JSON schema, so AiAgentConstants.STREAM_CHAT_PROPERTIES
+// omits the structured output property that AiAgentConstants.CHAT_PROPERTIES declares. Every other property
+// is shared by both actions, which is what makes the switch a toggle rather than a full action select.
+const RESPONSE_PARAMETER_NAME = 'response';
+
+interface UseAiAgentStreamResponseI {
+    isStreaming: boolean;
+    isStreamingSupported: boolean;
+    updateStreaming: (streaming: boolean) => void;
+}
+
+export default function useAiAgentStreamResponse(): UseAiAgentStreamResponseI {
+    const rootClusterElementNodeData = useWorkflowEditorStore((state) => state.rootClusterElementNodeData);
+    const setRootClusterElementNodeData = useWorkflowEditorStore((state) => state.setRootClusterElementNodeData);
+    const workflow = useWorkflowDataStore((state) => state.workflow);
+
+    const {updateWorkflowMutation} = useWorkflowEditor();
+
+    // The root task is read from the workflow definition rather than from rootClusterElementNodeData, which is
+    // seeded once per root and never carries the prompts written by AiAgentPromptField. saveWorkflowDefinition
+    // replaces a cluster root's parameters wholesale, so writing the stale copy back would wipe them.
+    const rootTask = useMemo(() => {
+        if (!workflow.definition || !rootClusterElementNodeData?.workflowNodeName) {
+            return undefined;
+        }
+
+        try {
+            const definition = JSON.parse(workflow.definition);
+
+            return getTask({
+                tasks: definition.tasks ?? [],
+                workflowNodeName: rootClusterElementNodeData.workflowNodeName,
+            });
+        } catch {
+            return undefined;
+        }
+    }, [rootClusterElementNodeData?.workflowNodeName, workflow.definition]);
+
+    const operationName =
+        rootTask?.type?.split('/')[2] ||
+        rootClusterElementNodeData?.operationName ||
+        rootClusterElementNodeData?.type?.split('/')[2] ||
+        '';
+
+    const updateStreaming = useCallback(
+        (streaming: boolean) => {
+            const targetOperationName = streaming ? STREAM_CHAT_OPERATION_NAME : CHAT_OPERATION_NAME;
+
+            if (!rootClusterElementNodeData?.componentName || !updateWorkflowMutation) {
+                return;
+            }
+
+            const componentVersion =
+                Number(rootClusterElementNodeData.type?.split('/')[1]?.replace(/^v/, '')) ||
+                rootClusterElementNodeData.version ||
+                1;
+
+            const parameters = {...(rootTask?.parameters ?? {})};
+
+            if (streaming) {
+                delete parameters[RESPONSE_PARAMETER_NAME];
+            }
+
+            const updatedRootClusterElementNodeData = {
+                ...rootClusterElementNodeData,
+                operationName: targetOperationName,
+                parameters,
+                type: `${rootClusterElementNodeData.componentName}/v${componentVersion}/${targetOperationName}`,
+            };
+
+            setRootClusterElementNodeData(updatedRootClusterElementNodeData);
+
+            saveWorkflowDefinition({
+                nodeData: updatedRootClusterElementNodeData,
+                updateWorkflowMutation,
+            });
+        },
+        [rootClusterElementNodeData, rootTask?.parameters, setRootClusterElementNodeData, updateWorkflowMutation]
+    );
+
+    return {
+        isStreaming: operationName === STREAM_CHAT_OPERATION_NAME,
+        isStreamingSupported: operationName === CHAT_OPERATION_NAME || operationName === STREAM_CHAT_OPERATION_NAME,
+        updateStreaming,
+    };
+}

--- a/client/src/pages/platform/cluster-element-editor/ai-agent-editor/components/ai-agent-configuration-panel/components/hooks/useAiAgentStreamResponse.ts
+++ b/client/src/pages/platform/cluster-element-editor/ai-agent-editor/components/ai-agent-configuration-panel/components/hooks/useAiAgentStreamResponse.ts
@@ -8,11 +8,6 @@ import {useCallback, useMemo} from 'react';
 export const CHAT_OPERATION_NAME = 'chat';
 export const STREAM_CHAT_OPERATION_NAME = 'streamChat';
 
-// A streamed response cannot be validated against a JSON schema, so AiAgentConstants.STREAM_CHAT_PROPERTIES
-// omits the structured output property that AiAgentConstants.CHAT_PROPERTIES declares. Every other property
-// is shared by both actions, which is what makes the switch a toggle rather than a full action select.
-const RESPONSE_PARAMETER_NAME = 'response';
-
 interface UseAiAgentStreamResponseI {
     isStreaming: boolean;
     isStreamingSupported: boolean;
@@ -56,7 +51,7 @@ export default function useAiAgentStreamResponse(): UseAiAgentStreamResponseI {
         (streaming: boolean) => {
             const targetOperationName = streaming ? STREAM_CHAT_OPERATION_NAME : CHAT_OPERATION_NAME;
 
-            if (!rootClusterElementNodeData?.componentName || !updateWorkflowMutation) {
+            if (!rootClusterElementNodeData?.componentName || !updateWorkflowMutation || !rootTask) {
                 return;
             }
 
@@ -65,11 +60,7 @@ export default function useAiAgentStreamResponse(): UseAiAgentStreamResponseI {
                 rootClusterElementNodeData.version ||
                 1;
 
-            const parameters = {...(rootTask?.parameters ?? {})};
-
-            if (streaming) {
-                delete parameters[RESPONSE_PARAMETER_NAME];
-            }
+            const parameters = {...(rootTask.parameters ?? {})};
 
             const updatedRootClusterElementNodeData = {
                 ...rootClusterElementNodeData,
@@ -85,7 +76,7 @@ export default function useAiAgentStreamResponse(): UseAiAgentStreamResponseI {
                 updateWorkflowMutation,
             });
         },
-        [rootClusterElementNodeData, rootTask?.parameters, setRootClusterElementNodeData, updateWorkflowMutation]
+        [rootClusterElementNodeData, rootTask, setRootClusterElementNodeData, updateWorkflowMutation]
     );
 
     return {


### PR DESCRIPTION
Closes #5561

The simple (non-canvas) AI Agent editor rendered no operation control, so the AI Agent action could only be changed from the advanced canvas' node details panel — open **Advanced**, click the AI Agent root node, use the Actions select. `AiAgentConfigurationPanel` renders a fixed field list (`AiAgentModelSelectField`, the three prompt fields, `AiAgentTools`) and never had an equivalent of `CurrentOperationSelect`.

### Fix

A **Stream response** switch under Model flips the root task between `aiAgent/vN/chat` and `aiAgent/vN/streamChat` — the two actions that share the same property set. Both declare `AiAgentConstants.CHAT_PROPERTIES` and both reach structured output through `AbstractAiAgentChatAction.getChatClientRequestSpec`, so the switch can be a toggle rather than a full action select. `realtimeChat` stays advanced-only.

Three details that are easy to get wrong and are handled deliberately:

- **Parameters are read from the workflow definition**, not from `rootClusterElementNodeData`. That store value is seeded once per root and goes stale, while `saveWorkflowDefinition` replaces a cluster root's parameters *wholesale* — reading the stale copy would wipe the prompts on every toggle. `AiAgentPromptField` reads them the same way.
- **Parameters are carried over unchanged, `response` included.** An earlier revision dropped `response` when switching to streaming, on the premise that `streamChat` declares a narrower property set. That premise was wrong — there is no `STREAM_CHAT_PROPERTIES` constant, `AiAgentStreamChatAction` declares the same `CHAT_PROPERTIES`, and `createPrompt` reads `response.responseFormat` / `response.responseSchema` on the streaming path too. Dropping it discarded a working structured-output configuration.
- **The toggle no-ops when the root task cannot be read from the definition.** `operationName` falls back to the node data, so the switch stays visible while the workflow loads; without the guard a click in that window wrote an empty parameter map over the prompts.
- **The toggle hides itself when the root action is neither `chat` nor `streamChat`**, so a `realtimeChat` agent is not misrepresented as "not streaming".

The write goes through the same path as the other simple-editor writers: update `rootClusterElementNodeData` in `useWorkflowEditorStore`, then `saveWorkflowDefinition` with the root node data.

### Verification

- `npm run check` (lint + typecheck + tests) on this branch: **355 files / 3811 tests, 0 failures**
- The panel's own tests re-run alone: **19 tests, 0 failures**
- Line coverage on both new files is 100% (`AiAgentStreamResponseField.tsx` 4/4, `useAiAgentStreamResponse.ts` 24/24)

One note for review: the cherry-pick from the development branch carried an `AiAgentSkills` import that does not exist on `master` — unrelated unshipped work, dropped in the conflict resolution. The component was never referenced in this file's JSX on `master`, and typecheck confirms nothing else refers to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
