### PR TITLE
3757 docs - Generate the API reference pages from the Next config

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -39,7 +39,9 @@ them.
 | `embedded-webhook-*` | `server/ee/libs/embedded/embedded-webhook/embedded-webhook-public-rest/openapi.yaml` |
 | `custom-components` | `server/ee/libs/platform/platform-custom-component/platform-custom-component-configuration/platform-custom-component-configuration-rest/openapi.yaml` |
 
-After editing a spec, regenerate from this directory:
+`npm run dev` and `next build` both generate them, from `next.config.ts`, so a fresh checkout needs
+no extra step and a deployment cannot skip it by overriding the build command. After editing a spec
+outside a running dev server, regenerate from this directory:
 
 ```bash
 npm run generate:openapi

--- a/docs/next.config.ts
+++ b/docs/next.config.ts
@@ -1,5 +1,8 @@
 import createBundleAnalyzer from '@next/bundle-analyzer';
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
 import { createMDX } from 'fumadocs-mdx/next';
+import { PHASE_DEVELOPMENT_SERVER, PHASE_PRODUCTION_BUILD } from 'next/constants.js';
 import type { NextConfig } from 'next';
 
 const withAnalyzer = createBundleAnalyzer({
@@ -334,4 +337,37 @@ const config: NextConfig = {
 
 const withMDX = createMDX();
 
-export default withAnalyzer(withMDX(config));
+/**
+ * Writes the API reference pages under `content/docs/openapi/`, which are generated from the
+ * monorepo's OpenAPI specs and left untracked.
+ *
+ * This runs from the config rather than from a `prebuild` script because the pages are only ever
+ * as present as the command the host happens to run: a build command of `next build` skips every
+ * npm script, and the site still builds -- fumadocs drops nav entries pointing at directories that
+ * do not exist, so the whole reference section disappears without a single error. Generating here
+ * cannot be skipped, and a failure fails the build.
+ *
+ * Only while building or serving in dev: `next start` loads this file too, and the runtime
+ * filesystem is read-only.
+ */
+function generateOpenApiPages() {
+  // Next loads this file again in each build worker, and a worker inherits this environment: without
+  // the guard the tree would be cleared and rewritten underneath a worker already reading it.
+  if (process.env.BYTECHEF_DOCS_OPENAPI_GENERATED === '1') return;
+
+  process.env.BYTECHEF_DOCS_OPENAPI_GENERATED = '1';
+
+  execFileSync(
+    process.execPath,
+    ['--experimental-strip-types', path.join(import.meta.dirname, 'scripts/generate-openapi.mts')],
+    { stdio: 'inherit' },
+  );
+}
+
+export default function nextConfig(phase: string) {
+  if (phase === PHASE_PRODUCTION_BUILD || phase === PHASE_DEVELOPMENT_SERVER) {
+    generateOpenApiPages();
+  }
+
+  return withAnalyzer(withMDX(config));
+}


### PR DESCRIPTION
Every page under `docs/content/docs/openapi/*/` is generated from the monorepo's OpenAPI specs and left untracked - only `openapi/index.mdx` and `openapi/meta.json` are in git. The generation step lives in an npm script, so the pages are only ever as present as the command the host happens to run: a build command of `next build` skips every npm script and still succeeds, because fumadocs quietly drops `meta.json` entries pointing at directories that do not exist.

That is the state docs.bytechef.io is in today - current prose, and every `/openapi/backend/*` and `/openapi/frontend/*` URL a 404:

```
$ curl -o /dev/null -w '%{http_code}' https://docs.bytechef.io/openapi/backend/embedded-action
404
```

Generating from `next.config.ts` instead cannot be skipped by a build command, and a failing generator now fails the build rather than publishing an empty reference section.

- Phase-gated to `PHASE_PRODUCTION_BUILD` / `PHASE_DEVELOPMENT_SERVER`: `next start` loads the config too, and the runtime filesystem is read-only.
- Spawned with `process.execPath` so it holds under bun as well as node.
- Env-guarded, because build workers inherit the environment and would otherwise clear the tree underneath one another.

`npm run build` still chains `generate:openapi` explicitly; the guard makes the second run a no-op.

## Verification

Run on this branch, from a fresh `npm install`, with `content/docs/openapi/*/` deleted first - the exact production scenario.

| Check | Result |
|---|---|
| `npx next build` | exit 0, generator ran once, 76 openapi routes prerendered |
| `npx next start` | 0 generator runs, `/openapi/backend/embedded-action` serves 200 |
| `npm run lint` link check | 544 URLs, 0 errored files |
| `npm run types:check` | pass |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
