### PR TITLE
5561 client - Keep agent cluster elements on action toggle and move the Stream response label

### DIFF
--- a/client/src/pages/platform/cluster-element-editor/ai-agent-editor/components/ai-agent-configuration-panel/components/AiAgentStreamResponseField.test.tsx
+++ b/client/src/pages/platform/cluster-element-editor/ai-agent-editor/components/ai-agent-configuration-panel/components/AiAgentStreamResponseField.test.tsx
@@ -33,6 +33,19 @@ describe('AiAgentStreamResponseField', () => {
         expect(container).toBeEmptyDOMElement();
     });
 
+    it('renders the title as a standalone heading, with the switch on its own row below', () => {
+        mockHook(false, true);
+
+        render(<AiAgentStreamResponseField />);
+
+        const heading = screen.getByRole('heading', {name: 'Stream response'});
+        const switchElement = screen.getByRole('switch', {name: /stream response/i});
+
+        expect(heading).toBeInTheDocument();
+        expect(heading).not.toContainElement(switchElement);
+        expect(screen.getByText(/token by token/i)).toBeInTheDocument();
+    });
+
     it('renders an unchecked switch for the chat action', () => {
         mockHook(false, true);
 

--- a/client/src/pages/platform/cluster-element-editor/ai-agent-editor/components/ai-agent-configuration-panel/components/AiAgentStreamResponseField.tsx
+++ b/client/src/pages/platform/cluster-element-editor/ai-agent-editor/components/ai-agent-configuration-panel/components/AiAgentStreamResponseField.tsx
@@ -10,11 +10,16 @@ export default function AiAgentStreamResponseField() {
     }
 
     return (
-        <Switch
-            checked={isStreaming}
-            description="Send the response back token by token instead of once it is complete."
-            label="Stream response"
-            onCheckedChange={updateStreaming}
-        />
+        <fieldset className="flex flex-col border-0">
+            <h2 className="mb-2">Stream response</h2>
+
+            <label className="flex w-fit cursor-pointer items-start gap-2">
+                <Switch aria-label="Stream response" checked={isStreaming} onCheckedChange={updateStreaming} />
+
+                <span className="text-sm leading-5 font-normal text-content-neutral-secondary">
+                    Send the response back token by token instead of once it is complete.
+                </span>
+            </label>
+        </fieldset>
     );
 }

--- a/client/src/pages/platform/cluster-element-editor/ai-agent-editor/components/ai-agent-configuration-panel/components/hooks/useAiAgentStreamResponse.test.ts
+++ b/client/src/pages/platform/cluster-element-editor/ai-agent-editor/components/ai-agent-configuration-panel/components/hooks/useAiAgentStreamResponse.test.ts
@@ -40,10 +40,25 @@ const rootClusterElementNodeData = {
     workflowNodeName: 'aiAgent_1',
 };
 
+// The live cluster elements, deliberately different from the seeded snapshot above: the definition is the
+// only source that tracks tools added after the AI Agent editor was opened.
+const definitionClusterElements = {
+    model: {label: 'Claude', name: 'anthropic_1', parameters: {model: 'claude-opus-5'}, type: 'anthropic/v1/model'},
+    tools: [
+        {
+            label: 'Sheets',
+            name: 'googleSheets_1',
+            parameters: {spreadsheetId: 'abc'},
+            type: 'googleSheets/v1/insertRow',
+        },
+    ],
+};
+
 const buildDefinition = (operationName: string) =>
     JSON.stringify({
         tasks: [
             {
+                clusterElements: definitionClusterElements,
                 name: 'aiAgent_1',
                 parameters: {
                     response: {responseFormat: 'JSON'},
@@ -116,8 +131,42 @@ describe('useAiAgentStreamResponse', () => {
             systemPrompt: 'Be helpful',
             userPrompt: 'Hello',
         });
-        expect(nodeData.clusterElements).toEqual(rootClusterElementNodeData.clusterElements);
+        expect(nodeData.clusterElements).toEqual(definitionClusterElements);
         expect(setRootClusterElementNodeDataMock).toHaveBeenCalledWith(nodeData);
+    });
+
+    it('keeps the cluster elements the definition holds, not the stale seeded snapshot', () => {
+        const {result} = renderHook(() => useAiAgentStreamResponse());
+
+        result.current.updateStreaming(true);
+
+        const [{nodeData}] = saveWorkflowDefinitionMock.mock.calls[0];
+
+        expect(nodeData.clusterElements).toEqual(definitionClusterElements);
+        expect(nodeData.clusterElements).not.toEqual(rootClusterElementNodeData.clusterElements);
+    });
+
+    it('keeps the cluster elements when the seeded root node data carries none at all', () => {
+        useWorkflowEditorStoreMock.mockImplementation((selector: (state: unknown) => unknown) =>
+            selector({
+                rootClusterElementNodeData: {
+                    componentName: 'aiAgent',
+                    name: 'aiAgent_1',
+                    operationName: 'chat',
+                    type: 'aiAgent/v1/chat',
+                    workflowNodeName: 'aiAgent_1',
+                },
+                setRootClusterElementNodeData: setRootClusterElementNodeDataMock,
+            })
+        );
+
+        const {result} = renderHook(() => useAiAgentStreamResponse());
+
+        result.current.updateStreaming(true);
+
+        const [{nodeData}] = saveWorkflowDefinitionMock.mock.calls[0];
+
+        expect(nodeData.clusterElements).toEqual(definitionClusterElements);
     });
 
     it('falls back to the node data operation when the workflow has no definition', () => {

--- a/client/src/pages/platform/cluster-element-editor/ai-agent-editor/components/ai-agent-configuration-panel/components/hooks/useAiAgentStreamResponse.ts
+++ b/client/src/pages/platform/cluster-element-editor/ai-agent-editor/components/ai-agent-configuration-panel/components/hooks/useAiAgentStreamResponse.ts
@@ -21,9 +21,6 @@ export default function useAiAgentStreamResponse(): UseAiAgentStreamResponseI {
 
     const {updateWorkflowMutation} = useWorkflowEditor();
 
-    // The root task is read from the workflow definition rather than from rootClusterElementNodeData, which is
-    // seeded once per root and never carries the prompts written by AiAgentPromptField. saveWorkflowDefinition
-    // replaces a cluster root's parameters wholesale, so writing the stale copy back would wipe them.
     const rootTask = useMemo(() => {
         if (!workflow.definition || !rootClusterElementNodeData?.workflowNodeName) {
             return undefined;
@@ -64,6 +61,7 @@ export default function useAiAgentStreamResponse(): UseAiAgentStreamResponseI {
 
             const updatedRootClusterElementNodeData = {
                 ...rootClusterElementNodeData,
+                clusterElements: rootTask.clusterElements,
                 operationName: targetOperationName,
                 parameters,
                 type: `${rootClusterElementNodeData.componentName}/v${componentVersion}/${targetOperationName}`,

--- a/client/src/pages/platform/workflow-editor/utils/saveWorkflowDefinition.test.ts
+++ b/client/src/pages/platform/workflow-editor/utils/saveWorkflowDefinition.test.ts
@@ -742,4 +742,74 @@ describe('saveWorkflowDefinition', () => {
             expect(mutation.mutate).toHaveBeenCalledOnce();
         });
     });
+    describe('clusterRoot clusterElements preservation', () => {
+        const clusterElements = {
+            model: {label: 'Claude', name: 'anthropic_1', parameters: {}, type: 'anthropic/v1/model'},
+            tools: [{label: 'Sheets', name: 'googleSheets_1', parameters: {}, type: 'googleSheets/v1/insertRow'}],
+        };
+
+        function makeClusterRootState() {
+            return makeWorkflowState([
+                {
+                    clusterElements,
+                    label: 'Agent',
+                    name: 'aiAgent_1',
+                    parameters: {systemPrompt: 'Be helpful'},
+                    type: 'aiAgent/v1/chat',
+                },
+            ]);
+        }
+
+        beforeEach(() => {
+            mockWorkflowState = makeClusterRootState();
+
+            mockWorkflowState.workflow.tasks = mockWorkflowState.workflow.tasks.map((task) => ({
+                ...task,
+                clusterRoot: true,
+            }));
+        });
+
+        it('should keep the existing cluster elements when the node data does not carry them', async () => {
+            const mutation = makeMutation();
+
+            await saveWorkflowDefinition({
+                nodeData: {
+                    componentName: 'aiAgent',
+                    name: 'aiAgent_1',
+                    parameters: {systemPrompt: 'Be helpful'},
+                    type: 'aiAgent/v1/streamChat',
+                    workflowNodeName: 'aiAgent_1',
+                } as unknown as NodeDataType,
+                updateWorkflowMutation: mutation,
+            });
+
+            const savedTask = JSON.parse(
+                (mutation.mutate as ReturnType<typeof vi.fn>).mock.calls[0][0].workflow.definition
+            ).tasks[0];
+
+            expect(savedTask.clusterElements).toEqual(clusterElements);
+        });
+
+        it('should still clear the cluster elements when the node data carries an explicit empty map', async () => {
+            const mutation = makeMutation();
+
+            await saveWorkflowDefinition({
+                nodeData: {
+                    clusterElements: {},
+                    componentName: 'aiAgent',
+                    name: 'aiAgent_1',
+                    parameters: {systemPrompt: 'Be helpful'},
+                    type: 'aiAgent/v1/chat',
+                    workflowNodeName: 'aiAgent_1',
+                } as unknown as NodeDataType,
+                updateWorkflowMutation: mutation,
+            });
+
+            const savedTask = JSON.parse(
+                (mutation.mutate as ReturnType<typeof vi.fn>).mock.calls[0][0].workflow.definition
+            ).tasks[0];
+
+            expect(savedTask.clusterElements).toEqual({});
+        });
+    });
 });

--- a/client/src/pages/platform/workflow-editor/utils/saveWorkflowDefinition.ts
+++ b/client/src/pages/platform/workflow-editor/utils/saveWorkflowDefinition.ts
@@ -173,11 +173,16 @@ export default async function saveWorkflowDefinition({
                 combinedParameters = newTask.parameters ?? {};
             }
 
+            const existingDefinitionTask = getTask({
+                tasks: workflowDefinitionTasks,
+                workflowNodeName: newTask.name,
+            });
+
             const taskToUpdate = existingWorkflowTask.clusterRoot
                 ? {
                       ...newTask,
                       clusterElements: {
-                          ...(newTask.clusterElements || {}),
+                          ...(newTask.clusterElements ?? existingDefinitionTask?.clusterElements ?? {}),
                       },
                   }
                 : {


### PR DESCRIPTION
Follow-ups to #5568 on the simple AI Agent editor.

## Keep the agent cluster elements when the action toggle saves

Toggling the AI Agent action (chat <-> streamChat) re-saved the cluster root from a node-data copy that carried no `clusterElements`, and `saveWorkflowDefinition` replaces a cluster root's `clusterElements` wholesale — so the agent's model, tools and memory were silently stripped from the definition on every toggle.

Two changes, either of which alone leaves a hole:

- `useAiAgentStreamResponse` now carries `rootTask.clusterElements` (read from the definition, not from the seeded-once `rootClusterElementNodeData`) into the updated root node data.
- `saveWorkflowDefinition` falls back to the existing definition task's `clusterElements` when the incoming task has none. Note this uses `??`, not `||`, so an explicit empty map still clears the elements — that distinction is covered by a test.

## Move the Stream response toggle below a standalone label

The title and the switch shared a row; the title is now a standalone heading with the switch on its own row below it.

## Tests

Regression coverage added for all three behaviours, including the explicit-empty-map case that distinguishes `??` from `||`.

- `npm run check` (lint + typecheck + tests): 357 test files, 3831 tests passed.

## Scope note

These commits were lifted off a longer-running branch. Two related follow-ups could not come along, because the code they touch is not on `master` yet:

- The same `clusterElements` fix applied to `useAiAgentSkills`, whose hook does not exist on `master`.
- A cluster-element sibling-spacing fix in `layoutUtils`, which targets a version of `getClusterElementsLayoutElements` that has diverged substantially from the one on `master`.

Both will need to ride along with the branches that introduce their prerequisites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)