### PR TITLE
fix: persist encryption key in Docker Compose for container restarts

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ docker run --name bytechef -it -p 8080:8080 \
     --env BYTECHEF_DATASOURCE_URL=jdbc:postgresql://postgres:5432/bytechef \
     --env BYTECHEF_DATASOURCE_USERNAME=postgres \
     --env BYTECHEF_DATASOURCE_PASSWORD=postgres \
+    --env BYTECHEF_ENCRYPTION_PROVIDER=property \
+    --env BYTECHEF_ENCRYPTION_PROPERTY_KEY=tTB1/UBIbYLuCXVi4PPfzA== \
     --env BYTECHEF_SECURITY_REMEMBER_ME_KEY=e48612ba1fd46fa7089fe9f5085d8d164b53ffb2 \
     --network bytechef_network \
     docker.bytechef.io/bytechef/bytechef:latest

--- a/docker-compose.src.yml
+++ b/docker-compose.src.yml
@@ -21,8 +21,10 @@ services:
       - BYTECHEF_DATASOURCE_URL=jdbc:postgresql://postgres:5432/bytechef
       - BYTECHEF_DATASOURCE_USERNAME=postgres
       - BYTECHEF_DATASOURCE_PASSWORD=postgres
+      - BYTECHEF_ENCRYPTION_PROVIDER=property
+      - BYTECHEF_ENCRYPTION_PROPERTY_KEY=tTB1/UBIbYLuCXVi4PPfzA==
       - BYTECHEF_FEATURE_FLAGS
-      - BYTECHEF_SECURITY_REMEMBER-ME_KEY=e48keep1this1safe3ffb2
+      - BYTECHEF_SECURITY_REMEMBER_ME_KEY=e48keep1this1safe3ffb2
     ports:
       - "8080:8080"
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,8 +26,10 @@ services:
       - BYTECHEF_DATASOURCE_URL=jdbc:postgresql://postgres:5432/bytechef
       - BYTECHEF_DATASOURCE_USERNAME=postgres
       - BYTECHEF_DATASOURCE_PASSWORD=postgres
+      - BYTECHEF_ENCRYPTION_PROVIDER=property
+      - BYTECHEF_ENCRYPTION_PROPERTY_KEY=tTB1/UBIbYLuCXVi4PPfzA==
       - BYTECHEF_FEATURE_FLAGS
-      - BYTECHEF_SECURITY_REMEMBER-ME_KEY=e48keep1this1safe3ffb2
+      - BYTECHEF_SECURITY_REMEMBER_ME_KEY=e48keep1this1safe3ffb2
     ports:
       - "8080:8080"
 volumes:

--- a/docs/content/docs/platform/use-bytechef/self-hosted/installation/local-docker.mdx
+++ b/docs/content/docs/platform/use-bytechef/self-hosted/installation/local-docker.mdx
@@ -31,6 +31,11 @@ workflows, connections, and execution history - lives there, so `docker compose 
 `-v`) deletes all of it. Plain `docker compose down` stops the containers and leaves the volume
 intact.
 
+The Compose file also sets a fixed encryption key (`BYTECHEF_ENCRYPTION_PROVIDER=property` with
+`BYTECHEF_ENCRYPTION_PROPERTY_KEY`) so stored OAuth connection credentials remain decryptable after
+you recreate the ByteChef container. Without a stable key, a fresh container cannot read connections
+already stored in PostgreSQL.
+
 To point ByteChef at a PostgreSQL server you run yourself instead, override the datasource settings
 on the `bytechef` service:
 
@@ -82,6 +87,8 @@ docker run --name bytechef -it -p 8080:8080 \
     --env BYTECHEF_DATASOURCE_URL=jdbc:postgresql://postgres:5432/bytechef \
     --env BYTECHEF_DATASOURCE_USERNAME=postgres \
     --env BYTECHEF_DATASOURCE_PASSWORD=postgres \
+    --env BYTECHEF_ENCRYPTION_PROVIDER=property \
+    --env BYTECHEF_ENCRYPTION_PROPERTY_KEY=tTB1/UBIbYLuCXVi4PPfzA== \
     --env BYTECHEF_SECURITY_REMEMBER_ME_KEY=e48612ba1fd46fa7089fe9f5085d8d164b53ffb2 \
     --network bytechef_network \
     docker.bytechef.io/bytechef/bytechef:latest


### PR DESCRIPTION
Fixes #3700

## Summary

When ByteChef runs in Docker with the default `filesystem` encryption provider, the key is stored inside the container filesystem (`~/.bytechef/key`). Recreating the container (`docker rm` + `docker run`) generates a new key while PostgreSQL data persists in a volume, so stored OAuth connection credentials cannot be decrypted.

## Solution

- Set `BYTECHEF_ENCRYPTION_PROVIDER=property` with a stable dev `BYTECHEF_ENCRYPTION_PROPERTY_KEY` in `docker-compose.yml` and `docker-compose.src.yml`
- Fix `BYTECHEF_SECURITY_REMEMBER_ME_KEY` env var name (was `REMEMBER-ME_KEY` with a hyphen)
- Align README and local Docker install docs with the same encryption env vars for manual `docker run`

## Type of change

- Bug fix (Docker / self-hosted local setup)

## How Has This Been Tested?

- Verified env var names against `ApplicationProperties` and existing Helm `values.yaml` pattern
- Matches property encryption integration test key used in the codebase

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes