### PR TITLE
feat: function autocomplete for expressions in the property input

### DIFF
--- a/client/src/graphql/platform/configuration/evaluatorFunctionDefinitions.graphql
+++ b/client/src/graphql/platform/configuration/evaluatorFunctionDefinitions.graphql
@@ -1,0 +1,16 @@
+query evaluatorFunctionDefinitions {
+    evaluatorFunctionDefinitions {
+        name
+        title
+        description
+        category
+        returnType
+        example
+        parameters {
+            name
+            description
+            type
+            required
+        }
+    }
+}

--- a/client/src/pages/platform/workflow-editor/components/properties/Property.tsx
+++ b/client/src/pages/platform/workflow-editor/components/properties/Property.tsx
@@ -230,6 +230,7 @@ const Property = ({
                     required={required}
                     setIsFormulaMode={setIsFormulaMode}
                     showInputTypeSwitchButton={showInputTypeSwitchButton}
+                    toolProperty={isToolsClusterElement}
                     type={type}
                     validateBeforeSave={validatePropertyValue}
                     value={mentionInputValue}

--- a/client/src/pages/platform/workflow-editor/components/properties/Property.tsx
+++ b/client/src/pages/platform/workflow-editor/components/properties/Property.tsx
@@ -20,6 +20,8 @@ import PropertyCodeEditor from '@/pages/platform/workflow-editor/components/prop
 import PropertyInput from '@/pages/platform/workflow-editor/components/properties/components/property-input/PropertyInput';
 import PropertyJsonSchemaBuilder from '@/pages/platform/workflow-editor/components/properties/components/property-json-schema-builder/PropertyJsonSchemaBuilder';
 import PropertyMentionsInput from '@/pages/platform/workflow-editor/components/properties/components/property-mentions-input/PropertyMentionsInput';
+import {reconstructControlledExpressionValue} from '@/pages/platform/workflow-editor/components/properties/components/property-mentions-input/controlledExpressionValue';
+import {getMentionsInputPlaceholder} from '@/pages/platform/workflow-editor/components/properties/components/property-mentions-input/mentionsInputPlaceholder';
 import useProperty from '@/pages/platform/workflow-editor/components/properties/hooks/useProperty';
 import isDynamicPropertiesQueryEnabled from '@/pages/platform/workflow-editor/components/properties/isDynamicPropertiesQueryEnabled';
 import getInputHTMLType from '@/pages/platform/workflow-editor/utils/getInputHTMLType';
@@ -135,7 +137,6 @@ const Property = ({
         propertyParameterValue,
         required,
         selectValue,
-        setDataPillPanelOpen,
         setIsFormulaMode,
         setLookupDependsOnValues,
         setSelectValue,
@@ -332,62 +333,44 @@ const Property = ({
                                     isToolsClusterElement &&
                                     (controlledFromAi !== undefined ? controlledFromAi : valueIsFromAi);
 
-                                const isExpressionMode = displayValue.startsWith('=');
-                                const strippedDisplayValue = isExpressionMode
-                                    ? displayValue.substring(1)
-                                    : displayValue;
-                                const strippedFromAiValue = fromAiExpression.startsWith('=')
-                                    ? fromAiExpression.substring(1)
-                                    : fromAiExpression;
-
-                                const {onChange: fieldOnChange, ...fieldRest} = field;
+                                const {onChange: fieldOnChange} = field;
 
                                 return (
-                                    <PropertyInput
-                                        {...fieldRest}
+                                    <PropertyMentionsInput
+                                        controlType={controlType || 'TEXT'}
                                         deletePropertyButton={deletePropertyButton}
                                         description={description}
-                                        disabled={isFieldFromAi}
+                                        disableAutoSave
                                         error={hasError}
                                         errorMessage={errorMessage}
-                                        expressionPrefix
+                                        expressionEnabled={expressionEnabled}
+                                        handleFromAiClick={
+                                            isToolsClusterElement
+                                                ? (fromAi) => handleFromAiToggle(fromAi, fieldOnChange)
+                                                : undefined
+                                        }
                                         handleInputTypeSwitchButtonClick={() => {
                                             fieldOnChange('');
                                             handleControlledModeSwitch(false);
                                         }}
-                                        inputOverlay={
-                                            isFieldFromAi ? (
-                                                <span className="flex h-full flex-1 items-center pl-property-input-position text-sm font-medium text-muted-foreground italic">
-                                                    Automatically defined by the model
-                                                </span>
-                                            ) : undefined
-                                        }
+                                        isFormulaMode
+                                        isFromAi={isFieldFromAi}
                                         label={label || name}
-                                        leadingIcon={
-                                            isExpressionMode || isFieldFromAi ? (
-                                                <SquareFunctionIcon className="size-4" />
-                                            ) : (
-                                                typeIcon
-                                            )
+                                        leadingIcon={typeIcon}
+                                        onValueChange={(value) =>
+                                            fieldOnChange(reconstructControlledExpressionValue(value))
                                         }
-                                        mentionInput
-                                        onChange={(event) => {
-                                            fieldOnChange(resolveExpressionValue(event.target.value, field.value));
-                                        }}
-                                        onFocus={() => setDataPillPanelOpen(true)}
-                                        placeholder="Use '=' for an expression"
+                                        path={calculatedPath}
+                                        placeholder={getMentionsInputPlaceholder({
+                                            expressionEnabled,
+                                            toolProperty: isToolsClusterElement,
+                                        })}
                                         required={required}
+                                        setIsFormulaMode={() => {}}
                                         showInputTypeSwitchButton
-                                        trailingAction={
-                                            isToolsClusterElement && expressionEnabled !== false ? (
-                                                <FromAiToggleButton
-                                                    isFromAi={!!isFieldFromAi}
-                                                    onToggle={(fromAi) => handleFromAiToggle(fromAi, fieldOnChange)}
-                                                />
-                                            ) : undefined
-                                        }
-                                        type={hidden ? 'hidden' : 'text'}
-                                        value={isFieldFromAi ? strippedFromAiValue : strippedDisplayValue}
+                                        toolProperty={isToolsClusterElement}
+                                        type={type}
+                                        value={displayValue}
                                     />
                                 );
                             }}
@@ -493,88 +476,120 @@ const Property = ({
 
                                     return (
                                         <>
-                                            <PropertyInput
-                                                {...fieldRest}
-                                                deletePropertyButton={deletePropertyButton}
-                                                description={description}
-                                                disabled={isFieldFromAi}
-                                                error={!!fieldState.error || !!controlledBlurError}
-                                                errorMessage={fieldState.error?.message || controlledBlurError}
-                                                expressionPrefix={showFromAi}
-                                                fieldsetClassName={objectName && arrayName && 'ml-2'}
-                                                handleInputTypeSwitchButtonClick={
-                                                    showControlledSwitch
-                                                        ? () => {
-                                                              fieldOnChange('=');
-                                                              handleControlledModeSwitch(true);
-                                                          }
-                                                        : undefined
-                                                }
-                                                inputOverlay={
-                                                    isFieldFromAi ? (
-                                                        <span className="flex h-full flex-1 items-center pl-property-input-position text-sm font-medium text-muted-foreground italic">
-                                                            Automatically defined by the model
-                                                        </span>
-                                                    ) : undefined
-                                                }
-                                                label={label || name}
-                                                leadingIcon={
-                                                    isExpressionMode || isFieldFromAi ? (
-                                                        <SquareFunctionIcon className="size-4" />
-                                                    ) : (
-                                                        typeIcon
-                                                    )
-                                                }
-                                                max={maxValue}
-                                                maxLength={maxLength}
-                                                min={minValue}
-                                                minLength={minLength}
-                                                onBlur={() => {
-                                                    field.onBlur();
+                                            {showFromAi && (isExpressionMode || isFieldFromAi) ? (
+                                                <PropertyMentionsInput
+                                                    controlType={controlType || 'TEXT'}
+                                                    deletePropertyButton={deletePropertyButton}
+                                                    description={description}
+                                                    disableAutoSave
+                                                    error={!!fieldState.error || !!controlledBlurError}
+                                                    errorMessage={fieldState.error?.message || controlledBlurError}
+                                                    expressionEnabled={expressionEnabled}
+                                                    handleFromAiClick={(fromAi) =>
+                                                        handleFromAiToggle(fromAi, fieldOnChange)
+                                                    }
+                                                    isFormulaMode
+                                                    isFromAi={isFieldFromAi}
+                                                    label={label || name}
+                                                    leadingIcon={typeIcon}
+                                                    onValueChange={(value) =>
+                                                        fieldOnChange(reconstructControlledExpressionValue(value))
+                                                    }
+                                                    path={calculatedPath}
+                                                    placeholder={getMentionsInputPlaceholder({
+                                                        expressionEnabled,
+                                                        toolProperty: true,
+                                                    })}
+                                                    required={required}
+                                                    setIsFormulaMode={() => {}}
+                                                    toolProperty
+                                                    type={type}
+                                                    value={displayValue}
+                                                />
+                                            ) : (
+                                                <PropertyInput
+                                                    {...fieldRest}
+                                                    deletePropertyButton={deletePropertyButton}
+                                                    description={description}
+                                                    disabled={isFieldFromAi}
+                                                    error={!!fieldState.error || !!controlledBlurError}
+                                                    errorMessage={fieldState.error?.message || controlledBlurError}
+                                                    expressionPrefix={showFromAi}
+                                                    fieldsetClassName={objectName && arrayName && 'ml-2'}
+                                                    handleInputTypeSwitchButtonClick={
+                                                        showControlledSwitch
+                                                            ? () => {
+                                                                  fieldOnChange('=');
+                                                                  handleControlledModeSwitch(true);
+                                                              }
+                                                            : undefined
+                                                    }
+                                                    inputOverlay={
+                                                        isFieldFromAi ? (
+                                                            <span className="flex h-full flex-1 items-center pl-property-input-position text-sm font-medium text-muted-foreground italic">
+                                                                Automatically defined by the model
+                                                            </span>
+                                                        ) : undefined
+                                                    }
+                                                    label={label || name}
+                                                    leadingIcon={
+                                                        isExpressionMode || isFieldFromAi ? (
+                                                            <SquareFunctionIcon className="size-4" />
+                                                        ) : (
+                                                            typeIcon
+                                                        )
+                                                    }
+                                                    max={maxValue}
+                                                    maxLength={maxLength}
+                                                    min={minValue}
+                                                    minLength={minLength}
+                                                    onBlur={() => {
+                                                        field.onBlur();
 
-                                                    handleControlledBlur(field.value);
-                                                }}
-                                                onChange={(event) => {
-                                                    if (!showFromAi) {
-                                                        if (isNumericalInput && event.target.value !== '') {
-                                                            fieldOnChange(
-                                                                type === 'INTEGER'
-                                                                    ? parseInt(event.target.value, 10)
-                                                                    : parseFloat(event.target.value)
-                                                            );
-                                                        } else {
-                                                            fieldOnChange(event);
+                                                        handleControlledBlur(field.value);
+                                                    }}
+                                                    onChange={(event) => {
+                                                        if (!showFromAi) {
+                                                            if (isNumericalInput && event.target.value !== '') {
+                                                                fieldOnChange(
+                                                                    type === 'INTEGER'
+                                                                        ? parseInt(event.target.value, 10)
+                                                                        : parseFloat(event.target.value)
+                                                                );
+                                                            } else {
+                                                                fieldOnChange(event);
+                                                            }
+
+                                                            return;
                                                         }
 
-                                                        return;
+                                                        fieldOnChange(
+                                                            resolveExpressionValue(event.target.value, field.value)
+                                                        );
+                                                    }}
+                                                    placeholder={
+                                                        isNumericalInput && minValue && maxValue
+                                                            ? `From ${minValue} to ${maxValue}`
+                                                            : placeholder ||
+                                                              `Type ${isNumericalInput ? 'a number' : 'something'}...`
                                                     }
-
-                                                    fieldOnChange(
-                                                        resolveExpressionValue(event.target.value, field.value)
-                                                    );
-                                                }}
-                                                placeholder={
-                                                    isNumericalInput && minValue && maxValue
-                                                        ? `From ${minValue} to ${maxValue}`
-                                                        : placeholder ||
-                                                          `Type ${isNumericalInput ? 'a number' : 'something'}...`
-                                                }
-                                                required={required}
-                                                showInputTypeSwitchButton={showControlledSwitch}
-                                                title={type}
-                                                trailingAction={
-                                                    showFromAi && expressionEnabled !== false ? (
-                                                        <FromAiToggleButton
-                                                            isFromAi={!!isFieldFromAi}
-                                                            onToggle={(fromAi) =>
-                                                                handleFromAiToggle(fromAi, fieldOnChange)
-                                                            }
-                                                        />
-                                                    ) : undefined
-                                                }
-                                                type={hidden ? 'hidden' : getInputHTMLType(controlType)}
-                                                value={isFieldFromAi ? strippedFromAiValue : strippedDisplayValue}
-                                            />
+                                                    required={required}
+                                                    showInputTypeSwitchButton={showControlledSwitch}
+                                                    title={type}
+                                                    trailingAction={
+                                                        showFromAi && expressionEnabled !== false ? (
+                                                            <FromAiToggleButton
+                                                                isFromAi={!!isFieldFromAi}
+                                                                onToggle={(fromAi) =>
+                                                                    handleFromAiToggle(fromAi, fieldOnChange)
+                                                                }
+                                                            />
+                                                        ) : undefined
+                                                    }
+                                                    type={hidden ? 'hidden' : getInputHTMLType(controlType)}
+                                                    value={isFieldFromAi ? strippedFromAiValue : strippedDisplayValue}
+                                                />
+                                            )}
 
                                             {!!options?.length && (
                                                 <PropertySelect

--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/ExpressionHelpNote.test.tsx
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/ExpressionHelpNote.test.tsx
@@ -1,0 +1,22 @@
+import {render, screen} from '@testing-library/react';
+import {describe, expect, it} from 'vitest';
+
+import ExpressionHelpNote, {EXPRESSIONS_DOCUMENTATION_URL} from './ExpressionHelpNote';
+
+describe('ExpressionHelpNote', () => {
+    it('tells the user the field supports functions', () => {
+        render(<ExpressionHelpNote />);
+
+        expect(screen.getByText(/supports functions/)).toBeInTheDocument();
+    });
+
+    it('links to the expressions reference in a new tab', () => {
+        render(<ExpressionHelpNote />);
+
+        const link = screen.getByRole('link', {name: /Learn more/});
+
+        expect(link).toHaveAttribute('href', EXPRESSIONS_DOCUMENTATION_URL);
+        expect(link).toHaveAttribute('target', '_blank');
+        expect(link).toHaveAttribute('rel', 'noreferrer');
+    });
+});

--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/ExpressionHelpNote.tsx
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/ExpressionHelpNote.tsx
@@ -1,0 +1,20 @@
+import {ExternalLinkIcon} from 'lucide-react';
+
+export const EXPRESSIONS_DOCUMENTATION_URL = 'https://docs.bytechef.io/reference/expressions';
+
+const ExpressionHelpNote = () => (
+    <p className="mt-1 flex flex-wrap items-start gap-x-1 text-xs text-content-neutral-secondary">
+        <span>This field supports functions to build a value.</span>
+
+        <a
+            className="underline underline-offset-2 hover:text-content-neutral-primary"
+            href={EXPRESSIONS_DOCUMENTATION_URL}
+            rel="noreferrer"
+            target="_blank"
+        >
+            Learn more <ExternalLinkIcon className="inline size-3" />
+        </a>
+    </p>
+);
+
+export default ExpressionHelpNote;

--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/FunctionSignature.extension.ts
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/FunctionSignature.extension.ts
@@ -18,7 +18,18 @@ export const FunctionSignature = Extension.create({
                 key: FunctionSignaturePluginKey,
                 view() {
                     let component: ReactRenderer | undefined;
+                    let isCreating = false;
                     let popup: TippyInstance | undefined;
+
+                    // Each editor gets its OWN detached reference node rather than sharing document.body.
+                    // tippy stamps the instance onto the reference as `reference._tippy` with no dedup
+                    // (createTippy overwrites it), so every property input on the page creating against `body`
+                    // clobbers the previous registration — and destroy() deletes `body._tippy`, leaving the
+                    // other instance's popper mounted with nothing able to reach it again. That orphan is what
+                    // showed as a signature tooltip surviving after its function text was deleted, and as two
+                    // tooltips stacked side by side. The node is never inserted into the document: positioning
+                    // comes entirely from getReferenceClientRect, and appendTo still puts the popper in <body>.
+                    const referenceElement = document.createElement('div');
 
                     const hide = () => {
                         popup?.destroy();
@@ -31,9 +42,7 @@ export const FunctionSignature = Extension.create({
                     // The tippy popper is appended to document.body, so it outlives the editor's own DOM and
                     // is torn down only when `hide` runs. The plugin's `update` only fires on ProseMirror
                     // transactions/selection changes — a plain blur (clicking another field) dispatches no
-                    // transaction, so without this listener the tooltip would orphan in <body> and stack up
-                    // behind the next field's tooltip (tippy('body') never dedups). Hiding on blur guarantees
-                    // the signature tooltip never persists past focus.
+                    // transaction, so without this listener the tooltip would persist past focus.
                     editor.on('blur', hide);
 
                     const update = () => {
@@ -93,16 +102,34 @@ export const FunctionSignature = Extension.create({
 
                             popup?.setProps({getReferenceClientRect});
                         } else {
-                            component = new ReactRenderer(FunctionSignatureTooltip, {editor, props});
+                            // `new ReactRenderer` renders through flushSync, which drains React's pending
+                            // effects — among them tiptap's own useEditor effect calling `editor.setOptions`,
+                            // which runs `view.setProps` -> `updatePluginViews` -> back into this `update`
+                            // before either assignment below has happened. That nested call would also find
+                            // `component` unset, create a second renderer and popper, and then have both
+                            // clobbered by the outer call's assignments — orphaning a popper in <body> with
+                            // no instance left to hide or destroy it. The nested call has nothing to add
+                            // over the creation already in flight, so it bails out here instead.
+                            if (isCreating) {
+                                return;
+                            }
 
-                            popup = tippy('body', {
-                                appendTo: () => document.body,
-                                content: component.element,
-                                getReferenceClientRect,
-                                placement: 'top-start',
-                                showOnCreate: true,
-                                trigger: 'manual',
-                            })[0];
+                            isCreating = true;
+
+                            try {
+                                component = new ReactRenderer(FunctionSignatureTooltip, {editor, props});
+
+                                popup = tippy(referenceElement, {
+                                    appendTo: () => document.body,
+                                    content: component.element,
+                                    getReferenceClientRect,
+                                    placement: 'top-start',
+                                    showOnCreate: true,
+                                    trigger: 'manual',
+                                });
+                            } finally {
+                                isCreating = false;
+                            }
                         }
                     };
 

--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/FunctionSignature.extension.ts
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/FunctionSignature.extension.ts
@@ -1,0 +1,122 @@
+import {EvaluatorFunctionDefinition} from '@/shared/middleware/graphql';
+import {Extension} from '@tiptap/core';
+import {Plugin, PluginKey} from '@tiptap/pm/state';
+import {ReactRenderer} from '@tiptap/react';
+import tippy, {type Instance as TippyInstance} from 'tippy.js';
+
+import FunctionSignatureTooltip from './FunctionSignatureTooltip';
+import {findEnclosingFunctionCall, isFormulaModeActive} from './functionSuggestionUtils';
+
+export const FunctionSignaturePluginKey = new PluginKey('functionSignature');
+
+export const FunctionSignature = Extension.create({
+    addProseMirrorPlugins() {
+        const editor = this.editor;
+
+        return [
+            new Plugin({
+                key: FunctionSignaturePluginKey,
+                view() {
+                    let component: ReactRenderer | undefined;
+                    let popup: TippyInstance | undefined;
+
+                    const hide = () => {
+                        popup?.destroy();
+                        component?.destroy();
+
+                        popup = undefined;
+                        component = undefined;
+                    };
+
+                    // The tippy popper is appended to document.body, so it outlives the editor's own DOM and
+                    // is torn down only when `hide` runs. The plugin's `update` only fires on ProseMirror
+                    // transactions/selection changes — a plain blur (clicking another field) dispatches no
+                    // transaction, so without this listener the tooltip would orphan in <body> and stack up
+                    // behind the next field's tooltip (tippy('body') never dedups). Hiding on blur guarantees
+                    // the signature tooltip never persists past focus.
+                    editor.on('blur', hide);
+
+                    const update = () => {
+                        const {state} = editor.view;
+                        const {selection} = state;
+
+                        if (!editor.isFocused || !selection.empty || !isFormulaModeActive(editor)) {
+                            hide();
+
+                            return;
+                        }
+
+                        const caret = selection.from;
+                        const blockStart = selection.$from.start();
+                        const blockEnd = selection.$from.end();
+                        const textBeforeCaret = state.doc.textBetween(blockStart, caret, '\n', '');
+                        const textAfterCaret = state.doc.textBetween(caret, blockEnd, '\n', '');
+
+                        const call = findEnclosingFunctionCall(textBeforeCaret, textAfterCaret);
+
+                        if (!call) {
+                            hide();
+
+                            return;
+                        }
+
+                        const definitions: EvaluatorFunctionDefinition[] =
+                            editor.storage.FunctionSuggestion?.functionDefinitions ?? [];
+                        const definition = definitions.find((candidate) => candidate.name === call.name);
+
+                        if (!definition) {
+                            hide();
+
+                            return;
+                        }
+
+                        const coords = editor.view.coordsAtPos(caret);
+                        const getReferenceClientRect = () =>
+                            ({
+                                bottom: coords.bottom,
+                                height: 0,
+                                left: coords.left,
+                                right: coords.left,
+                                toJSON() {
+                                    return {};
+                                },
+                                top: coords.top,
+                                width: 0,
+                                x: coords.left,
+                                y: coords.top,
+                            }) as DOMRect;
+
+                        const props = {activeArgIndex: call.argIndex, definition};
+
+                        if (component) {
+                            component.updateProps(props);
+
+                            popup?.setProps({getReferenceClientRect});
+                        } else {
+                            component = new ReactRenderer(FunctionSignatureTooltip, {editor, props});
+
+                            popup = tippy('body', {
+                                appendTo: () => document.body,
+                                content: component.element,
+                                getReferenceClientRect,
+                                placement: 'top-start',
+                                showOnCreate: true,
+                                trigger: 'manual',
+                            })[0];
+                        }
+                    };
+
+                    return {
+                        destroy: () => {
+                            editor.off('blur', hide);
+
+                            hide();
+                        },
+                        update,
+                    };
+                },
+            }),
+        ];
+    },
+    name: 'FunctionSignature',
+});

--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/FunctionSignatureTooltip.test.tsx
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/FunctionSignatureTooltip.test.tsx
@@ -1,0 +1,32 @@
+import {render, screen} from '@testing-library/react';
+import {describe, expect, it} from 'vitest';
+
+import FunctionSignatureTooltip from './FunctionSignatureTooltip';
+
+const definition = {
+    category: 'STRING',
+    description: '',
+    example: '',
+    name: 'substring',
+    parameters: [
+        {description: 'the source string', name: 'value', required: true, type: 'STRING'},
+        {description: 'where to start', name: 'beginIndex', required: true, type: 'INTEGER'},
+    ],
+    returnType: 'STRING',
+    title: '',
+} as never;
+
+describe('FunctionSignatureTooltip', () => {
+    it('renders the function name and return type', () => {
+        render(<FunctionSignatureTooltip activeArgIndex={0} definition={definition} />);
+
+        expect(screen.getByText('substring')).toBeInTheDocument();
+        expect(screen.getAllByText(/String/).length).toBeGreaterThan(0);
+    });
+
+    it('shows the active parameter description', () => {
+        render(<FunctionSignatureTooltip activeArgIndex={1} definition={definition} />);
+
+        expect(screen.getByText('where to start')).toBeInTheDocument();
+    });
+});

--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/FunctionSignatureTooltip.tsx
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/FunctionSignatureTooltip.tsx
@@ -1,0 +1,46 @@
+import {EvaluatorFunctionDefinition} from '@/shared/middleware/graphql';
+import {twMerge} from 'tailwind-merge';
+
+import {formatFunctionSignatureParts} from './functionSuggestionUtils';
+
+interface FunctionSignatureTooltipProps {
+    activeArgIndex: number;
+    definition: EvaluatorFunctionDefinition;
+}
+
+const FunctionSignatureTooltip = ({activeArgIndex, definition}: FunctionSignatureTooltipProps) => {
+    const {params, returnType} = formatFunctionSignatureParts(definition);
+
+    return (
+        <div className="max-w-sm rounded-md border bg-background p-2 font-mono text-xs shadow-md">
+            <span className="text-primary">{definition.name}</span>
+
+            <span className="text-muted-foreground">(</span>
+
+            {params.map((param, index) => (
+                <span key={param}>
+                    <span
+                        className={twMerge(
+                            'text-muted-foreground',
+                            index === activeArgIndex && 'font-bold text-foreground'
+                        )}
+                    >
+                        {param}
+                    </span>
+
+                    <span className="text-muted-foreground">{index < params.length - 1 ? ', ' : ''}</span>
+                </span>
+            ))}
+
+            <span className="text-muted-foreground">): {returnType}</span>
+
+            {definition.parameters[activeArgIndex]?.description && (
+                <div className="mt-1 font-sans whitespace-normal text-muted-foreground">
+                    {definition.parameters[activeArgIndex].description}
+                </div>
+            )}
+        </div>
+    );
+};
+
+export default FunctionSignatureTooltip;

--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/FunctionSuggestion.extension.ts
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/FunctionSuggestion.extension.ts
@@ -1,0 +1,35 @@
+import {EvaluatorFunctionDefinition} from '@/shared/middleware/graphql';
+import {Extension} from '@tiptap/core';
+import {PluginKey} from '@tiptap/pm/state';
+import {Suggestion} from '@tiptap/suggestion';
+
+import {getFunctionSuggestionOptions} from './functionSuggestionOptions';
+
+export const FunctionSuggestionPluginKey = new PluginKey('functionSuggestion');
+
+declare module '@tiptap/core' {
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    interface Storage {
+        FunctionSuggestion: {
+            functionDefinitions: EvaluatorFunctionDefinition[];
+        };
+    }
+}
+
+export const FunctionSuggestion = Extension.create({
+    addProseMirrorPlugins() {
+        return [
+            Suggestion({
+                editor: this.editor,
+                pluginKey: FunctionSuggestionPluginKey,
+                ...getFunctionSuggestionOptions(),
+            }),
+        ];
+    },
+    addStorage() {
+        return {
+            functionDefinitions: [],
+        };
+    },
+    name: 'FunctionSuggestion',
+});

--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/FunctionSuggestionList.test.tsx
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/FunctionSuggestionList.test.tsx
@@ -1,0 +1,79 @@
+import {EvaluatorFunctionDefinition} from '@/shared/middleware/graphql';
+import {act, fireEvent, render, screen} from '@testing-library/react';
+import {SuggestionProps} from '@tiptap/suggestion';
+import {type Ref, createRef} from 'react';
+import {describe, expect, it, vi} from 'vitest';
+
+import FunctionSuggestionList, {FunctionSuggestionListRefType} from './FunctionSuggestionList';
+
+function definition(name: string, overrides: Partial<EvaluatorFunctionDefinition> = {}): EvaluatorFunctionDefinition {
+    return {
+        category: 'STRING',
+        description: `${name} description`,
+        example: `${name}(...)`,
+        name,
+        parameters: [],
+        returnType: 'STRING',
+        title: name,
+        ...overrides,
+    } as EvaluatorFunctionDefinition;
+}
+
+// The list only consumes command and items; the remaining SuggestionProps fields are irrelevant here.
+function renderFunctionSuggestionList(
+    items: EvaluatorFunctionDefinition[],
+    command: SuggestionProps<EvaluatorFunctionDefinition>['command'],
+    ref?: Ref<FunctionSuggestionListRefType>
+) {
+    const props = {command, items} as unknown as SuggestionProps<EvaluatorFunctionDefinition>;
+
+    return render(<FunctionSuggestionList {...props} ref={ref} />);
+}
+
+describe('FunctionSuggestionList', () => {
+    it('renders the function names and shows detail for the highlighted row only', () => {
+        renderFunctionSuggestionList([definition('concat'), definition('contains')], vi.fn());
+
+        expect(screen.getByText('concat')).toBeInTheDocument();
+        expect(screen.getByText('contains')).toBeInTheDocument();
+        // First row is highlighted by default -> its description is shown.
+        expect(screen.getByText('concat description')).toBeInTheDocument();
+        // Non-highlighted row detail is not rendered.
+        expect(screen.queryByText('contains description')).not.toBeInTheDocument();
+    });
+
+    it('renders an empty state when there are no items', () => {
+        renderFunctionSuggestionList([], vi.fn());
+
+        expect(screen.getByText('No functions found.')).toBeInTheDocument();
+    });
+
+    it('calls command with the clicked definition', () => {
+        const command = vi.fn();
+        const items = [definition('concat'), definition('contains')];
+
+        renderFunctionSuggestionList(items, command);
+
+        fireEvent.click(screen.getByText('contains'));
+
+        expect(command).toHaveBeenCalledWith(items[1]);
+    });
+
+    it('selects the highlighted item on Enter via the ref handler', () => {
+        const command = vi.fn();
+        const items = [definition('concat'), definition('contains')];
+        const ref = createRef<FunctionSuggestionListRefType>();
+
+        renderFunctionSuggestionList(items, command, ref);
+
+        act(() => {
+            ref.current!.onKeyDown({event: new KeyboardEvent('keydown', {key: 'ArrowDown'})} as never);
+        });
+
+        act(() => {
+            ref.current!.onKeyDown({event: new KeyboardEvent('keydown', {key: 'Enter'})} as never);
+        });
+
+        expect(command).toHaveBeenCalledWith(items[1]);
+    });
+});

--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/FunctionSuggestionList.test.tsx
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/FunctionSuggestionList.test.tsx
@@ -76,4 +76,30 @@ describe('FunctionSuggestionList', () => {
 
         expect(command).toHaveBeenCalledWith(items[1]);
     });
+
+    it('wraps to the last item on ArrowUp and ignores keys it does not handle', () => {
+        const command = vi.fn();
+        const items = [definition('concat'), definition('contains')];
+        const ref = createRef<FunctionSuggestionListRefType>();
+
+        renderFunctionSuggestionList(items, command, ref);
+
+        let handled = false;
+
+        act(() => {
+            handled = ref.current!.onKeyDown({event: new KeyboardEvent('keydown', {key: 'a'})} as never);
+        });
+
+        expect(handled).toBe(false);
+
+        act(() => {
+            ref.current!.onKeyDown({event: new KeyboardEvent('keydown', {key: 'ArrowUp'})} as never);
+        });
+
+        act(() => {
+            ref.current!.onKeyDown({event: new KeyboardEvent('keydown', {key: 'Enter'})} as never);
+        });
+
+        expect(command).toHaveBeenCalledWith(items[1]);
+    });
 });

--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/FunctionSuggestionList.tsx
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/FunctionSuggestionList.tsx
@@ -1,22 +1,20 @@
 import './PropertyMentionsInputEditorSuggestionList.css';
 
 import {EvaluatorFunctionDefinition} from '@/shared/middleware/graphql';
-import {SuggestionKeyDownProps, SuggestionProps} from '@tiptap/suggestion';
-import {forwardRef, useEffect, useImperativeHandle, useState} from 'react';
+import {SuggestionProps} from '@tiptap/suggestion';
+import {forwardRef} from 'react';
 import {twMerge} from 'tailwind-merge';
 
 import {formatFunctionSignature} from './functionSuggestionUtils';
+import {SuggestionListRefType} from './suggestionPopupRenderer';
+import {useSuggestionListNavigation} from './useSuggestionListNavigation';
 
-export type FunctionSuggestionListRefType = {
-    onKeyDown: (props: SuggestionKeyDownProps) => boolean;
-};
+export type FunctionSuggestionListRefType = SuggestionListRefType;
 
 type FunctionSuggestionListPropsType = SuggestionProps<EvaluatorFunctionDefinition>;
 
 const FunctionSuggestionList = forwardRef<FunctionSuggestionListRefType, FunctionSuggestionListPropsType>(
     ({command, items}, ref) => {
-        const [selectedIndex, setSelectedIndex] = useState(0);
-
         const selectItem = (index: number) => {
             const item = items[index];
 
@@ -25,37 +23,7 @@ const FunctionSuggestionList = forwardRef<FunctionSuggestionListRefType, Functio
             }
         };
 
-        const upHandler = () => setSelectedIndex((selectedIndex + items.length - 1) % items.length);
-
-        const downHandler = () => setSelectedIndex((selectedIndex + 1) % items.length);
-
-        const enterHandler = () => selectItem(selectedIndex);
-
-        useEffect(() => setSelectedIndex(0), [items]);
-
-        useImperativeHandle(ref, () => ({
-            onKeyDown: ({event}: {event: KeyboardEvent}) => {
-                if (event.key === 'ArrowUp') {
-                    upHandler();
-
-                    return true;
-                }
-
-                if (event.key === 'ArrowDown') {
-                    downHandler();
-
-                    return true;
-                }
-
-                if (event.key === 'Enter') {
-                    enterHandler();
-
-                    return true;
-                }
-
-                return false;
-            },
-        }));
+        const selectedIndex = useSuggestionListNavigation(items, ref, selectItem);
 
         return (
             <ul className="property-mentions-suggestion-menu max-h-96 gap-y-1 overflow-y-auto">
@@ -65,6 +33,7 @@ const FunctionSuggestionList = forwardRef<FunctionSuggestionListRefType, Functio
                             <button
                                 className={twMerge('flex-col items-start', index === selectedIndex && 'is-selected')}
                                 onClick={() => selectItem(index)}
+                                type="button"
                             >
                                 <span className="font-mono">
                                     <span className="text-primary">{item.name}</span>

--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/FunctionSuggestionList.tsx
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/FunctionSuggestionList.tsx
@@ -1,0 +1,95 @@
+import './PropertyMentionsInputEditorSuggestionList.css';
+
+import {EvaluatorFunctionDefinition} from '@/shared/middleware/graphql';
+import {SuggestionKeyDownProps, SuggestionProps} from '@tiptap/suggestion';
+import {forwardRef, useEffect, useImperativeHandle, useState} from 'react';
+import {twMerge} from 'tailwind-merge';
+
+import {formatFunctionSignature} from './functionSuggestionUtils';
+
+export type FunctionSuggestionListRefType = {
+    onKeyDown: (props: SuggestionKeyDownProps) => boolean;
+};
+
+type FunctionSuggestionListPropsType = SuggestionProps<EvaluatorFunctionDefinition>;
+
+const FunctionSuggestionList = forwardRef<FunctionSuggestionListRefType, FunctionSuggestionListPropsType>(
+    ({command, items}, ref) => {
+        const [selectedIndex, setSelectedIndex] = useState(0);
+
+        const selectItem = (index: number) => {
+            const item = items[index];
+
+            if (item) {
+                command(item);
+            }
+        };
+
+        const upHandler = () => setSelectedIndex((selectedIndex + items.length - 1) % items.length);
+
+        const downHandler = () => setSelectedIndex((selectedIndex + 1) % items.length);
+
+        const enterHandler = () => selectItem(selectedIndex);
+
+        useEffect(() => setSelectedIndex(0), [items]);
+
+        useImperativeHandle(ref, () => ({
+            onKeyDown: ({event}: {event: KeyboardEvent}) => {
+                if (event.key === 'ArrowUp') {
+                    upHandler();
+
+                    return true;
+                }
+
+                if (event.key === 'ArrowDown') {
+                    downHandler();
+
+                    return true;
+                }
+
+                if (event.key === 'Enter') {
+                    enterHandler();
+
+                    return true;
+                }
+
+                return false;
+            },
+        }));
+
+        return (
+            <ul className="property-mentions-suggestion-menu max-h-96 gap-y-1 overflow-y-auto">
+                {items.length ? (
+                    items.map((item, index) => (
+                        <li key={item.name}>
+                            <button
+                                className={twMerge('flex-col items-start', index === selectedIndex && 'is-selected')}
+                                onClick={() => selectItem(index)}
+                            >
+                                <span className="font-mono">
+                                    <span className="text-primary">{item.name}</span>
+
+                                    <span className="text-muted-foreground">{formatFunctionSignature(item)}</span>
+                                </span>
+
+                                {index === selectedIndex && (
+                                    <span className="mt-1 text-xs whitespace-normal text-muted-foreground">
+                                        {item.description}
+
+                                        {item.example && <span className="mt-0.5 block font-mono">{item.example}</span>}
+                                    </span>
+                                )}
+                            </button>
+                        </li>
+                    ))
+                ) : (
+                    <span className="text-sm">No functions found.</span>
+                )}
+            </ul>
+        );
+    }
+);
+
+FunctionSuggestionList.displayName = 'FunctionSuggestionList';
+
+export default FunctionSuggestionList;

--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/MentionStorage.extension.ts
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/MentionStorage.extension.ts
@@ -1,6 +1,7 @@
 import {Extension} from '@tiptap/core';
 
 import type {DataPillType} from '@/shared/types';
+import type {Editor} from '@tiptap/react';
 
 declare module '@tiptap/core' {
     // eslint-disable-next-line  @typescript-eslint/naming-convention
@@ -8,6 +9,8 @@ declare module '@tiptap/core' {
         MentionStorage: {
             controlType?: string;
             dataPills: DataPillType[];
+            /** Whether a `$` data-pill or `=` function suggestion popup is showing over this editor. */
+            suggestionOpen: boolean;
         };
     }
 }
@@ -16,7 +19,21 @@ export const MentionStorage = Extension.create({
     addStorage() {
         return {
             dataPills: [],
+            suggestionOpen: false,
         };
     },
     name: 'MentionStorage',
 });
+
+/**
+ * Records that a suggestion popup is, or is no longer, showing over `editor`.
+ *
+ * Both suggestion renderers report through here so the editor can refuse to replace its document
+ * while one is open: `setContent` rebuilds the doc, which drops the match the suggestion plugin is
+ * tracking and takes the popup down with it, mid-keystroke.
+ */
+export function setMentionSuggestionOpen(editor: Editor, suggestionOpen: boolean): void {
+    if (editor.storage.MentionStorage) {
+        editor.storage.MentionStorage.suggestionOpen = suggestionOpen;
+    }
+}

--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/PropertyMentionsInput.css
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/PropertyMentionsInput.css
@@ -48,3 +48,12 @@
         }
     }
 }
+
+/*
+ * Set smaller font to datapill mentions in formula mode to match the font size of the formula input
+ */
+@layer components {
+    .property-mentions-editor--formula-mode .tiptap .property-mention-chip {
+        @apply text-xs/5!;
+    }
+}

--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/PropertyMentionsInput.tsx
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/PropertyMentionsInput.tsx
@@ -58,6 +58,7 @@ interface PropertyMentionsInputProps {
     required?: boolean;
     setIsFormulaMode?: (isFormulaMode: boolean) => void;
     showInputTypeSwitchButton?: boolean;
+    toolProperty?: boolean;
     type?: string;
     validateBeforeSave?: (value: string | number) => boolean;
     value?: string;
@@ -86,6 +87,7 @@ const PropertyMentionsInput = forwardRef<Editor, PropertyMentionsInputProps>(
             required = false,
             setIsFormulaMode,
             showInputTypeSwitchButton = false,
+            toolProperty,
             type = 'STRING',
             validateBeforeSave,
             value,
@@ -306,6 +308,7 @@ const PropertyMentionsInput = forwardRef<Editor, PropertyMentionsInputProps>(
                             ref={getPropertyMentionsInputEditorRef}
                             setIsFormulaMode={setIsFormulaMode}
                             taskDispatcherDefinitions={taskDispatcherDefinitions}
+                            toolProperty={toolProperty}
                             type={type}
                             validateBeforeSave={validateBeforeSave}
                             value={value ?? defaultValue}

--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/PropertyMentionsInput.tsx
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/PropertyMentionsInput.tsx
@@ -43,6 +43,7 @@ interface PropertyMentionsInputProps {
     defaultValue?: string;
     deletePropertyButton?: ReactNode;
     description?: string;
+    disableAutoSave?: boolean;
     error?: boolean;
     errorMessage?: string;
     expressionEnabled?: boolean;
@@ -72,6 +73,7 @@ const PropertyMentionsInput = forwardRef<Editor, PropertyMentionsInputProps>(
             defaultValue,
             deletePropertyButton,
             description,
+            disableAutoSave,
             error,
             errorMessage,
             expressionEnabled,
@@ -294,6 +296,7 @@ const PropertyMentionsInput = forwardRef<Editor, PropertyMentionsInputProps>(
                             componentDefinitions={componentDefinitions}
                             controlType={controlType}
                             dataPills={dataPills}
+                            disableAutoSave={disableAutoSave}
                             elementId={elementId}
                             expressionEnabled={expressionEnabled}
                             handleFromAiClick={handleFromAiClick}

--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/PropertyMentionsInput.tsx
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/PropertyMentionsInput.tsx
@@ -21,6 +21,7 @@ import RequiredMark from '@/components/RequiredMark';
 import {Label} from '@/components/ui/label';
 import {Skeleton} from '@/components/ui/skeleton';
 import PropertyInputTypeSwitch from '@/pages/platform/workflow-editor/components/properties/components/PropertyInputTypeSwitch';
+import ExpressionHelpNote from '@/pages/platform/workflow-editor/components/properties/components/property-mentions-input/ExpressionHelpNote';
 import PropertyMentionsInputEditor from '@/pages/platform/workflow-editor/components/properties/components/property-mentions-input/PropertyMentionsInputEditor';
 import useDataPillPanelStore from '@/pages/platform/workflow-editor/stores/useDataPillPanelStore';
 import useWorkflowDataStore from '@/pages/platform/workflow-editor/stores/useWorkflowDataStore';
@@ -287,6 +288,9 @@ const PropertyMentionsInput = forwardRef<Editor, PropertyMentionsInputProps>(
                     <div
                         className={twMerge(
                             'property-mentions-editor flex h-full min-h-9 w-full rounded-md bg-white',
+                            // Data pill chips size themselves, so the editor's own text-xs does not
+                            // reach them. The modifier lets the stylesheet bring them down to match.
+                            isFormulaMode && 'property-mentions-editor--formula-mode',
                             leadingIcon && 'border-0 pr-0.5 pl-10',
                             className
                         )}
@@ -325,6 +329,8 @@ const PropertyMentionsInput = forwardRef<Editor, PropertyMentionsInputProps>(
                         {errorMessage || ERROR_MESSAGES.PROPERTY.FIELD_REQUIRED}
                     </p>
                 )}
+
+                {isFormulaMode && expressionEnabled !== false && !isFromAi && <ExpressionHelpNote />}
             </fieldset>
         );
     }

--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/PropertyMentionsInputEditor.test.tsx
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/PropertyMentionsInputEditor.test.tsx
@@ -103,6 +103,7 @@ import * as React from 'react';
 import {type Mock, afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 
 import PropertyMentionsInput from './PropertyMentionsInput';
+import {FORMULA_MODE_PLACEHOLDER} from './mentionsInputPlaceholder';
 
 const microtaskTick = async (times = 1) => {
     for (let index = 0; index < times; index++) {
@@ -575,6 +576,160 @@ describe('PropertyMentionsInputEditor', () => {
             await microtaskTick(2);
 
             expect(screen.getByRole('textbox', {name: 'FormulaEditor'}).textContent).toBe('3 + 4');
+        });
+
+        it('should render the editor content in a monospace font in formula mode', async () => {
+            renderEditor({isFormulaMode: true, value: '=1 + 2'});
+
+            await microtaskTick(2);
+
+            expect(screen.getByRole('textbox', {name: 'Editor'})).toHaveClass('font-mono');
+        });
+
+        it('should not render the editor content in a monospace font outside formula mode', async () => {
+            renderEditor({isFormulaMode: false, value: 'plain'});
+
+            await microtaskTick(2);
+
+            expect(screen.getByRole('textbox', {name: 'Editor'})).not.toHaveClass('font-mono');
+        });
+
+        // The editor is created once, so the monospace class only tracks the toggle if tiptap's
+        // useEditor effect reapplies editorProps.attributes through setOptions on rerender.
+        it('should apply the monospace font when formula mode is switched on', async () => {
+            const {rerender} = render(
+                <WorkflowEditorProvider value={editorProviderValue}>
+                    <PropertyMentionsInput
+                        controlType="TEXT"
+                        isFormulaMode={false}
+                        label="FormulaEditor"
+                        leadingIcon="📄"
+                        path="parameters.field"
+                        placeholder=""
+                        type="STRING"
+                        value="plain"
+                    />
+                </WorkflowEditorProvider>
+            );
+
+            await microtaskTick(2);
+
+            expect(screen.getByRole('textbox', {name: 'FormulaEditor'})).not.toHaveClass('font-mono');
+
+            rerender(
+                <WorkflowEditorProvider value={editorProviderValue}>
+                    <PropertyMentionsInput
+                        controlType="TEXT"
+                        isFormulaMode={true}
+                        label="FormulaEditor"
+                        leadingIcon="📄"
+                        path="parameters.field"
+                        placeholder=""
+                        type="STRING"
+                        value="plain"
+                    />
+                </WorkflowEditorProvider>
+            );
+
+            await microtaskTick(2);
+
+            expect(screen.getByRole('textbox', {name: 'FormulaEditor'})).toHaveClass('font-mono');
+        });
+
+        // text-xs/5, not plain text-xs: the /5 keeps the text-sm leading so the field holds its
+        // height across the toggle and the smaller text stays vertically centred in the line box.
+        it('should shrink the editor content to text-xs at the text-sm leading in formula mode', async () => {
+            renderEditor({isFormulaMode: true, value: '=1 + 2'});
+
+            await microtaskTick(2);
+
+            const textbox = screen.getByRole('textbox', {name: 'Editor'});
+
+            expect(textbox).toHaveClass('text-xs/5');
+            expect(textbox).not.toHaveClass('text-sm');
+        });
+
+        it('should keep the editor content at text-sm outside formula mode', async () => {
+            renderEditor({isFormulaMode: false, value: 'plain'});
+
+            await microtaskTick(2);
+
+            expect(screen.getByRole('textbox', {name: 'Editor'})).toHaveClass('text-sm');
+        });
+
+        // Data pill chips set their own text-sm, so the editor's text-xs does not reach them. The
+        // modifier on the wrapper is what the stylesheet hangs the smaller chip size off.
+        it('should mark the editor wrapper so data pill chips can shrink with the text', async () => {
+            const {container} = renderEditor({isFormulaMode: true, value: '=1 + 2'});
+
+            await microtaskTick(2);
+
+            expect(container.querySelector('.property-mentions-editor--formula-mode')).toBeInTheDocument();
+        });
+
+        it('should not mark the editor wrapper outside formula mode', async () => {
+            const {container} = renderEditor({isFormulaMode: false, value: 'plain'});
+
+            await microtaskTick(2);
+
+            expect(container.querySelector('.property-mentions-editor--formula-mode')).not.toBeInTheDocument();
+        });
+
+        it('should show the expression sample placeholder in formula mode', async () => {
+            const {container} = renderEditor({isFormulaMode: true, value: ''});
+
+            await microtaskTick(2);
+
+            expect(container.querySelector('[data-placeholder]')).toHaveAttribute(
+                'data-placeholder',
+                FORMULA_MODE_PLACEHOLDER
+            );
+        });
+
+        // The placeholder is resolved per decoration rather than baked into the extensions memo, so
+        // toggling formula mode has to swap it without the editor being rebuilt.
+        it('should swap the placeholder when formula mode is switched on', async () => {
+            const {container, rerender} = render(
+                <WorkflowEditorProvider value={editorProviderValue}>
+                    <PropertyMentionsInput
+                        controlType="TEXT"
+                        isFormulaMode={false}
+                        label="FormulaEditor"
+                        leadingIcon="📄"
+                        path="parameters.field"
+                        type="STRING"
+                        value=""
+                    />
+                </WorkflowEditorProvider>
+            );
+
+            await microtaskTick(2);
+
+            expect(container.querySelector('[data-placeholder]')).not.toHaveAttribute(
+                'data-placeholder',
+                FORMULA_MODE_PLACEHOLDER
+            );
+
+            rerender(
+                <WorkflowEditorProvider value={editorProviderValue}>
+                    <PropertyMentionsInput
+                        controlType="TEXT"
+                        isFormulaMode={true}
+                        label="FormulaEditor"
+                        leadingIcon="📄"
+                        path="parameters.field"
+                        type="STRING"
+                        value=""
+                    />
+                </WorkflowEditorProvider>
+            );
+
+            await microtaskTick(2);
+
+            expect(container.querySelector('[data-placeholder]')).toHaveAttribute(
+                'data-placeholder',
+                FORMULA_MODE_PLACEHOLDER
+            );
         });
     });
 

--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/PropertyMentionsInputEditor.tsx
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/PropertyMentionsInputEditor.tsx
@@ -222,7 +222,16 @@ const PropertyMentionsInputEditor = forwardRef<Editor, PropertyMentionsInputEdit
                     ...(expressionEnabled !== false ? {suggestion: getSuggestionOptions()} : {}),
                 }),
                 Placeholder.configure({
-                    placeholder: getMentionsInputPlaceholder({expressionEnabled, placeholder, toolProperty}),
+                    // Resolved per decoration rather than baked in, so toggling formula mode swaps the
+                    // hint. Recreating `extensions` instead would rebuild the editor and drop the
+                    // document, and this memo deliberately does not depend on isFormulaMode.
+                    placeholder: () =>
+                        getMentionsInputPlaceholder({
+                            expressionEnabled,
+                            formulaMode: isFormulaModeRef.current ?? false,
+                            placeholder,
+                            toolProperty,
+                        }),
                 }),
             ];
 
@@ -499,6 +508,7 @@ const PropertyMentionsInputEditor = forwardRef<Editor, PropertyMentionsInputEdit
                     class: twMerge(
                         'w-full max-w-full min-w-0 border-none text-sm wrap-break-word break-all whitespace-pre-wrap ring-0 outline-hidden',
                         controlType === 'RICH_TEXT' && 'prose prose-sm',
+                        isFormulaMode && 'font-mono text-xs/5',
                         className
                     ),
                     id: elementId ?? '',

--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/PropertyMentionsInputEditor.tsx
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/PropertyMentionsInputEditor.tsx
@@ -34,6 +34,7 @@ import {FunctionSignature} from './FunctionSignature.extension';
 import {FunctionSuggestion, FunctionSuggestionPluginKey} from './FunctionSuggestion.extension';
 import {MentionStorage} from './MentionStorage.extension';
 import PropertyMentionNodeView from './PropertyMentionNodeView';
+import {buildToolFunctionDefinitions} from './fromAiFunctionDefinition';
 import {getDataPillIconSource} from './getDataPillIconSource';
 import {
     PROPERTY_MENTION_CHIP_CLASS,
@@ -62,6 +63,7 @@ interface PropertyMentionsInputEditorProps {
     placeholder?: string;
     setIsFormulaMode?: (isFormulaMode: boolean) => void;
     taskDispatcherDefinitions: TaskDispatcherDefinitionBasic[];
+    toolProperty?: boolean;
     type: string;
     value?: string | number;
     validateBeforeSave?: (value: string | number) => boolean;
@@ -88,6 +90,7 @@ const PropertyMentionsInputEditor = forwardRef<Editor, PropertyMentionsInputEdit
             placeholder,
             setIsFormulaMode,
             taskDispatcherDefinitions,
+            toolProperty,
             type,
             validateBeforeSave,
             value,
@@ -592,8 +595,11 @@ const PropertyMentionsInputEditor = forwardRef<Editor, PropertyMentionsInputEdit
                 return;
             }
 
-            editor.storage.FunctionSuggestion.functionDefinitions = evaluatorFunctionDefinitions;
-        }, [editor, evaluatorFunctionDefinitions]);
+            editor.storage.FunctionSuggestion.functionDefinitions = buildToolFunctionDefinitions(
+                evaluatorFunctionDefinitions,
+                toolProperty ?? false
+            );
+        }, [editor, evaluatorFunctionDefinitions, toolProperty]);
 
         // Applies what the sync effect above decided, and inherits its rule: never replace the
         // document the user is working in.

--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/PropertyMentionsInputEditor.tsx
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/PropertyMentionsInputEditor.tsx
@@ -36,6 +36,7 @@ import {MentionStorage} from './MentionStorage.extension';
 import PropertyMentionNodeView from './PropertyMentionNodeView';
 import {buildToolFunctionDefinitions} from './fromAiFunctionDefinition';
 import {getDataPillIconSource} from './getDataPillIconSource';
+import {getMentionsInputPlaceholder} from './mentionsInputPlaceholder';
 import {
     PROPERTY_MENTION_CHIP_CLASS,
     PROPERTY_MENTION_LABEL_CLASS,
@@ -219,10 +220,7 @@ const PropertyMentionsInputEditor = forwardRef<Editor, PropertyMentionsInputEdit
                     ...(expressionEnabled !== false ? {suggestion: getSuggestionOptions()} : {}),
                 }),
                 Placeholder.configure({
-                    placeholder:
-                        expressionEnabled === false
-                            ? placeholder || ''
-                            : placeholder || "Use '$' for data pills and '=' for an expression",
+                    placeholder: getMentionsInputPlaceholder({expressionEnabled, placeholder, toolProperty}),
                 }),
             ];
 
@@ -262,6 +260,7 @@ const PropertyMentionsInputEditor = forwardRef<Editor, PropertyMentionsInputEdit
             path,
             placeholder,
             setIsFormulaMode,
+            toolProperty,
             type,
             updateClusterElementParameterMutation,
             updateWorkflowNodeParameterMutation,

--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/PropertyMentionsInputEditor.tsx
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/PropertyMentionsInputEditor.tsx
@@ -596,7 +596,7 @@ const PropertyMentionsInputEditor = forwardRef<Editor, PropertyMentionsInputEdit
         // Keep the function suggestion catalog in editor storage so the suggestion items callback can read it
         // without recreating the editor.
         useEffect(() => {
-            if (!editor || editor.storage.FunctionSuggestion === undefined) {
+            if (editor?.storage.FunctionSuggestion === undefined) {
                 return;
             }
 

--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/PropertyMentionsInputEditor.tsx
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/PropertyMentionsInputEditor.tsx
@@ -33,6 +33,8 @@ import {useDebouncedCallback} from 'use-debounce';
 import {useShallow} from 'zustand/react/shallow';
 
 import {FormulaMode} from './FormulaMode.extension';
+import {FunctionSignature} from './FunctionSignature.extension';
+import {FunctionSuggestion, FunctionSuggestionPluginKey} from './FunctionSuggestion.extension';
 import {MentionStorage} from './MentionStorage.extension';
 import PropertyMentionNodeView from './PropertyMentionNodeView';
 import {getDataPillIconSource} from './getDataPillIconSource';
@@ -42,6 +44,7 @@ import {
     PROPERTY_MENTION_ROOT_CLASS,
     replaceMentionNodesInHtmlWithVariables,
 } from './propertyMentionDom';
+import {useEvaluatorFunctionDefinitions} from './useEvaluatorFunctionDefinitions';
 
 interface PropertyMentionsInputEditorProps {
     className?: string;
@@ -129,6 +132,8 @@ const PropertyMentionsInputEditor = forwardRef<Editor, PropertyMentionsInputEdit
             [componentDefinitions, taskDispatcherDefinitions, workflow]
         );
 
+        const evaluatorFunctionDefinitions = useEvaluatorFunctionDefinitions();
+
         const extensions = useMemo(() => {
             const extensions = [
                 ...(controlType === 'RICH_TEXT' ? [StarterKit] : [Document, Paragraph, Text]),
@@ -159,6 +164,7 @@ const PropertyMentionsInputEditor = forwardRef<Editor, PropertyMentionsInputEdit
                     setIsFormulaMode: setIsFormulaMode || (() => {}),
                 }),
                 MentionStorage,
+                ...(expressionEnabled !== false ? [FunctionSuggestion, FunctionSignature] : []),
                 Mention.extend({
                     addNodeView() {
                         return ReactNodeViewRenderer(PropertyMentionNodeView);
@@ -222,9 +228,24 @@ const PropertyMentionsInputEditor = forwardRef<Editor, PropertyMentionsInputEdit
             if (controlType !== 'TEXT_AREA' && controlType !== 'RICH_TEXT' && controlType !== 'FORMULA_MODE') {
                 extensions.push(
                     Extension.create({
-                        addKeyboardShortcuts(this) {
+                        addKeyboardShortcuts() {
                             return {
-                                Enter: () => true,
+                                // Single-line inputs swallow Enter to prevent newlines. But when the
+                                // function suggestion popup is open, defer to its keydown handler so Enter
+                                // accepts the highlighted function instead of being eaten here. Tiptap
+                                // reverses extensions when building plugins, so this keymap sits ahead of
+                                // the Suggestion plugin and would otherwise consume Enter first.
+                                Enter: ({editor}) => {
+                                    const functionSuggestionActive = FunctionSuggestionPluginKey.getState(
+                                        editor.state
+                                    )?.active;
+
+                                    if (functionSuggestionActive) {
+                                        return false;
+                                    }
+
+                                    return true;
+                                },
                             };
                         },
                     })
@@ -608,6 +629,16 @@ const PropertyMentionsInputEditor = forwardRef<Editor, PropertyMentionsInputEdit
             editor.storage.MentionStorage.dataPills = dataPills;
             editor.storage.MentionStorage.controlType = controlType;
         }, [controlType, dataPills, editor]);
+
+        // Keep the function suggestion catalog in editor storage so the suggestion items callback can read it
+        // without recreating the editor.
+        useEffect(() => {
+            if (!editor || editor.storage.FunctionSuggestion === undefined) {
+                return;
+            }
+
+            editor.storage.FunctionSuggestion.functionDefinitions = evaluatorFunctionDefinitions;
+        }, [editor, evaluatorFunctionDefinitions]);
 
         // Update editor content when editorValue changes (but not during local updates)
         useEffect(() => {

--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/PropertyMentionsInputEditor.tsx
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/PropertyMentionsInputEditor.tsx
@@ -485,7 +485,7 @@ const PropertyMentionsInputEditor = forwardRef<Editor, PropertyMentionsInputEdit
                     'aria-multiline': 'true',
                     class: twMerge(
                         'w-full max-w-full min-w-0 border-none text-sm wrap-break-word break-all whitespace-pre-wrap ring-0 outline-hidden',
-                        controlType === 'RICH_TEXT' && 'prose prose-sm sm:prose-base lg:prose-lg xl:prose-2xl',
+                        controlType === 'RICH_TEXT' && 'prose prose-sm',
                         className
                     ),
                     id: elementId ?? '',

--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/PropertyMentionsInputEditor.tsx
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/PropertyMentionsInputEditor.tsx
@@ -51,6 +51,7 @@ interface PropertyMentionsInputEditorProps {
     componentDefinitions: ComponentDefinitionBasic[];
     controlType?: string;
     dataPills: DataPillType[];
+    disableAutoSave?: boolean;
     elementId?: string;
     expressionEnabled?: boolean;
     handleFromAiClick?: (fromAi: boolean) => void;
@@ -78,6 +79,7 @@ const PropertyMentionsInputEditor = forwardRef<Editor, PropertyMentionsInputEdit
             componentDefinitions,
             controlType,
             dataPills,
+            disableAutoSave,
             elementId,
             expressionEnabled,
             handleFromAiClick,
@@ -268,6 +270,10 @@ const PropertyMentionsInputEditor = forwardRef<Editor, PropertyMentionsInputEdit
         ]);
 
         const saveMentionInputValue = useDebouncedCallback((editorValue: string | number) => {
+            if (disableAutoSave) {
+                return;
+            }
+
             if (
                 !workflow.id ||
                 !(updateWorkflowNodeParameterMutation || updateClusterElementParameterMutation) ||
@@ -667,7 +673,7 @@ const PropertyMentionsInputEditor = forwardRef<Editor, PropertyMentionsInputEdit
                     />
                 )}
 
-                {handleFromAiClick && expressionEnabled !== false && currentNode?.clusterElementType === 'tools' && (
+                {handleFromAiClick && expressionEnabled !== false && toolProperty && (
                     <FromAiToggleButton isFromAi={isFromAi} onToggle={handleFromAiClick} />
                 )}
 

--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/PropertyMentionsInputEditor.tsx
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/PropertyMentionsInputEditor.tsx
@@ -4,10 +4,7 @@ import PropertyMentionsInputBubbleMenu from '@/pages/platform/workflow-editor/co
 import {getSuggestionOptions} from '@/pages/platform/workflow-editor/components/properties/components/property-mentions-input/propertyMentionsInputEditorSuggestionOptions';
 import {useWorkflowEditor} from '@/pages/platform/workflow-editor/providers/workflowEditorProvider';
 import useWorkflowNodeDetailsPanelStore from '@/pages/platform/workflow-editor/stores/useWorkflowNodeDetailsPanelStore';
-import {
-    escapeHtmlForParagraph,
-    transformValueForObjectAccess,
-} from '@/pages/platform/workflow-editor/utils/encodingUtils';
+import {transformValueForObjectAccess} from '@/pages/platform/workflow-editor/utils/encodingUtils';
 import saveProperty from '@/pages/platform/workflow-editor/utils/saveProperty';
 import {
     ComponentDefinitionBasic,
@@ -42,6 +39,7 @@ import {
     PROPERTY_MENTION_CHIP_CLASS,
     PROPERTY_MENTION_LABEL_CLASS,
     PROPERTY_MENTION_ROOT_CLASS,
+    buildPropertyMentionsContent,
     replaceMentionNodesInHtmlWithVariables,
 } from './propertyMentionDom';
 import {useEvaluatorFunctionDefinitions} from './useEvaluatorFunctionDefinitions';
@@ -403,55 +401,7 @@ const PropertyMentionsInputEditor = forwardRef<Editor, PropertyMentionsInputEdit
         );
 
         const getContent = useCallback(
-            (value?: string) => {
-                if (typeof value !== 'string') {
-                    return;
-                }
-
-                if (!value) {
-                    return '';
-                }
-
-                let content = value;
-                let contentIsDecodedHtml = false;
-
-                if (
-                    controlType === 'RICH_TEXT' &&
-                    (content.includes('&lt;') || content.includes('&gt;') || content.includes('&amp;'))
-                ) {
-                    content = decode(content);
-
-                    content = sanitizeHtml(content);
-
-                    contentIsDecodedHtml = true;
-                }
-
-                if (!contentIsDecodedHtml && content.includes('\n')) {
-                    const valueLines = content.split('\n');
-
-                    const paragraphedLines =
-                        controlType === 'TEXT_AREA' || controlType === 'TEXT' || controlType === 'FORMULA_MODE'
-                            ? valueLines.map((valueLine) => `<p>${escapeHtmlForParagraph(valueLine)}</p>`)
-                            : valueLines.map((valueLine) => `<p>${valueLine}</p>`);
-
-                    content = paragraphedLines.join('');
-                }
-
-                const dataPillRegex = /\${([^}]+)}/g;
-
-                const matches = value.match(dataPillRegex)?.map((match) => match.slice(2, -1));
-
-                if (matches) {
-                    for (const match of matches) {
-                        content = content.replace(
-                            `\${${match}}`,
-                            `<span data-type="mention" class="${PROPERTY_MENTION_ROOT_CLASS}" data-id="${match}"></span>`
-                        );
-                    }
-                }
-
-                return content;
-            },
+            (value?: string) => buildPropertyMentionsContent(value, controlType),
             [controlType]
         );
 

--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/PropertyMentionsInputEditor.tsx
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/PropertyMentionsInputEditor.tsx
@@ -303,7 +303,12 @@ const PropertyMentionsInputEditor = forwardRef<Editor, PropertyMentionsInputEdit
 
                 transformedValue = transformValueForObjectAccess(transformedValue);
 
-                if (isFormulaMode && !transformedValue.startsWith('=')) {
+                // An empty formula field is NOT the expression `=`. Prefixing it anyway persisted a bare
+                // `=`, which reads downstream as a condition that is present but never true - a graph
+                // transition carrying one was skipped by the conditional pass for evaluating falsy and
+                // by the unconditional pass for having a condition at all, and its node quietly
+                // stranded. Nothing typed means nothing saved.
+                if (isFormulaMode && transformedValue !== '' && !transformedValue.startsWith('=')) {
                     transformedValue = `=${transformedValue}`;
                 }
             }

--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/PropertyMentionsInputEditor.tsx
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/PropertyMentionsInputEditor.tsx
@@ -590,14 +590,27 @@ const PropertyMentionsInputEditor = forwardRef<Editor, PropertyMentionsInputEdit
             editor.storage.FunctionSuggestion.functionDefinitions = evaluatorFunctionDefinitions;
         }, [editor, evaluatorFunctionDefinitions]);
 
-        // Update editor content when editorValue changes (but not during local updates)
+        // Applies what the sync effect above decided, and inherits its rule: never replace the
+        // document the user is working in.
+        //
+        // `setContent` rebuilds the doc from scratch, so it drops the match the `$` and `=` suggestion
+        // plugins track, taking the popup down mid-keystroke, and it repaints the field from
+        // `editorValue`, which is empty whenever this reruns against a value the panel has not caught
+        // up with yet. `isLocalUpdate` alone did not cover it: it says the last change came from here,
+        // not that the user is still in the field.
         useEffect(() => {
-            if (editor && !isLocalUpdate && memoizedContent !== undefined) {
-                editor.commands.setContent(memoizedContent, {
-                    emitUpdate: false,
-                    parseOptions: {preserveWhitespace: 'full'},
-                });
+            if (!editor || isLocalUpdate || memoizedContent === undefined) {
+                return;
             }
+
+            if (editor.isFocused || isFocusedRef.current || editor.storage.MentionStorage?.suggestionOpen) {
+                return;
+            }
+
+            editor.commands.setContent(memoizedContent, {
+                emitUpdate: false,
+                parseOptions: {preserveWhitespace: 'full'},
+            });
         }, [editor, memoizedContent, isLocalUpdate]);
 
         // Sync formula mode state with editor storage

--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/PropertyMentionsInputEditorSuggestionList.css
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/PropertyMentionsInputEditorSuggestionList.css
@@ -12,6 +12,17 @@
     @apply relative;
     @apply text-sm;
 
+    /*
+     * Inside a Radix modal dialog (the cluster elements canvas), DismissableLayer sets
+     * document.body pointer-events to "none", and the tippy popup is portaled to the body.
+     * The popup cannot re-enable pointer events on its own root: tippy's handleStyles() resets
+     * popper.style.pointerEvents to "" on every setProps() call, and the suggestion's onUpdate
+     * calls setProps() on each keystroke to reposition the popup. Claiming pointer events here,
+     * on the menu itself, survives that reset because a child may always override an inherited
+     * "none". Without this the popup is inert: it neither scrolls nor accepts clicks.
+     */
+    @apply pointer-events-auto;
+
     button {
         @apply items-center;
         @apply flex;

--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/PropertyMentionsInputEditorSuggestionList.tsx
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/PropertyMentionsInputEditorSuggestionList.tsx
@@ -1,14 +1,15 @@
 import './PropertyMentionsInputEditorSuggestionList.css';
 
 import {DataPillType} from '@/shared/types';
-import {SuggestionKeyDownProps, SuggestionProps} from '@tiptap/suggestion';
-import {forwardRef, useEffect, useImperativeHandle, useState} from 'react';
+import {SuggestionProps} from '@tiptap/suggestion';
+import {forwardRef} from 'react';
 import InlineSVG from 'react-inlinesvg';
 import {twMerge} from 'tailwind-merge';
 
-export type PropertyMentionsInputListRefType = {
-    onKeyDown: (props: SuggestionKeyDownProps) => boolean;
-};
+import {SuggestionListRefType} from './suggestionPopupRenderer';
+import {useSuggestionListNavigation} from './useSuggestionListNavigation';
+
+export type PropertyMentionsInputListRefType = SuggestionListRefType;
 
 type PropertyMentionsInputListPropsType = SuggestionProps<DataPillType>;
 
@@ -16,8 +17,6 @@ const PropertyMentionsInputEditorSuggestionList = forwardRef<
     PropertyMentionsInputListRefType,
     PropertyMentionsInputListPropsType
 >(({command, items}, ref) => {
-    const [selectedIndex, setSelectedIndex] = useState(0);
-
     const selectItem = (index: number) => {
         const item: DataPillType = items[index];
 
@@ -26,37 +25,7 @@ const PropertyMentionsInputEditorSuggestionList = forwardRef<
         }
     };
 
-    const upHandler = () => setSelectedIndex((selectedIndex + items.length - 1) % items.length);
-
-    const downHandler = () => setSelectedIndex((selectedIndex + 1) % items.length);
-
-    const enterHandler = () => selectItem(selectedIndex);
-
-    useEffect(() => setSelectedIndex(0), [items]);
-
-    useImperativeHandle(ref, () => ({
-        onKeyDown: ({event}: {event: KeyboardEvent}) => {
-            if (event.key === 'ArrowUp') {
-                upHandler();
-
-                return true;
-            }
-
-            if (event.key === 'ArrowDown') {
-                downHandler();
-
-                return true;
-            }
-
-            if (event.key === 'Enter') {
-                enterHandler();
-
-                return true;
-            }
-
-            return false;
-        },
-    }));
+    const selectedIndex = useSuggestionListNavigation(items, ref, selectItem);
 
     return (
         <ul className="property-mentions-suggestion-menu max-h-96 gap-y-1 overflow-y-auto">

--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/controlledExpressionValue.ts
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/controlledExpressionValue.ts
@@ -1,0 +1,12 @@
+// In controlled (react-hook-form) function mode the TipTap editor reports its content WITHOUT the
+// leading "=". Re-add it so the form value stays a well-formed expression; empty content clears.
+export function reconstructControlledExpressionValue(rawValue: string | number): string {
+    const stringValue = typeof rawValue === 'string' ? rawValue : String(rawValue ?? '');
+    const trimmed = stringValue.trim();
+
+    if (trimmed === '') {
+        return '';
+    }
+
+    return trimmed.startsWith('=') ? trimmed : `=${trimmed}`;
+}

--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/fromAiFunctionDefinition.ts
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/fromAiFunctionDefinition.ts
@@ -1,0 +1,55 @@
+import {
+    EvaluatorFunctionCategory,
+    EvaluatorFunctionDefinition,
+    EvaluatorFunctionType,
+} from '@/shared/middleware/graphql';
+
+// Synthetic catalog entry so `fromAi` appears in the function-autocomplete dropdown for tool
+// properties. It is NOT a real evaluator function (the server catalog has no `fromAi`); it exists
+// purely as a UI affordance and behaves like any other function when selected (inserts `fromAi()`).
+export const FROM_AI_FUNCTION_DEFINITION: EvaluatorFunctionDefinition = {
+    category: EvaluatorFunctionCategory.Utility,
+    description: 'Let the AI model supply this value at runtime.',
+    example: "=fromAi('name', 'STRING', {'required': true})",
+    name: 'fromAi',
+    parameters: [
+        {
+            description: 'Identifier the model sees for this value.',
+            name: 'name',
+            required: true,
+            type: EvaluatorFunctionType.String,
+        },
+        {
+            description: 'Value type, for example STRING.',
+            name: 'type',
+            required: true,
+            type: EvaluatorFunctionType.String,
+        },
+        {
+            description: 'Optional metadata: description, defaultValue, options, required.',
+            name: 'options',
+            required: false,
+            type: EvaluatorFunctionType.Map,
+        },
+    ],
+    returnType: EvaluatorFunctionType.String,
+    title: 'fromAi',
+};
+
+// The function-suggestion catalog for the editor: the base evaluator definitions, plus the synthetic
+// `fromAi` entry when the field is a tool property. fromAi is prepended so it surfaces first when the
+// user types "fr...".
+export function buildToolFunctionDefinitions(
+    definitions: EvaluatorFunctionDefinition[],
+    toolProperty: boolean
+): EvaluatorFunctionDefinition[] {
+    if (!toolProperty) {
+        return definitions;
+    }
+
+    if (definitions.some((definition) => definition.name === 'fromAi')) {
+        return definitions;
+    }
+
+    return [FROM_AI_FUNCTION_DEFINITION, ...definitions];
+}

--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/functionSuggestionOptions.ts
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/functionSuggestionOptions.ts
@@ -4,6 +4,7 @@ import {SuggestionOptions} from '@tiptap/suggestion';
 import tippy, {type Instance as TippyInstance} from 'tippy.js';
 
 import FunctionSuggestionList, {FunctionSuggestionListRefType} from './FunctionSuggestionList';
+import {setMentionSuggestionOpen} from './MentionStorage.extension';
 import {
     buildFunctionInsertion,
     filterFunctionDefinitions,
@@ -51,9 +52,18 @@ export function getFunctionSuggestionOptions(): Omit<SuggestionOptions<Evaluator
             let popup: TippyInstance | undefined;
             let lastValidRect: DOMRect = DOM_RECT_FALLBACK;
             let wheelAbortController: AbortController | undefined;
+            // Held so `onExit` can clear the open flag. It has no props of its own, and it also runs
+            // for a suggestion `onStart` declined to show, where there is nothing to clear.
+            let openedEditor: Editor | undefined;
 
             return {
                 onExit() {
+                    if (openedEditor) {
+                        setMentionSuggestionOpen(openedEditor, false);
+
+                        openedEditor = undefined;
+                    }
+
                     wheelAbortController?.abort();
                     popup?.destroy();
                     component?.destroy();
@@ -115,6 +125,10 @@ export function getFunctionSuggestionOptions(): Omit<SuggestionOptions<Evaluator
                         passive: true,
                         signal: wheelAbortController.signal,
                     });
+
+                    openedEditor = props.editor;
+
+                    setMentionSuggestionOpen(props.editor, true);
                 },
 
                 onUpdate(props) {

--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/functionSuggestionOptions.ts
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/functionSuggestionOptions.ts
@@ -1,30 +1,15 @@
 import {EvaluatorFunctionDefinition} from '@/shared/middleware/graphql';
-import {Editor, ReactRenderer} from '@tiptap/react';
+import {Editor} from '@tiptap/react';
 import {SuggestionOptions} from '@tiptap/suggestion';
-import tippy, {type Instance as TippyInstance} from 'tippy.js';
 
-import FunctionSuggestionList, {FunctionSuggestionListRefType} from './FunctionSuggestionList';
-import {setMentionSuggestionOpen} from './MentionStorage.extension';
+import FunctionSuggestionList from './FunctionSuggestionList';
 import {
     buildFunctionInsertion,
     filterFunctionDefinitions,
     findFunctionSuggestionMatch,
     isFormulaModeActive,
 } from './functionSuggestionUtils';
-
-const DOM_RECT_FALLBACK: DOMRect = {
-    bottom: 0,
-    height: 0,
-    left: 0,
-    right: 0,
-    toJSON() {
-        return {};
-    },
-    top: 0,
-    width: 0,
-    x: 0,
-    y: 0,
-};
+import {createSuggestionPopupRenderer} from './suggestionPopupRenderer';
 
 export function getFunctionSuggestionOptions(): Omit<SuggestionOptions<EvaluatorFunctionDefinition>, 'editor'> {
     return {
@@ -47,107 +32,7 @@ export function getFunctionSuggestionOptions(): Omit<SuggestionOptions<Evaluator
 
             return filterFunctionDefinitions(definitions, query);
         },
-        render: () => {
-            let component: ReactRenderer<FunctionSuggestionListRefType> | undefined;
-            let popup: TippyInstance | undefined;
-            let lastValidRect: DOMRect = DOM_RECT_FALLBACK;
-            let wheelAbortController: AbortController | undefined;
-            // Held so `onExit` can clear the open flag. It has no props of its own, and it also runs
-            // for a suggestion `onStart` declined to show, where there is nothing to clear.
-            let openedEditor: Editor | undefined;
-
-            return {
-                onExit() {
-                    if (openedEditor) {
-                        setMentionSuggestionOpen(openedEditor, false);
-
-                        openedEditor = undefined;
-                    }
-
-                    wheelAbortController?.abort();
-                    popup?.destroy();
-                    component?.destroy();
-                },
-
-                onKeyDown(props) {
-                    if (props.event.key === 'Escape') {
-                        popup?.hide();
-
-                        return true;
-                    }
-
-                    if (!component?.ref) {
-                        return false;
-                    }
-
-                    return component.ref.onKeyDown(props);
-                },
-
-                onStart: (props) => {
-                    if (!props.editor.isFocused) {
-                        return;
-                    }
-
-                    component = new ReactRenderer(FunctionSuggestionList, {
-                        editor: props.editor,
-                        props,
-                    });
-
-                    const initialRect = props.clientRect?.();
-
-                    if (!initialRect) {
-                        component.destroy();
-                        component = undefined;
-
-                        return;
-                    }
-
-                    lastValidRect = initialRect;
-
-                    popup = tippy('body', {
-                        appendTo: () => document.body,
-                        content: component.element,
-                        getReferenceClientRect: () => lastValidRect,
-                        interactive: true,
-                        placement: 'bottom-start',
-                        showOnCreate: true,
-                        trigger: 'manual',
-                    })[0];
-
-                    // Inside a Radix modal dialog, react-remove-scroll blocks wheel events outside the
-                    // dialog content. Intercept them on the popup before they reach the document
-                    // listener that would preventDefault on them. Pointer events are re-enabled by the
-                    // menu's own stylesheet, since tippy resets the popper's inline value on setProps.
-                    wheelAbortController = new AbortController();
-
-                    popup.popper.addEventListener('wheel', (event) => event.stopPropagation(), {
-                        capture: true,
-                        passive: true,
-                        signal: wheelAbortController.signal,
-                    });
-
-                    openedEditor = props.editor;
-
-                    setMentionSuggestionOpen(props.editor, true);
-                },
-
-                onUpdate(props) {
-                    component?.updateProps(props);
-
-                    const updatedRect = props.clientRect?.();
-
-                    if (!updatedRect) {
-                        return;
-                    }
-
-                    lastValidRect = updatedRect;
-
-                    popup?.setProps({
-                        getReferenceClientRect: () => lastValidRect,
-                    });
-                },
-            };
-        },
+        render: createSuggestionPopupRenderer<EvaluatorFunctionDefinition>(FunctionSuggestionList),
         // Don't activate the suggestion (and therefore don't open a popup) unless at least one function
         // matches. The trailing-word match fires on any word — including plain argument values like
         // "true" — so without this the popup would appear empty ("No functions found.") next to the

--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/functionSuggestionOptions.ts
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/functionSuggestionOptions.ts
@@ -1,0 +1,146 @@
+import {EvaluatorFunctionDefinition} from '@/shared/middleware/graphql';
+import {Editor, ReactRenderer} from '@tiptap/react';
+import {SuggestionOptions} from '@tiptap/suggestion';
+import tippy, {type Instance as TippyInstance} from 'tippy.js';
+
+import FunctionSuggestionList, {FunctionSuggestionListRefType} from './FunctionSuggestionList';
+import {
+    buildFunctionInsertion,
+    filterFunctionDefinitions,
+    findFunctionSuggestionMatch,
+    isFormulaModeActive,
+} from './functionSuggestionUtils';
+
+const DOM_RECT_FALLBACK: DOMRect = {
+    bottom: 0,
+    height: 0,
+    left: 0,
+    right: 0,
+    toJSON() {
+        return {};
+    },
+    top: 0,
+    width: 0,
+    x: 0,
+    y: 0,
+};
+
+export function getFunctionSuggestionOptions(): Omit<SuggestionOptions<EvaluatorFunctionDefinition>, 'editor'> {
+    return {
+        // Stay open while already active even if the editor briefly loses focus — clicking a function
+        // in the tippy popup blurs the editor, and a focus-only guard would tear the popup down before
+        // the click lands. Mirrors the datapill suggestion's isActive survival check.
+        allow: ({editor, isActive}) => (editor.isFocused || isActive === true) && isFormulaModeActive(editor),
+        char: '',
+        command: ({editor, props, range}) => {
+            const {caretOffset, content} = buildFunctionInsertion(props.name);
+
+            editor.chain().focus().insertContentAt(range, content).run();
+
+            editor.commands.setTextSelection(range.from + caretOffset);
+        },
+        findSuggestionMatch: findFunctionSuggestionMatch,
+        items: ({editor, query}): EvaluatorFunctionDefinition[] => {
+            const definitions: EvaluatorFunctionDefinition[] =
+                editor.storage.FunctionSuggestion?.functionDefinitions ?? [];
+
+            return filterFunctionDefinitions(definitions, query);
+        },
+        render: () => {
+            let component: ReactRenderer<FunctionSuggestionListRefType> | undefined;
+            let popup: TippyInstance | undefined;
+            let lastValidRect: DOMRect = DOM_RECT_FALLBACK;
+            let wheelAbortController: AbortController | undefined;
+
+            return {
+                onExit() {
+                    wheelAbortController?.abort();
+                    popup?.destroy();
+                    component?.destroy();
+                },
+
+                onKeyDown(props) {
+                    if (props.event.key === 'Escape') {
+                        popup?.hide();
+
+                        return true;
+                    }
+
+                    if (!component?.ref) {
+                        return false;
+                    }
+
+                    return component.ref.onKeyDown(props);
+                },
+
+                onStart: (props) => {
+                    if (!props.editor.isFocused) {
+                        return;
+                    }
+
+                    component = new ReactRenderer(FunctionSuggestionList, {
+                        editor: props.editor,
+                        props,
+                    });
+
+                    const initialRect = props.clientRect?.();
+
+                    if (!initialRect) {
+                        component.destroy();
+                        component = undefined;
+
+                        return;
+                    }
+
+                    lastValidRect = initialRect;
+
+                    popup = tippy('body', {
+                        appendTo: () => document.body,
+                        content: component.element,
+                        getReferenceClientRect: () => lastValidRect,
+                        interactive: true,
+                        placement: 'bottom-start',
+                        showOnCreate: true,
+                        trigger: 'manual',
+                    })[0];
+
+                    popup.popper.style.pointerEvents = 'auto';
+
+                    wheelAbortController = new AbortController();
+
+                    popup.popper.addEventListener('wheel', (event) => event.stopPropagation(), {
+                        capture: true,
+                        passive: true,
+                        signal: wheelAbortController.signal,
+                    });
+                },
+
+                onUpdate(props) {
+                    component?.updateProps(props);
+
+                    const updatedRect = props.clientRect?.();
+
+                    if (!updatedRect) {
+                        return;
+                    }
+
+                    lastValidRect = updatedRect;
+
+                    popup?.setProps({
+                        getReferenceClientRect: () => lastValidRect,
+                    });
+                },
+            };
+        },
+        // Don't activate the suggestion (and therefore don't open a popup) unless at least one function
+        // matches. The trailing-word match fires on any word — including plain argument values like
+        // "true" — so without this the popup would appear empty ("No functions found.") next to the
+        // signature tooltip.
+        shouldShow: ({editor, query}: {editor: Editor; query: string}) => {
+            const definitions: EvaluatorFunctionDefinition[] =
+                editor.storage.FunctionSuggestion?.functionDefinitions ?? [];
+
+            return filterFunctionDefinitions(definitions, query).length > 0;
+        },
+    };
+}

--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/functionSuggestionOptions.ts
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/functionSuggestionOptions.ts
@@ -104,8 +104,10 @@ export function getFunctionSuggestionOptions(): Omit<SuggestionOptions<Evaluator
                         trigger: 'manual',
                     })[0];
 
-                    popup.popper.style.pointerEvents = 'auto';
-
+                    // Inside a Radix modal dialog, react-remove-scroll blocks wheel events outside the
+                    // dialog content. Intercept them on the popup before they reach the document
+                    // listener that would preventDefault on them. Pointer events are re-enabled by the
+                    // menu's own stylesheet, since tippy resets the popper's inline value on setProps.
                     wheelAbortController = new AbortController();
 
                     popup.popper.addEventListener('wheel', (event) => event.stopPropagation(), {

--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/functionSuggestionUtils.test.ts
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/functionSuggestionUtils.test.ts
@@ -1,0 +1,193 @@
+import {EvaluatorFunctionDefinition, EvaluatorFunctionType} from '@/shared/middleware/graphql';
+import {describe, expect, it} from 'vitest';
+
+import {
+    buildFunctionInsertion,
+    filterFunctionDefinitions,
+    findEnclosingFunctionCall,
+    findFunctionSuggestionMatch,
+    formatFunctionSignature,
+    formatFunctionSignatureParts,
+    isFormulaModeActive,
+} from './functionSuggestionUtils';
+
+function definition(overrides: Partial<EvaluatorFunctionDefinition>): EvaluatorFunctionDefinition {
+    return {
+        category: 'STRING',
+        description: '',
+        example: '',
+        name: 'fn',
+        parameters: [],
+        returnType: 'STRING',
+        title: '',
+        ...overrides,
+    } as EvaluatorFunctionDefinition;
+}
+
+describe('formatFunctionSignature', () => {
+    it('formats a multi-parameter signature with a return type', () => {
+        const result = formatFunctionSignature(
+            definition({
+                name: 'substring',
+                parameters: [
+                    {description: '', name: 'value', required: true, type: EvaluatorFunctionType.String},
+                    {description: '', name: 'beginIndex', required: true, type: EvaluatorFunctionType.Integer},
+                ],
+                returnType: EvaluatorFunctionType.String,
+            })
+        );
+
+        expect(result).toBe('(value: String, beginIndex: Integer): String');
+    });
+
+    it('formats a zero-argument signature', () => {
+        const result = formatFunctionSignature(
+            definition({name: 'uuid', parameters: [], returnType: EvaluatorFunctionType.String})
+        );
+
+        expect(result).toBe('(): String');
+    });
+});
+
+describe('filterFunctionDefinitions', () => {
+    const definitions = [
+        definition({name: 'concat', title: 'Concatenate'}),
+        definition({name: 'contains', title: 'Contains'}),
+        definition({name: 'substring', title: 'Substring'}),
+        definition({name: 'join', title: 'Join collection'}),
+    ];
+
+    it('matches by case-insensitive name prefix', () => {
+        const result = filterFunctionDefinitions(definitions, 'CON');
+
+        expect(result.map((definition) => definition.name)).toEqual(['concat', 'contains']);
+    });
+
+    it('falls back to a title substring match when the name does not prefix-match', () => {
+        const result = filterFunctionDefinitions(definitions, 'collection');
+
+        expect(result.map((definition) => definition.name)).toEqual(['join']);
+    });
+
+    it('caps the number of returned results', () => {
+        const many = Array.from({length: 100}, (_, index) => definition({name: `fn${index}`}));
+
+        expect(filterFunctionDefinitions(many, 'fn').length).toBe(50);
+    });
+});
+
+describe('buildFunctionInsertion', () => {
+    it('builds the call text and the caret offset between the parens', () => {
+        expect(buildFunctionInsertion('concat')).toEqual({caretOffset: 7, content: 'concat()'});
+    });
+});
+
+describe('findFunctionSuggestionMatch', () => {
+    it('matches the trailing word of 2+ characters before the caret', () => {
+        const $position = {nodeBefore: {isText: true, text: 'conc'}, pos: 6} as never;
+
+        expect(findFunctionSuggestionMatch({$position})).toEqual({
+            query: 'conc',
+            range: {from: 2, to: 6},
+            text: 'conc',
+        });
+    });
+
+    it('returns null for a single trailing character', () => {
+        const $position = {nodeBefore: {isText: true, text: 'c'}, pos: 3} as never;
+
+        expect(findFunctionSuggestionMatch({$position})).toBeNull();
+    });
+
+    it('returns null when there is no trailing word', () => {
+        const $position = {nodeBefore: {isText: true, text: 'add('}, pos: 5} as never;
+
+        expect(findFunctionSuggestionMatch({$position})).toBeNull();
+    });
+
+    it('returns null when nodeBefore is not a text node', () => {
+        const $position = {nodeBefore: {isText: false, text: undefined}, pos: 4} as never;
+
+        expect(findFunctionSuggestionMatch({$position})).toBeNull();
+    });
+
+    it('returns null when the word is the tail of a $ datapill token', () => {
+        const $position = {nodeBefore: {isText: true, text: '$conc'}, pos: 7} as never;
+
+        expect(findFunctionSuggestionMatch({$position})).toBeNull();
+    });
+});
+
+describe('isFormulaModeActive', () => {
+    it('is true only when FormulaMode storage flag is set', () => {
+        expect(isFormulaModeActive({storage: {FormulaMode: {isFormulaMode: true}}} as never)).toBe(true);
+        expect(isFormulaModeActive({storage: {FormulaMode: {isFormulaMode: false}}} as never)).toBe(false);
+        expect(isFormulaModeActive({storage: {}} as never)).toBe(false);
+    });
+});
+
+describe('findEnclosingFunctionCall', () => {
+    it('returns the call and arg 0 right after the open paren when a closing paren follows', () => {
+        expect(findEnclosingFunctionCall('contains(', ')')).toEqual({argIndex: 0, name: 'contains'});
+    });
+
+    it('advances the arg index past commas', () => {
+        expect(findEnclosingFunctionCall('contains(a, ', ')')).toEqual({argIndex: 1, name: 'contains'});
+        expect(findEnclosingFunctionCall('contains(a, b', ')')).toEqual({argIndex: 1, name: 'contains'});
+    });
+
+    it('returns the innermost named call', () => {
+        expect(findEnclosingFunctionCall('concat(a, substring(x, ', '))')).toEqual({argIndex: 1, name: 'substring'});
+    });
+
+    it('attributes commas inside a grouping paren to the grouping, not the outer call', () => {
+        expect(findEnclosingFunctionCall('concat(a, (b, c), ', ')')).toEqual({argIndex: 2, name: 'concat'});
+    });
+
+    it('ignores commas inside quotes', () => {
+        expect(findEnclosingFunctionCall('contains("a, b", ', ')')).toEqual({argIndex: 1, name: 'contains'});
+    });
+
+    it('returns null when there is no open call', () => {
+        expect(findEnclosingFunctionCall('contains(a)', '')).toBeNull();
+        expect(findEnclosingFunctionCall('abc', '')).toBeNull();
+    });
+
+    it('returns null when the caret sits past the last closing paren (outside all calls)', () => {
+        expect(findEnclosingFunctionCall('contains(contains(x, true))', '')).toBeNull();
+    });
+
+    it('returns null when the enclosing call is never closed after the caret (unbalanced)', () => {
+        // contains(contains(x, true)| — outer paren is never closed, caret is right after the inner ).
+        expect(findEnclosingFunctionCall('contains(contains(x, true)', '')).toBeNull();
+    });
+
+    it('shows the outer call when the caret is inside it but before its closing paren', () => {
+        // contains(contains(x, true)|) — caret is inside the outer call; its ) still follows the caret.
+        expect(findEnclosingFunctionCall('contains(contains(x, true)', ')')).toEqual({argIndex: 0, name: 'contains'});
+    });
+
+    it('shows the inner call when the caret is inside it', () => {
+        expect(findEnclosingFunctionCall('contains(contains(x', ', true))')).toEqual({argIndex: 0, name: 'contains'});
+    });
+});
+
+describe('formatFunctionSignatureParts', () => {
+    it('splits params and return type', () => {
+        const result = formatFunctionSignatureParts({
+            category: 'STRING',
+            description: '',
+            example: '',
+            name: 'substring',
+            parameters: [
+                {description: '', name: 'value', required: true, type: 'STRING'},
+                {description: '', name: 'beginIndex', required: true, type: 'INTEGER'},
+            ],
+            returnType: 'STRING',
+            title: '',
+        } as never);
+
+        expect(result.params).toEqual(['value: String', 'beginIndex: Integer']);
+        expect(result.returnType).toBe('String');
+    });
+});

--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/functionSuggestionUtils.test.ts
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/functionSuggestionUtils.test.ts
@@ -170,6 +170,14 @@ describe('findEnclosingFunctionCall', () => {
     it('shows the inner call when the caret is inside it', () => {
         expect(findEnclosingFunctionCall('contains(contains(x', ', true))')).toEqual({argIndex: 0, name: 'contains'});
     });
+
+    it('ignores parens opened and closed again after the caret', () => {
+        expect(findEnclosingFunctionCall('contains(', '(a))')).toEqual({argIndex: 0, name: 'contains'});
+    });
+
+    it('skips an unnamed grouping paren and reports the call enclosing it', () => {
+        expect(findEnclosingFunctionCall('contains((', '))')).toEqual({argIndex: 0, name: 'contains'});
+    });
 });
 
 describe('formatFunctionSignatureParts', () => {

--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/functionSuggestionUtils.ts
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/functionSuggestionUtils.ts
@@ -3,7 +3,8 @@ import {Editor} from '@tiptap/react';
 
 const MAX_RESULTS = 50;
 const MINIMUM_QUERY_LENGTH = 2;
-const TRAILING_WORD = /[A-Za-z][A-Za-z0-9]*$/;
+const ALPHABETIC_CHARACTER = /[A-Za-z]/;
+const ALPHANUMERIC_CHARACTER = /[A-Za-z0-9]/;
 
 // SCREAMING_SNAKE enum value (e.g. "STRING", "INTEGER") -> readable label (e.g. "String", "Integer").
 function formatFunctionType(type: EvaluatorFunctionType): string {
@@ -43,6 +44,24 @@ interface SuggestionMatchResultI {
     text: string;
 }
 
+// The trailing run of letters and digits at the end of `text`, starting at its first letter — the
+// word the caret is typing. Scanned backwards by hand rather than with an end-anchored regex: an
+// unanchored-at-the-start pattern like /[A-Za-z][A-Za-z0-9]*$/ retries from every position and
+// degrades super-linearly on long text that ends in a non-word character.
+function findTrailingWord(text: string): string {
+    let start = text.length;
+
+    while (start > 0 && ALPHANUMERIC_CHARACTER.test(text[start - 1])) {
+        start -= 1;
+    }
+
+    while (start < text.length && !ALPHABETIC_CHARACTER.test(text[start])) {
+        start += 1;
+    }
+
+    return text.slice(start);
+}
+
 // Custom findSuggestionMatch: trigger on the trailing word before the caret (no explicit trigger char).
 // nodeBefore is the contiguous text node ending at the caret, so its trailing-word length maps 1:1 to
 // document positions even when a datapill node precedes it on the same line.
@@ -57,13 +76,11 @@ export function findFunctionSuggestionMatch({
         return null;
     }
 
-    const match = nodeBefore.text.match(TRAILING_WORD);
+    const word = findTrailingWord(nodeBefore.text);
 
-    if (!match || match[0].length < MINIMUM_QUERY_LENGTH) {
+    if (word.length < MINIMUM_QUERY_LENGTH) {
         return null;
     }
-
-    const word = match[0];
 
     // Don't compete with the `$` datapill suggestion: if the matched word is the tail of a `$`-prefixed
     // token (e.g. "$conc"), let the datapill source own it so both popups don't open at once.
@@ -102,7 +119,29 @@ export interface EnclosingFunctionCallI {
     name: string;
 }
 
-const IDENTIFIER_CHARACTER = /[A-Za-z0-9_]/;
+const IDENTIFIER_CHARACTER = /\w/;
+
+// Blanks out string literals — the quotes and everything between them — so the scanners below can look
+// for structural characters without each re-implementing quote tracking. Length is preserved, and a
+// blank is not an identifier character, so a literal still terminates the word that precedes it.
+function maskQuotedSegments(text: string): string {
+    let masked = '';
+    let quote: string | null = null;
+
+    for (const character of text) {
+        if (quote) {
+            masked += ' ';
+            quote = character === quote ? null : quote;
+        } else if (character === '"' || character === "'") {
+            masked += ' ';
+            quote = character;
+        } else {
+            masked += character;
+        }
+    }
+
+    return masked;
+}
 
 // Counts closing parens in `text` that are not matched by an opening paren within `text` — i.e. the
 // parens that close scopes opened before this text. Used to tell whether the caret is still enclosed
@@ -110,20 +149,9 @@ const IDENTIFIER_CHARACTER = /[A-Za-z0-9_]/;
 function countUnmatchedClosingParens(text: string): number {
     let depth = 0;
     let unmatched = 0;
-    let quote: string | null = null;
 
-    for (const character of text) {
-        if (quote) {
-            if (character === quote) {
-                quote = null;
-            }
-
-            continue;
-        }
-
-        if (character === '"' || character === "'") {
-            quote = character;
-        } else if (character === '(') {
+    for (const character of maskQuotedSegments(text)) {
+        if (character === '(') {
             depth += 1;
         } else if (character === ')') {
             if (depth === 0) {
@@ -137,58 +165,59 @@ function countUnmatchedClosingParens(text: string): number {
     return unmatched;
 }
 
-export function findEnclosingFunctionCall(textBeforeCaret: string, textAfterCaret = ''): EnclosingFunctionCallI | null {
+// The calls still open at the end of `text`, outermost first — each with the argument index the text
+// ends in. An unnamed entry is a plain grouping paren rather than a call.
+function collectOpenFunctionCalls(text: string): EnclosingFunctionCallI[] {
     const stack: EnclosingFunctionCallI[] = [];
 
     let word = '';
-    let quote: string | null = null;
 
-    for (const character of textBeforeCaret) {
-        if (quote) {
-            if (character === quote) {
-                quote = null;
-            }
+    for (const character of maskQuotedSegments(text)) {
+        if (IDENTIFIER_CHARACTER.test(character)) {
+            word += character;
 
             continue;
         }
 
-        if (character === '"' || character === "'") {
-            quote = character;
-            word = '';
-        } else if (IDENTIFIER_CHARACTER.test(character)) {
-            word += character;
-        } else if (character === '(') {
+        if (character === '(') {
             stack.push({argIndex: 0, name: word});
-            word = '';
         } else if (character === ')') {
             stack.pop();
-            word = '';
         } else if (character === ',') {
-            if (stack.length > 0) {
-                stack[stack.length - 1].argIndex += 1;
-            }
+            const innermostCall = stack.at(-1);
 
-            word = '';
-        } else {
-            word = '';
+            if (innermostCall) {
+                innermostCall.argIndex += 1;
+            }
         }
+
+        word = '';
     }
 
+    return stack;
+}
+
+export function findEnclosingFunctionCall(textBeforeCaret: string, textAfterCaret = ''): EnclosingFunctionCallI | null {
+    const stack = collectOpenFunctionCalls(textBeforeCaret);
     const unmatchedClosesAfterCaret = countUnmatchedClosingParens(textAfterCaret);
 
     for (let index = stack.length - 1; index >= 0; index--) {
-        if (stack[index].name) {
-            // The enclosing call only counts when its own ")" sits at or after the caret — there must
-            // be enough unmatched ")" following the caret to pop the stack back down to this call.
-            // Otherwise the caret has moved past the call's end (or it was never closed), so the
-            // signature tooltip stays hidden. Outer calls need even more closes, so once the innermost
-            // named call fails this check none can pass.
-            if (unmatchedClosesAfterCaret < stack.length - index) {
-                return null;
-            }
+        const call = stack[index];
 
-            return {argIndex: stack[index].argIndex, name: stack[index].name};
+        if (!call.name) {
+            continue;
         }
+
+        // The enclosing call only counts when its own ")" sits at or after the caret — there must
+        // be enough unmatched ")" following the caret to pop the stack back down to this call.
+        // Otherwise the caret has moved past the call's end (or it was never closed), so the
+        // signature tooltip stays hidden. Outer calls need even more closes, so once the innermost
+        // named call fails this check none can pass.
+        if (unmatchedClosesAfterCaret < stack.length - index) {
+            return null;
+        }
+
+        return {argIndex: call.argIndex, name: call.name};
     }
 
     return null;

--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/functionSuggestionUtils.ts
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/functionSuggestionUtils.ts
@@ -1,0 +1,207 @@
+import {EvaluatorFunctionDefinition, EvaluatorFunctionType} from '@/shared/middleware/graphql';
+import {Editor} from '@tiptap/react';
+
+const MAX_RESULTS = 50;
+const MINIMUM_QUERY_LENGTH = 2;
+const TRAILING_WORD = /[A-Za-z][A-Za-z0-9]*$/;
+
+// SCREAMING_SNAKE enum value (e.g. "STRING", "INTEGER") -> readable label (e.g. "String", "Integer").
+function formatFunctionType(type: EvaluatorFunctionType): string {
+    return type.charAt(0) + type.slice(1).toLowerCase();
+}
+
+export function formatFunctionSignature(definition: EvaluatorFunctionDefinition): string {
+    const parameters = definition.parameters
+        .map((parameter) => `${parameter.name}: ${formatFunctionType(parameter.type)}`)
+        .join(', ');
+
+    return `(${parameters}): ${formatFunctionType(definition.returnType)}`;
+}
+
+export function filterFunctionDefinitions(
+    definitions: EvaluatorFunctionDefinition[],
+    query: string
+): EvaluatorFunctionDefinition[] {
+    const lowercaseQuery = query.toLowerCase();
+
+    return definitions
+        .filter(
+            (definition) =>
+                definition.name.toLowerCase().startsWith(lowercaseQuery) ||
+                definition.title.toLowerCase().includes(lowercaseQuery)
+        )
+        .slice(0, MAX_RESULTS);
+}
+
+export function buildFunctionInsertion(name: string): {caretOffset: number; content: string} {
+    return {caretOffset: name.length + 1, content: `${name}()`};
+}
+
+interface SuggestionMatchResultI {
+    query: string;
+    range: {from: number; to: number};
+    text: string;
+}
+
+// Custom findSuggestionMatch: trigger on the trailing word before the caret (no explicit trigger char).
+// nodeBefore is the contiguous text node ending at the caret, so its trailing-word length maps 1:1 to
+// document positions even when a datapill node precedes it on the same line.
+export function findFunctionSuggestionMatch({
+    $position,
+}: {
+    $position: {nodeBefore: {isText: boolean; text?: string | null} | null; pos: number};
+}): SuggestionMatchResultI | null {
+    const nodeBefore = $position.nodeBefore;
+
+    if (!nodeBefore || !nodeBefore.isText || !nodeBefore.text) {
+        return null;
+    }
+
+    const match = nodeBefore.text.match(TRAILING_WORD);
+
+    if (!match || match[0].length < MINIMUM_QUERY_LENGTH) {
+        return null;
+    }
+
+    const word = match[0];
+
+    // Don't compete with the `$` datapill suggestion: if the matched word is the tail of a `$`-prefixed
+    // token (e.g. "$conc"), let the datapill source own it so both popups don't open at once.
+    if (nodeBefore.text[nodeBefore.text.length - word.length - 1] === '$') {
+        return null;
+    }
+
+    const to = $position.pos;
+    const from = to - word.length;
+
+    return {query: word, range: {from, to}, text: word};
+}
+
+export function isFormulaModeActive(
+    editor: Pick<Editor, 'storage'> & Partial<Pick<Editor, 'extensionManager'>>
+): boolean {
+    // Prefer the FormulaMode extension's live getter over the storage flag. The storage flag is seeded
+    // once at editor creation and synced via a React effect, so it lags the actual formula-mode state
+    // after a page reload (the saved "=" value loads asynchronously). The getter reads the ref that
+    // also drives the f(x) icon, so it always reflects the current state — without it the function
+    // suggestion never activates on a reloaded expression until formula mode is toggled off and on.
+    const formulaModeExtension = editor.extensionManager?.extensions?.find(
+        (extension) => extension.name === 'FormulaMode'
+    );
+    const getIsFormulaMode = formulaModeExtension?.options?.getIsFormulaMode as (() => boolean) | undefined;
+
+    if (typeof getIsFormulaMode === 'function') {
+        return getIsFormulaMode() === true;
+    }
+
+    return editor.storage?.FormulaMode?.isFormulaMode === true;
+}
+
+export interface EnclosingFunctionCallI {
+    argIndex: number;
+    name: string;
+}
+
+const IDENTIFIER_CHARACTER = /[A-Za-z0-9_]/;
+
+// Counts closing parens in `text` that are not matched by an opening paren within `text` — i.e. the
+// parens that close scopes opened before this text. Used to tell whether the caret is still enclosed
+// by a call whose ")" comes later, or has already moved past it.
+function countUnmatchedClosingParens(text: string): number {
+    let depth = 0;
+    let unmatched = 0;
+    let quote: string | null = null;
+
+    for (const character of text) {
+        if (quote) {
+            if (character === quote) {
+                quote = null;
+            }
+
+            continue;
+        }
+
+        if (character === '"' || character === "'") {
+            quote = character;
+        } else if (character === '(') {
+            depth += 1;
+        } else if (character === ')') {
+            if (depth === 0) {
+                unmatched += 1;
+            } else {
+                depth -= 1;
+            }
+        }
+    }
+
+    return unmatched;
+}
+
+export function findEnclosingFunctionCall(textBeforeCaret: string, textAfterCaret = ''): EnclosingFunctionCallI | null {
+    const stack: EnclosingFunctionCallI[] = [];
+
+    let word = '';
+    let quote: string | null = null;
+
+    for (const character of textBeforeCaret) {
+        if (quote) {
+            if (character === quote) {
+                quote = null;
+            }
+
+            continue;
+        }
+
+        if (character === '"' || character === "'") {
+            quote = character;
+            word = '';
+        } else if (IDENTIFIER_CHARACTER.test(character)) {
+            word += character;
+        } else if (character === '(') {
+            stack.push({argIndex: 0, name: word});
+            word = '';
+        } else if (character === ')') {
+            stack.pop();
+            word = '';
+        } else if (character === ',') {
+            if (stack.length > 0) {
+                stack[stack.length - 1].argIndex += 1;
+            }
+
+            word = '';
+        } else {
+            word = '';
+        }
+    }
+
+    const unmatchedClosesAfterCaret = countUnmatchedClosingParens(textAfterCaret);
+
+    for (let index = stack.length - 1; index >= 0; index--) {
+        if (stack[index].name) {
+            // The enclosing call only counts when its own ")" sits at or after the caret — there must
+            // be enough unmatched ")" following the caret to pop the stack back down to this call.
+            // Otherwise the caret has moved past the call's end (or it was never closed), so the
+            // signature tooltip stays hidden. Outer calls need even more closes, so once the innermost
+            // named call fails this check none can pass.
+            if (unmatchedClosesAfterCaret < stack.length - index) {
+                return null;
+            }
+
+            return {argIndex: stack[index].argIndex, name: stack[index].name};
+        }
+    }
+
+    return null;
+}
+
+export interface FunctionSignaturePartsI {
+    params: string[];
+    returnType: string;
+}
+
+export function formatFunctionSignatureParts(definition: EvaluatorFunctionDefinition): FunctionSignaturePartsI {
+    return {
+        params: definition.parameters.map((parameter) => `${parameter.name}: ${formatFunctionType(parameter.type)}`),
+        returnType: formatFunctionType(definition.returnType),
+    };
+}

--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/mentionsInputPlaceholder.ts
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/mentionsInputPlaceholder.ts
@@ -1,26 +1,34 @@
 export const TOOL_PROPERTY_PLACEHOLDER = 'Click the AI button or write =fromAi(...)';
 
+export const FORMULA_MODE_PLACEHOLDER = "e.g. concat(firstName, ' ', lastName)";
+
+export const TOOL_PROPERTY_FORMULA_MODE_PLACEHOLDER = "e.g. fromAi('name', 'STRING')";
+
 const DEFAULT_PLACEHOLDER = "Use '$' for data pills and '=' for an expression";
 
-// Mirrors the Placeholder.configure logic in PropertyMentionsInputEditor. An explicit placeholder
-// always wins. With expressions disabled there is no expression hint. Tool properties are effectively
-// always expression fields (AI button or a hand-written =fromAi(...)), so the data-pill hint is
-// replaced with a tools-specific message.
-export function getMentionsInputPlaceholder({
-    expressionEnabled,
-    placeholder,
-    toolProperty,
-}: {
+interface MentionsInputPlaceholderProps {
     expressionEnabled: boolean | undefined;
+    formulaMode?: boolean;
     placeholder?: string;
     toolProperty?: boolean;
-}): string {
+}
+
+export function getMentionsInputPlaceholder({
+    expressionEnabled,
+    formulaMode,
+    placeholder,
+    toolProperty,
+}: MentionsInputPlaceholderProps): string {
     if (placeholder) {
         return placeholder;
     }
 
     if (expressionEnabled === false) {
         return '';
+    }
+
+    if (formulaMode) {
+        return toolProperty ? TOOL_PROPERTY_FORMULA_MODE_PLACEHOLDER : FORMULA_MODE_PLACEHOLDER;
     }
 
     if (toolProperty) {

--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/mentionsInputPlaceholder.ts
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/mentionsInputPlaceholder.ts
@@ -1,0 +1,31 @@
+export const TOOL_PROPERTY_PLACEHOLDER = 'Click the AI button or write =fromAi(...)';
+
+const DEFAULT_PLACEHOLDER = "Use '$' for data pills and '=' for an expression";
+
+// Mirrors the Placeholder.configure logic in PropertyMentionsInputEditor. An explicit placeholder
+// always wins. With expressions disabled there is no expression hint. Tool properties are effectively
+// always expression fields (AI button or a hand-written =fromAi(...)), so the data-pill hint is
+// replaced with a tools-specific message.
+export function getMentionsInputPlaceholder({
+    expressionEnabled,
+    placeholder,
+    toolProperty,
+}: {
+    expressionEnabled: boolean | undefined;
+    placeholder?: string;
+    toolProperty?: boolean;
+}): string {
+    if (placeholder) {
+        return placeholder;
+    }
+
+    if (expressionEnabled === false) {
+        return '';
+    }
+
+    if (toolProperty) {
+        return TOOL_PROPERTY_PLACEHOLDER;
+    }
+
+    return DEFAULT_PLACEHOLDER;
+}

--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/propertyMentionDom.test.ts
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/propertyMentionDom.test.ts
@@ -1,5 +1,32 @@
-import {replaceMentionNodesInHtmlWithVariables} from '@/pages/platform/workflow-editor/components/properties/components/property-mentions-input/propertyMentionDom';
+import {
+    buildPropertyMentionsContent,
+    replaceMentionNodesInHtmlWithVariables,
+} from '@/pages/platform/workflow-editor/components/properties/components/property-mentions-input/propertyMentionDom';
 import {describe, expect, it} from 'vitest';
+
+describe('buildPropertyMentionsContent', () => {
+    it('converts each ${id} pill into a mention span', () => {
+        expect(buildPropertyMentionsContent('Hi ${trigger_1.firstName}', 'TEXT')).toBe(
+            'Hi <span data-type="mention" class="property-mention" data-id="trigger_1.firstName"></span>'
+        );
+    });
+
+    it('converts multiple occurrences of the same pill', () => {
+        expect(buildPropertyMentionsContent('${a.b} and ${a.b}', 'TEXT')).toBe(
+            '<span data-type="mention" class="property-mention" data-id="a.b"></span> and ' +
+                '<span data-type="mention" class="property-mention" data-id="a.b"></span>'
+        );
+    });
+
+    it('returns plain constant text unchanged', () => {
+        expect(buildPropertyMentionsContent('a constant value', 'TEXT')).toBe('a constant value');
+    });
+
+    it('returns empty string for empty input and undefined for non-string input', () => {
+        expect(buildPropertyMentionsContent('', 'TEXT')).toBe('');
+        expect(buildPropertyMentionsContent(undefined, 'TEXT')).toBeUndefined();
+    });
+});
 
 describe('replaceMentionNodesInHtmlWithVariables', () => {
     it('replaces a flat mention span with ${id}', () => {

--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/propertyMentionDom.ts
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/propertyMentionDom.ts
@@ -1,3 +1,7 @@
+import {escapeHtmlForParagraph} from '@/pages/platform/workflow-editor/utils/encodingUtils';
+import {decode} from 'html-entities';
+import sanitizeHtml from 'sanitize-html';
+
 /**
  * DOM structure for TipTap property mentions (see Mention.configure renderHTML in PropertyMentionsInputEditor).
  * Root keeps data-type / data-id for parse and serialization; chip carries pill visuals so unavailable styling
@@ -8,6 +12,63 @@ export const PROPERTY_MENTION_CHIP_CLASS = 'property-mention-chip';
 export const PROPERTY_MENTION_LABEL_CLASS = 'property-mention-label';
 
 export const PROPERTY_MENTION_ROOT_CLASS = 'property-mention';
+
+/**
+ * Converts a stored property value into editor HTML: newlines become paragraphs (RICH_TEXT html is decoded
+ * and sanitized instead) and each ${nodeName.path} data pill becomes a span[data-type="mention"][data-id] so
+ * TipTap's Mention extension renders it as a visual chip. This is the forward direction of
+ * replaceMentionNodesInHtmlWithVariables and is shared by the editor's content sync and the copilot apply path
+ * so applied pills render immediately instead of only after a refresh.
+ */
+export function buildPropertyMentionsContent(value?: string, controlType?: string): string | undefined {
+    if (typeof value !== 'string') {
+        return;
+    }
+
+    if (!value) {
+        return '';
+    }
+
+    let content = value;
+    let contentIsDecodedHtml = false;
+
+    if (
+        controlType === 'RICH_TEXT' &&
+        (content.includes('&lt;') || content.includes('&gt;') || content.includes('&amp;'))
+    ) {
+        content = decode(content);
+
+        content = sanitizeHtml(content);
+
+        contentIsDecodedHtml = true;
+    }
+
+    if (!contentIsDecodedHtml && content.includes('\n')) {
+        const valueLines = content.split('\n');
+
+        const paragraphedLines =
+            controlType === 'TEXT_AREA' || controlType === 'TEXT' || controlType === 'FORMULA_MODE'
+                ? valueLines.map((valueLine) => `<p>${escapeHtmlForParagraph(valueLine)}</p>`)
+                : valueLines.map((valueLine) => `<p>${valueLine}</p>`);
+
+        content = paragraphedLines.join('');
+    }
+
+    const dataPillRegex = /\${([^}]+)}/g;
+
+    const matches = value.match(dataPillRegex)?.map((match) => match.slice(2, -1));
+
+    if (matches) {
+        for (const match of matches) {
+            content = content.replace(
+                `\${${match}}`,
+                `<span data-type="mention" class="${PROPERTY_MENTION_ROOT_CLASS}" data-id="${match}"></span>`
+            );
+        }
+    }
+
+    return content;
+}
 
 /**
  * Replaces each span[data-type="mention"][data-id] subtree with ${id} for persistence.

--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/propertyMentionsInputEditorSuggestionOptions.ts
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/propertyMentionsInputEditorSuggestionOptions.ts
@@ -1,35 +1,9 @@
-import PropertyMentionsInputEditorSuggestionList, {
-    PropertyMentionsInputListRefType,
-} from '@/pages/platform/workflow-editor/components/properties/components/property-mentions-input/PropertyMentionsInputEditorSuggestionList';
+import PropertyMentionsInputEditorSuggestionList from '@/pages/platform/workflow-editor/components/properties/components/property-mentions-input/PropertyMentionsInputEditorSuggestionList';
 import {DataPillType} from '@/shared/types';
 import {MentionOptions} from '@tiptap/extension-mention';
-import {Editor, ReactRenderer} from '@tiptap/react';
-import tippy, {type Instance as TippyInstance} from 'tippy.js';
+import {Editor} from '@tiptap/react';
 
-import {setMentionSuggestionOpen} from './MentionStorage.extension';
-
-/**
- * Workaround for the current typing incompatibility between Tippy.js and Tiptap
- * Suggestion utility.
- *
- * @see https://github.com/ueberdosis/tiptap/issues/2795#issuecomment-1160623792
- *
- * Adopted from
- * https://github.com/Doist/typist/blob/a1726a6be089e3e1452def641dfcfc622ac3e942/stories/typist-editor/constants/suggestions.ts#L169-L186
- */
-const DOM_RECT_FALLBACK: DOMRect = {
-    bottom: 0,
-    height: 0,
-    left: 0,
-    right: 0,
-    toJSON() {
-        return {};
-    },
-    top: 0,
-    width: 0,
-    x: 0,
-    y: 0,
-};
+import {createSuggestionPopupRenderer} from './suggestionPopupRenderer';
 
 export function getSuggestionOptions(): MentionOptions['suggestion'] {
     return {
@@ -66,106 +40,6 @@ export function getSuggestionOptions(): MentionOptions['suggestion'] {
 
             return dataPills.filter((dataPill) => dataPill.value.toLowerCase().startsWith(query.toLowerCase()));
         },
-        render: () => {
-            let component: ReactRenderer<PropertyMentionsInputListRefType> | undefined;
-            let popup: TippyInstance | undefined;
-            let lastValidRect: DOMRect = DOM_RECT_FALLBACK;
-            let wheelAbortController: AbortController | undefined;
-            // Held so `onExit` can clear the open flag. It has no props of its own, and it also runs
-            // for a suggestion `onStart` declined to show, where there is nothing to clear.
-            let openedEditor: Editor | undefined;
-
-            return {
-                onExit() {
-                    if (openedEditor) {
-                        setMentionSuggestionOpen(openedEditor, false);
-
-                        openedEditor = undefined;
-                    }
-
-                    wheelAbortController?.abort();
-                    popup?.destroy();
-                    component?.destroy();
-                },
-
-                onKeyDown(props) {
-                    if (props.event.key === 'Escape') {
-                        popup?.hide();
-
-                        return true;
-                    }
-
-                    if (!component?.ref) {
-                        return false;
-                    }
-
-                    return component?.ref.onKeyDown(props);
-                },
-
-                onStart: (props) => {
-                    if (!props.editor.isFocused) {
-                        return;
-                    }
-
-                    component = new ReactRenderer(PropertyMentionsInputEditorSuggestionList, {
-                        editor: props.editor,
-                        props,
-                    });
-
-                    const initialRect = props.clientRect?.();
-
-                    if (!initialRect) {
-                        component.destroy();
-                        component = undefined;
-
-                        return;
-                    }
-
-                    lastValidRect = initialRect;
-
-                    popup = tippy('body', {
-                        appendTo: () => document.body,
-                        content: component.element,
-                        getReferenceClientRect: () => lastValidRect,
-                        interactive: true,
-                        placement: 'bottom-start',
-                        showOnCreate: true,
-                        trigger: 'manual',
-                    })[0];
-
-                    // Inside a Radix modal dialog, react-remove-scroll blocks wheel events outside the
-                    // dialog content. Intercept them on the popup before they reach the document
-                    // listener that would preventDefault on them. Pointer events are re-enabled by the
-                    // menu's own stylesheet, since tippy resets the popper's inline value on setProps.
-                    wheelAbortController = new AbortController();
-
-                    popup.popper.addEventListener('wheel', (event) => event.stopPropagation(), {
-                        capture: true,
-                        passive: true,
-                        signal: wheelAbortController.signal,
-                    });
-
-                    openedEditor = props.editor;
-
-                    setMentionSuggestionOpen(props.editor, true);
-                },
-
-                onUpdate(props) {
-                    component?.updateProps(props);
-
-                    const updatedRect = props.clientRect?.();
-
-                    if (!updatedRect) {
-                        return;
-                    }
-
-                    lastValidRect = updatedRect;
-
-                    popup?.setProps({
-                        getReferenceClientRect: () => lastValidRect,
-                    });
-                },
-            };
-        },
+        render: createSuggestionPopupRenderer<DataPillType>(PropertyMentionsInputEditorSuggestionList),
     };
 }

--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/propertyMentionsInputEditorSuggestionOptions.ts
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/propertyMentionsInputEditorSuggestionOptions.ts
@@ -122,8 +122,10 @@ export function getSuggestionOptions(): MentionOptions['suggestion'] {
                         trigger: 'manual',
                     })[0];
 
-                    popup.popper.style.pointerEvents = 'auto';
-
+                    // Inside a Radix modal dialog, react-remove-scroll blocks wheel events outside the
+                    // dialog content. Intercept them on the popup before they reach the document
+                    // listener that would preventDefault on them. Pointer events are re-enabled by the
+                    // menu's own stylesheet, since tippy resets the popper's inline value on setProps.
                     wheelAbortController = new AbortController();
 
                     popup.popper.addEventListener('wheel', (event) => event.stopPropagation(), {

--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/propertyMentionsInputEditorSuggestionOptions.ts
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/propertyMentionsInputEditorSuggestionOptions.ts
@@ -6,6 +6,8 @@ import {MentionOptions} from '@tiptap/extension-mention';
 import {Editor, ReactRenderer} from '@tiptap/react';
 import tippy, {type Instance as TippyInstance} from 'tippy.js';
 
+import {setMentionSuggestionOpen} from './MentionStorage.extension';
+
 /**
  * Workaround for the current typing incompatibility between Tippy.js and Tiptap
  * Suggestion utility.
@@ -69,9 +71,18 @@ export function getSuggestionOptions(): MentionOptions['suggestion'] {
             let popup: TippyInstance | undefined;
             let lastValidRect: DOMRect = DOM_RECT_FALLBACK;
             let wheelAbortController: AbortController | undefined;
+            // Held so `onExit` can clear the open flag. It has no props of its own, and it also runs
+            // for a suggestion `onStart` declined to show, where there is nothing to clear.
+            let openedEditor: Editor | undefined;
 
             return {
                 onExit() {
+                    if (openedEditor) {
+                        setMentionSuggestionOpen(openedEditor, false);
+
+                        openedEditor = undefined;
+                    }
+
                     wheelAbortController?.abort();
                     popup?.destroy();
                     component?.destroy();
@@ -133,6 +144,10 @@ export function getSuggestionOptions(): MentionOptions['suggestion'] {
                         passive: true,
                         signal: wheelAbortController.signal,
                     });
+
+                    openedEditor = props.editor;
+
+                    setMentionSuggestionOpen(props.editor, true);
                 },
 
                 onUpdate(props) {

--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/suggestionPopupRenderer.ts
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/suggestionPopupRenderer.ts
@@ -1,0 +1,148 @@
+import {Editor, ReactRenderer} from '@tiptap/react';
+import {SuggestionKeyDownProps, SuggestionOptions, SuggestionProps} from '@tiptap/suggestion';
+import {ForwardRefExoticComponent, PropsWithoutRef, RefAttributes} from 'react';
+import tippy, {type Instance as TippyInstance} from 'tippy.js';
+
+import {setMentionSuggestionOpen} from './MentionStorage.extension';
+
+export type SuggestionListRefType = {
+    onKeyDown: (props: SuggestionKeyDownProps) => boolean;
+};
+
+type SuggestionListComponentType<ItemType> = ForwardRefExoticComponent<
+    PropsWithoutRef<SuggestionProps<ItemType>> & RefAttributes<SuggestionListRefType>
+>;
+
+/**
+ * Workaround for the current typing incompatibility between Tippy.js and Tiptap
+ * Suggestion utility.
+ *
+ * @see https://github.com/ueberdosis/tiptap/issues/2795#issuecomment-1160623792
+ *
+ * Adopted from
+ * https://github.com/Doist/typist/blob/a1726a6be089e3e1452def641dfcfc622ac3e942/stories/typist-editor/constants/suggestions.ts#L169-L186
+ */
+const DOM_RECT_FALLBACK: DOMRect = {
+    bottom: 0,
+    height: 0,
+    left: 0,
+    right: 0,
+    toJSON() {
+        return {};
+    },
+    top: 0,
+    width: 0,
+    x: 0,
+    y: 0,
+};
+
+/**
+ * The tippy popup lifecycle shared by the editor's suggestion sources — `$` datapills and, in formula
+ * mode, evaluator functions. Both anchor a keyboard-navigable list at the caret in a manually
+ * triggered tippy, so only the list component differs.
+ */
+export function createSuggestionPopupRenderer<ItemType>(
+    listComponent: SuggestionListComponentType<ItemType>
+): NonNullable<SuggestionOptions<ItemType>['render']> {
+    return () => {
+        let component: ReactRenderer<SuggestionListRefType> | undefined;
+        let popup: TippyInstance | undefined;
+        let lastValidRect: DOMRect = DOM_RECT_FALLBACK;
+        let wheelAbortController: AbortController | undefined;
+        // Held so `onExit` can clear the open flag. It has no props of its own, and it also runs
+        // for a suggestion `onStart` declined to show, where there is nothing to clear.
+        let openedEditor: Editor | undefined;
+
+        return {
+            onExit() {
+                if (openedEditor) {
+                    setMentionSuggestionOpen(openedEditor, false);
+
+                    openedEditor = undefined;
+                }
+
+                wheelAbortController?.abort();
+                popup?.destroy();
+                component?.destroy();
+            },
+
+            onKeyDown(props) {
+                if (props.event.key === 'Escape') {
+                    popup?.hide();
+
+                    return true;
+                }
+
+                if (!component?.ref) {
+                    return false;
+                }
+
+                return component.ref.onKeyDown(props);
+            },
+
+            onStart(props) {
+                if (!props.editor.isFocused) {
+                    return;
+                }
+
+                component = new ReactRenderer(listComponent, {
+                    editor: props.editor,
+                    props,
+                });
+
+                const initialRect = props.clientRect?.();
+
+                if (!initialRect) {
+                    component.destroy();
+                    component = undefined;
+
+                    return;
+                }
+
+                lastValidRect = initialRect;
+
+                popup = tippy('body', {
+                    appendTo: () => document.body,
+                    content: component.element,
+                    getReferenceClientRect: () => lastValidRect,
+                    interactive: true,
+                    placement: 'bottom-start',
+                    showOnCreate: true,
+                    trigger: 'manual',
+                })[0];
+
+                // Inside a Radix modal dialog, react-remove-scroll blocks wheel events outside the
+                // dialog content. Intercept them on the popup before they reach the document
+                // listener that would preventDefault on them. Pointer events are re-enabled by the
+                // menu's own stylesheet, since tippy resets the popper's inline value on setProps.
+                wheelAbortController = new AbortController();
+
+                popup.popper.addEventListener('wheel', (event) => event.stopPropagation(), {
+                    capture: true,
+                    passive: true,
+                    signal: wheelAbortController.signal,
+                });
+
+                openedEditor = props.editor;
+
+                setMentionSuggestionOpen(props.editor, true);
+            },
+
+            onUpdate(props) {
+                component?.updateProps(props);
+
+                const updatedRect = props.clientRect?.();
+
+                if (!updatedRect) {
+                    return;
+                }
+
+                lastValidRect = updatedRect;
+
+                popup?.setProps({
+                    getReferenceClientRect: () => lastValidRect,
+                });
+            },
+        };
+    };
+}

--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/tests/controlledExpressionValue.test.ts
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/tests/controlledExpressionValue.test.ts
@@ -1,0 +1,22 @@
+import {describe, expect, it} from 'vitest';
+
+import {reconstructControlledExpressionValue} from '../controlledExpressionValue';
+
+describe('reconstructControlledExpressionValue', () => {
+    it('prefixes = when missing', () => {
+        expect(reconstructControlledExpressionValue('concat(a, b)')).toBe('=concat(a, b)');
+    });
+
+    it('keeps an existing = prefix', () => {
+        expect(reconstructControlledExpressionValue('=concat(a, b)')).toBe('=concat(a, b)');
+    });
+
+    it('returns empty for blank content', () => {
+        expect(reconstructControlledExpressionValue('   ')).toBe('');
+        expect(reconstructControlledExpressionValue('')).toBe('');
+    });
+
+    it('coerces numbers to a prefixed string', () => {
+        expect(reconstructControlledExpressionValue(42)).toBe('=42');
+    });
+});

--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/tests/fromAiFunctionDefinition.test.ts
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/tests/fromAiFunctionDefinition.test.ts
@@ -1,0 +1,43 @@
+import {EvaluatorFunctionDefinition} from '@/shared/middleware/graphql';
+import {describe, expect, it} from 'vitest';
+
+import {FROM_AI_FUNCTION_DEFINITION, buildToolFunctionDefinitions} from '../fromAiFunctionDefinition';
+
+const baseDefinition = {
+    category: 'STRING',
+    description: 'Concatenates.',
+    example: '=concat(a, b)',
+    name: 'concat',
+    parameters: [],
+    returnType: 'STRING',
+    title: 'concat',
+} as unknown as EvaluatorFunctionDefinition;
+
+describe('buildToolFunctionDefinitions', () => {
+    it('returns the base catalog unchanged for non-tool properties', () => {
+        const result = buildToolFunctionDefinitions([baseDefinition], false);
+
+        expect(result).toEqual([baseDefinition]);
+        expect(result.some((definition) => definition.name === 'fromAi')).toBe(false);
+    });
+
+    it('prepends the fromAi definition for tool properties', () => {
+        const result = buildToolFunctionDefinitions([baseDefinition], true);
+
+        expect(result[0]).toBe(FROM_AI_FUNCTION_DEFINITION);
+        expect(result).toHaveLength(2);
+    });
+
+    it('does not duplicate fromAi when it is already present', () => {
+        const result = buildToolFunctionDefinitions([FROM_AI_FUNCTION_DEFINITION, baseDefinition], true);
+
+        expect(result.filter((definition) => definition.name === 'fromAi')).toHaveLength(1);
+    });
+});
+
+describe('FROM_AI_FUNCTION_DEFINITION', () => {
+    it('is named fromAi and returns a string', () => {
+        expect(FROM_AI_FUNCTION_DEFINITION.name).toBe('fromAi');
+        expect(FROM_AI_FUNCTION_DEFINITION.returnType).toBe('STRING');
+    });
+});

--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/tests/functionSignatureTooltipOrphan.test.tsx
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/tests/functionSignatureTooltipOrphan.test.tsx
@@ -1,0 +1,95 @@
+import Document from '@tiptap/extension-document';
+import {Paragraph} from '@tiptap/extension-paragraph';
+import {Text} from '@tiptap/extension-text';
+import {Editor} from '@tiptap/react';
+import {afterEach, describe, expect, it, vi} from 'vitest';
+
+import {FormulaMode} from '../FormulaMode.extension';
+import {FunctionSignature} from '../FunctionSignature.extension';
+import {FunctionSuggestion} from '../FunctionSuggestion.extension';
+
+// The real ReactRenderer renders through `flushSync`, which drains pending React effects. One of them
+// is tiptap's own useEditor effect calling `editor.setOptions`, which runs `view.setProps` ->
+// `updatePluginViews` -> the signature plugin's `update` — re-entering it while the outer call is
+// still constructing its renderer. This double reproduces that single re-entrant call.
+vi.mock('@tiptap/react', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('@tiptap/react')>();
+
+    let reentered = false;
+
+    class ReentrantReactRenderer extends actual.ReactRenderer {
+        constructor(...args: ConstructorParameters<typeof actual.ReactRenderer>) {
+            super(...args);
+
+            if (!reentered) {
+                reentered = true;
+
+                args[1].editor.setOptions({});
+            }
+        }
+    }
+
+    return {...actual, ReactRenderer: ReentrantReactRenderer};
+});
+
+const definitions = [
+    {
+        category: 'STRING',
+        description: 'Checks whether a string contains a substring',
+        example: '',
+        name: 'contains',
+        parameters: [
+            {description: 'The string to search in', name: 'string', required: true, type: 'STRING'},
+            {description: 'The substring', name: 'substring', required: true, type: 'STRING'},
+        ],
+        returnType: 'BOOLEAN',
+        title: 'contains',
+    },
+] as never;
+
+let editor: Editor | undefined;
+
+const tippyRoots = () => document.querySelectorAll('[data-tippy-root]');
+
+afterEach(() => {
+    editor?.destroy();
+
+    editor = undefined;
+
+    document.body.innerHTML = '';
+});
+
+describe('FunctionSignature tooltip lifecycle', () => {
+    it('does not orphan a popper when update re-enters while the tooltip is being created', () => {
+        const element = document.createElement('div');
+
+        document.body.appendChild(element);
+
+        editor = new Editor({
+            element,
+            extensions: [
+                Document,
+                Paragraph,
+                Text,
+                FormulaMode.configure({getIsFormulaMode: () => true, initialFormulaMode: true}),
+                FunctionSuggestion,
+                FunctionSignature,
+            ],
+        });
+
+        vi.spyOn(editor, 'isFocused', 'get').mockReturnValue(true);
+
+        editor.storage.FunctionSuggestion.functionDefinitions = definitions;
+
+        // Mirrors what the suggestion command inserts: "name()" with the caret between the parens.
+        editor.commands.insertContent('contains()');
+        editor.commands.setTextSelection(editor.state.selection.from - 1);
+
+        expect(tippyRoots().length, 'poppers while the caret sits inside contains()').toBe(1);
+
+        // Every popper must still be reachable through its instance, or nothing can ever hide it.
+        editor.commands.setTextSelection(editor.state.doc.content.size - 1);
+
+        expect(tippyRoots().length, 'poppers after the caret leaves the call').toBe(0);
+    });
+});

--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/tests/functionSuggestionWiring.test.tsx
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/tests/functionSuggestionWiring.test.tsx
@@ -60,4 +60,35 @@ describe('FunctionSuggestion wiring', () => {
         // FormulaMode extension is not registered here, so the flag is absent -> dormant.
         expect(options.allow!({editor, isActive: false, range: {from: 0, to: 0}} as never)).toBe(false);
     });
+
+    it('shouldShow() only activates the suggestion when a function matches the query', () => {
+        editor.storage.FunctionSuggestion.functionDefinitions = [
+            {
+                category: 'STRING',
+                description: '',
+                example: '',
+                name: 'concat',
+                parameters: [],
+                returnType: 'STRING',
+                title: 'concat',
+            },
+        ] as never;
+
+        const options = getFunctionSuggestionOptions();
+
+        expect(options.shouldShow!({editor, query: 'conc'} as never)).toBe(true);
+        expect(options.shouldShow!({editor, query: 'true'} as never)).toBe(false);
+    });
+
+    it('command() inserts the call and parks the caret between the parentheses', () => {
+        editor.commands.insertContent('con');
+
+        const options = getFunctionSuggestionOptions();
+
+        options.command!({editor, props: {name: 'concat'}, range: {from: 1, to: 4}} as never);
+
+        expect(editor.state.doc.textContent).toBe('concat()');
+        // from + 'concat'.length + 1 -> inside the parentheses.
+        expect(editor.state.selection.from).toBe(8);
+    });
 });

--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/tests/functionSuggestionWiring.test.tsx
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/tests/functionSuggestionWiring.test.tsx
@@ -1,0 +1,63 @@
+import Document from '@tiptap/extension-document';
+import {Paragraph} from '@tiptap/extension-paragraph';
+import {Text} from '@tiptap/extension-text';
+import {Editor} from '@tiptap/react';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+
+import {FunctionSuggestion} from '../FunctionSuggestion.extension';
+import {getFunctionSuggestionOptions} from '../functionSuggestionOptions';
+
+vi.mock('tippy.js', () => ({default: vi.fn(() => [{popper: {style: {}}}])}));
+
+describe('FunctionSuggestion wiring', () => {
+    let editor: Editor;
+
+    beforeEach(() => {
+        editor = new Editor({extensions: [Document, FunctionSuggestion, Paragraph, Text]});
+    });
+
+    it('exposes a FunctionSuggestion storage bucket initialised to an empty catalog', () => {
+        expect(editor.storage.FunctionSuggestion.functionDefinitions).toEqual([]);
+    });
+
+    it('accepts a catalog pushed into storage', () => {
+        editor.storage.FunctionSuggestion.functionDefinitions = [{name: 'concat'}] as never;
+
+        expect(editor.storage.FunctionSuggestion.functionDefinitions).toHaveLength(1);
+    });
+
+    it('items() reads the catalog from storage and filters by query', () => {
+        editor.storage.FunctionSuggestion.functionDefinitions = [
+            {
+                category: 'STRING',
+                description: '',
+                example: '',
+                name: 'concat',
+                parameters: [],
+                returnType: 'STRING',
+                title: 'concat',
+            },
+            {
+                category: 'STRING',
+                description: '',
+                example: '',
+                name: 'substring',
+                parameters: [],
+                returnType: 'STRING',
+                title: 'substring',
+            },
+        ] as never;
+
+        const options = getFunctionSuggestionOptions();
+        const items = options.items!({editor, query: 'conc'} as never) as Array<{name: string}>;
+
+        expect(items.map((item) => item.name)).toEqual(['concat']);
+    });
+
+    it('allow() is false when formula mode is not active', () => {
+        const options = getFunctionSuggestionOptions();
+
+        // FormulaMode extension is not registered here, so the flag is absent -> dormant.
+        expect(options.allow!({editor, isActive: false, range: {from: 0, to: 0}} as never)).toBe(false);
+    });
+});

--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/tests/mentionsInputPlaceholder.test.ts
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/tests/mentionsInputPlaceholder.test.ts
@@ -1,6 +1,11 @@
 import {describe, expect, it} from 'vitest';
 
-import {TOOL_PROPERTY_PLACEHOLDER, getMentionsInputPlaceholder} from '../mentionsInputPlaceholder';
+import {
+    FORMULA_MODE_PLACEHOLDER,
+    TOOL_PROPERTY_FORMULA_MODE_PLACEHOLDER,
+    TOOL_PROPERTY_PLACEHOLDER,
+    getMentionsInputPlaceholder,
+} from '../mentionsInputPlaceholder';
 
 describe('getMentionsInputPlaceholder', () => {
     it('uses the tool-property placeholder for tool properties', () => {
@@ -24,5 +29,35 @@ describe('getMentionsInputPlaceholder', () => {
     it('returns empty (or explicit) when expressions are disabled', () => {
         expect(getMentionsInputPlaceholder({expressionEnabled: false, toolProperty: true})).toBe('');
         expect(getMentionsInputPlaceholder({expressionEnabled: false, placeholder: 'X', toolProperty: true})).toBe('X');
+    });
+
+    it('hints at expression syntax in formula mode', () => {
+        expect(getMentionsInputPlaceholder({expressionEnabled: true, formulaMode: true, toolProperty: false})).toBe(
+            FORMULA_MODE_PLACEHOLDER
+        );
+    });
+
+    it('hints at fromAi for a tool property in formula mode', () => {
+        expect(getMentionsInputPlaceholder({expressionEnabled: true, formulaMode: true, toolProperty: true})).toBe(
+            TOOL_PROPERTY_FORMULA_MODE_PLACEHOLDER
+        );
+    });
+
+    // The editor strips the leading "=" from expression content, so a sample carrying one would not
+    // match what the user types over it.
+    it('omits the leading = from the formula mode samples', () => {
+        expect(FORMULA_MODE_PLACEHOLDER.startsWith('=')).toBe(false);
+        expect(TOOL_PROPERTY_FORMULA_MODE_PLACEHOLDER.startsWith('=')).toBe(false);
+    });
+
+    it('still prefers an explicit placeholder in formula mode', () => {
+        expect(
+            getMentionsInputPlaceholder({
+                expressionEnabled: true,
+                formulaMode: true,
+                placeholder: 'Custom',
+                toolProperty: true,
+            })
+        ).toBe('Custom');
     });
 });

--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/tests/mentionsInputPlaceholder.test.ts
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/tests/mentionsInputPlaceholder.test.ts
@@ -1,0 +1,28 @@
+import {describe, expect, it} from 'vitest';
+
+import {TOOL_PROPERTY_PLACEHOLDER, getMentionsInputPlaceholder} from '../mentionsInputPlaceholder';
+
+describe('getMentionsInputPlaceholder', () => {
+    it('uses the tool-property placeholder for tool properties', () => {
+        expect(getMentionsInputPlaceholder({expressionEnabled: true, toolProperty: true})).toBe(
+            TOOL_PROPERTY_PLACEHOLDER
+        );
+    });
+
+    it('uses the data-pill placeholder for non-tool properties', () => {
+        expect(getMentionsInputPlaceholder({expressionEnabled: true, toolProperty: false})).toBe(
+            "Use '$' for data pills and '=' for an expression"
+        );
+    });
+
+    it('prefers an explicit placeholder over the tool-property default', () => {
+        expect(getMentionsInputPlaceholder({expressionEnabled: true, placeholder: 'Custom', toolProperty: true})).toBe(
+            'Custom'
+        );
+    });
+
+    it('returns empty (or explicit) when expressions are disabled', () => {
+        expect(getMentionsInputPlaceholder({expressionEnabled: false, toolProperty: true})).toBe('');
+        expect(getMentionsInputPlaceholder({expressionEnabled: false, placeholder: 'X', toolProperty: true})).toBe('X');
+    });
+});

--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/tests/suggestionPopupRenderer.test.ts
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/tests/suggestionPopupRenderer.test.ts
@@ -1,0 +1,169 @@
+import {SuggestionProps} from '@tiptap/suggestion';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+
+import {createSuggestionPopupRenderer} from '../suggestionPopupRenderer';
+
+const reactRendererInstances: Array<{
+    destroy: ReturnType<typeof vi.fn>;
+    ref: {onKeyDown: ReturnType<typeof vi.fn>};
+    updateProps: ReturnType<typeof vi.fn>;
+}> = [];
+const tippyInstances: Array<{
+    destroy: ReturnType<typeof vi.fn>;
+    hide: ReturnType<typeof vi.fn>;
+    popper: {addEventListener: ReturnType<typeof vi.fn>};
+    setProps: ReturnType<typeof vi.fn>;
+}> = [];
+
+vi.mock('@tiptap/react', () => ({
+    ReactRenderer: vi.fn(function ReactRendererMock(this: Record<string, unknown>) {
+        const instance = {
+            destroy: vi.fn(),
+            element: document.createElement('div'),
+            ref: {onKeyDown: vi.fn(() => true)},
+            updateProps: vi.fn(),
+        };
+
+        reactRendererInstances.push(instance);
+
+        Object.assign(this, instance);
+    }),
+}));
+
+const tippyOptions: Array<Record<string, () => unknown>> = [];
+
+vi.mock('tippy.js', () => ({
+    default: vi.fn((_target: string, options: Record<string, () => unknown>) => {
+        tippyOptions.push(options);
+
+        const instance = {
+            destroy: vi.fn(),
+            hide: vi.fn(),
+            popper: {addEventListener: vi.fn()},
+            setProps: vi.fn(),
+        };
+
+        tippyInstances.push(instance);
+
+        return [instance];
+    }),
+}));
+
+const listComponent = (() => null) as never;
+
+function createEditor(isFocused = true) {
+    return {
+        isFocused,
+        storage: {MentionStorage: {dataPills: [], suggestionOpen: false}},
+    };
+}
+
+const CARET_RECT = (() => ({})) as unknown as () => DOMRect;
+
+function createStartProps(editor: ReturnType<typeof createEditor>, clientRect: (() => DOMRect) | null = CARET_RECT) {
+    return {clientRect, editor, items: [], query: ''} as unknown as SuggestionProps<unknown>;
+}
+
+describe('createSuggestionPopupRenderer', () => {
+    beforeEach(() => {
+        reactRendererInstances.length = 0;
+        tippyInstances.length = 0;
+        tippyOptions.length = 0;
+    });
+
+    it('does not open a popup while the editor is unfocused', () => {
+        const renderer = createSuggestionPopupRenderer(listComponent)();
+
+        renderer.onStart!(createStartProps(createEditor(false)));
+
+        expect(reactRendererInstances).toHaveLength(0);
+        expect(tippyInstances).toHaveLength(0);
+    });
+
+    it('tears the renderer down again when the caret has no client rect', () => {
+        const renderer = createSuggestionPopupRenderer(listComponent)();
+
+        renderer.onStart!(createStartProps(createEditor(), null));
+
+        expect(reactRendererInstances[0].destroy).toHaveBeenCalled();
+        expect(tippyInstances).toHaveLength(0);
+    });
+
+    it('opens the popup, intercepts wheel events and flags the suggestion as open', () => {
+        const editor = createEditor();
+        const renderer = createSuggestionPopupRenderer(listComponent)();
+
+        renderer.onStart!(createStartProps(editor));
+
+        expect(tippyInstances).toHaveLength(1);
+        expect(tippyInstances[0].popper.addEventListener).toHaveBeenCalledWith(
+            'wheel',
+            expect.any(Function),
+            expect.objectContaining({capture: true, passive: true})
+        );
+        expect(editor.storage.MentionStorage.suggestionOpen).toBe(true);
+    });
+
+    it('hides the popup on Escape and otherwise delegates to the list', () => {
+        const renderer = createSuggestionPopupRenderer(listComponent)();
+
+        expect(renderer.onKeyDown!({event: {key: 'ArrowDown'}} as never)).toBe(false);
+
+        renderer.onStart!(createStartProps(createEditor()));
+
+        expect(renderer.onKeyDown!({event: {key: 'Escape'}} as never)).toBe(true);
+        expect(tippyInstances[0].hide).toHaveBeenCalled();
+
+        expect(renderer.onKeyDown!({event: {key: 'ArrowDown'}} as never)).toBe(true);
+        expect(reactRendererInstances[0].ref.onKeyDown).toHaveBeenCalled();
+    });
+
+    it('anchors the popup on the body at the caret rect', () => {
+        const renderer = createSuggestionPopupRenderer(listComponent)();
+
+        renderer.onStart!(createStartProps(createEditor()));
+
+        expect(tippyOptions[0].appendTo()).toBe(document.body);
+        expect(tippyOptions[0].getReferenceClientRect()).toEqual(CARET_RECT());
+    });
+
+    it('repositions the popup on update, and keeps the last rect when one is missing', () => {
+        const updatedRect = {top: 42} as unknown as DOMRect;
+        const renderer = createSuggestionPopupRenderer(listComponent)();
+
+        renderer.onStart!(createStartProps(createEditor()));
+
+        renderer.onUpdate!(createStartProps(createEditor(), () => updatedRect));
+
+        expect(reactRendererInstances[0].updateProps).toHaveBeenCalled();
+        expect(tippyInstances[0].setProps).toHaveBeenCalledTimes(1);
+
+        const [{getReferenceClientRect}] = tippyInstances[0].setProps.mock.calls[0];
+
+        expect(getReferenceClientRect()).toBe(updatedRect);
+
+        renderer.onUpdate!(createStartProps(createEditor(), null));
+
+        expect(tippyInstances[0].setProps).toHaveBeenCalledTimes(1);
+        // The popup keeps pointing at the last rect it was given rather than jumping to the origin.
+        expect(getReferenceClientRect()).toBe(updatedRect);
+    });
+
+    it('clears the open flag and destroys the popup on exit', () => {
+        const editor = createEditor();
+        const renderer = createSuggestionPopupRenderer(listComponent)();
+
+        renderer.onStart!(createStartProps(editor));
+        renderer.onExit!(createStartProps(editor));
+
+        expect(editor.storage.MentionStorage.suggestionOpen).toBe(false);
+        expect(tippyInstances[0].destroy).toHaveBeenCalled();
+        expect(reactRendererInstances[0].destroy).toHaveBeenCalled();
+    });
+
+    it('exits cleanly when the popup was never opened', () => {
+        const renderer = createSuggestionPopupRenderer(listComponent)();
+
+        expect(() => renderer.onExit!(createStartProps(createEditor(false)))).not.toThrow();
+    });
+});

--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/useEvaluatorFunctionDefinitions.test.ts
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/useEvaluatorFunctionDefinitions.test.ts
@@ -1,0 +1,47 @@
+import {renderHook} from '@testing-library/react';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+
+import {useEvaluatorFunctionDefinitions} from './useEvaluatorFunctionDefinitions';
+
+const useEvaluatorFunctionDefinitionsQueryMock = vi.fn();
+
+vi.mock('@/shared/middleware/graphql', () => ({
+    useEvaluatorFunctionDefinitionsQuery: (...args: unknown[]) => useEvaluatorFunctionDefinitionsQueryMock(...args),
+}));
+
+describe('useEvaluatorFunctionDefinitions', () => {
+    beforeEach(() => {
+        useEvaluatorFunctionDefinitionsQueryMock.mockReset();
+    });
+
+    it('returns the definitions array when data is present', () => {
+        const definitions = [{name: 'concat'}, {name: 'contains'}];
+
+        useEvaluatorFunctionDefinitionsQueryMock.mockReturnValue({
+            data: {evaluatorFunctionDefinitions: definitions},
+        });
+
+        const {result} = renderHook(() => useEvaluatorFunctionDefinitions());
+
+        expect(result.current).toBe(definitions);
+    });
+
+    it('returns an empty array when data is undefined', () => {
+        useEvaluatorFunctionDefinitionsQueryMock.mockReturnValue({data: undefined});
+
+        const {result} = renderHook(() => useEvaluatorFunctionDefinitions());
+
+        expect(result.current).toEqual([]);
+    });
+
+    it('requests with an infinite staleTime so the static catalog is fetched once', () => {
+        useEvaluatorFunctionDefinitionsQueryMock.mockReturnValue({data: undefined});
+
+        renderHook(() => useEvaluatorFunctionDefinitions());
+
+        expect(useEvaluatorFunctionDefinitionsQueryMock).toHaveBeenCalledWith(
+            {},
+            expect.objectContaining({staleTime: Infinity})
+        );
+    });
+});

--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/useEvaluatorFunctionDefinitions.ts
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/useEvaluatorFunctionDefinitions.ts
@@ -1,0 +1,8 @@
+import {EvaluatorFunctionDefinition, useEvaluatorFunctionDefinitionsQuery} from '@/shared/middleware/graphql';
+
+// The evaluator function catalog is static per deployment, so fetch it once and never refetch.
+export function useEvaluatorFunctionDefinitions(): EvaluatorFunctionDefinition[] {
+    const {data} = useEvaluatorFunctionDefinitionsQuery({}, {staleTime: Infinity});
+
+    return data?.evaluatorFunctionDefinitions ?? [];
+}

--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/useSuggestionListNavigation.ts
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/useSuggestionListNavigation.ts
@@ -1,0 +1,44 @@
+import {ForwardedRef, useEffect, useImperativeHandle, useState} from 'react';
+
+import {SuggestionListRefType} from './suggestionPopupRenderer';
+
+/**
+ * Arrow-key and Enter navigation shared by the editor's suggestion lists. Owns the highlighted index,
+ * resets it whenever the filtered item set changes, and publishes the `onKeyDown` handler that the
+ * tippy popup renderer reaches through the forwarded ref.
+ */
+export function useSuggestionListNavigation(
+    items: unknown[],
+    ref: ForwardedRef<SuggestionListRefType>,
+    selectItem: (index: number) => void
+): number {
+    const [selectedIndex, setSelectedIndex] = useState(0);
+
+    useImperativeHandle(ref, () => ({
+        onKeyDown: ({event}: {event: KeyboardEvent}) => {
+            if (event.key === 'ArrowUp') {
+                setSelectedIndex((selectedIndex + items.length - 1) % items.length);
+
+                return true;
+            }
+
+            if (event.key === 'ArrowDown') {
+                setSelectedIndex((selectedIndex + 1) % items.length);
+
+                return true;
+            }
+
+            if (event.key === 'Enter') {
+                selectItem(selectedIndex);
+
+                return true;
+            }
+
+            return false;
+        },
+    }));
+
+    useEffect(() => setSelectedIndex(0), [items]);
+
+    return selectedIndex;
+}

--- a/client/src/shared/middleware/graphql-types.ts
+++ b/client/src/shared/middleware/graphql-types.ts
@@ -1476,6 +1476,7 @@ export type Mutation = {
   addDataTableColumn: Scalars['Boolean']['output'];
   cancelAiAgentEvalRun: AiAgentEvalRun;
   cancelGenerationJob: Scalars['Boolean']['output'];
+  createAdditionalFilesInSkill: AiSkill;
   createAiAgentEvalScenario: AiAgentEvalScenario;
   createAiAgentEvalTest: AiAgentEvalTest;
   createAiAgentJudge: AiAgentJudge;
@@ -1557,6 +1558,7 @@ export type Mutation = {
   inviteUser: Scalars['Boolean']['output'];
   publishAutomationWorkflowProject: Scalars['Boolean']['output'];
   removeDataTableColumn: Scalars['Boolean']['output'];
+  removeFileInSkill: AiSkill;
   renameDataTable: Scalars['Boolean']['output'];
   renameDataTableColumn: Scalars['Boolean']['output'];
   saveClusterElementTestConfigurationConnection?: Maybe<Scalars['Boolean']['output']>;
@@ -1617,6 +1619,12 @@ export type MutationCancelAiAgentEvalRunArgs = {
 
 export type MutationCancelGenerationJobArgs = {
   jobId: Scalars['String']['input'];
+};
+
+
+export type MutationCreateAdditionalFilesInSkillArgs = {
+  additionalFiles: Scalars['Map']['input'];
+  id: Scalars['ID']['input'];
 };
 
 
@@ -2074,6 +2082,12 @@ export type MutationPublishAutomationWorkflowProjectArgs = {
 
 export type MutationRemoveDataTableColumnArgs = {
   input: RemoveColumnInput;
+};
+
+
+export type MutationRemoveFileInSkillArgs = {
+  id: Scalars['ID']['input'];
+  path: Scalars['String']['input'];
 };
 
 

--- a/client/src/shared/middleware/graphql.ts
+++ b/client/src/shared/middleware/graphql.ts
@@ -248,6 +248,14 @@ export type AiSkillsQueryVariables = Exact<{ [key: string]: never; }>;
 
 export type AiSkillsQuery = { aiSkills: Array<{ id: string, name: string, description: string | null, createdDate: any, lastModifiedDate: any }> };
 
+export type CreateAdditionalFilesInSkillMutationVariables = Exact<{
+  id: string | number;
+  additionalFiles: any;
+}>;
+
+
+export type CreateAdditionalFilesInSkillMutation = { createAdditionalFilesInSkill: { description: string | null, id: string, lastModifiedDate: any, name: string } };
+
 export type CreateAiSkillMutationVariables = Exact<{
   name: string;
   description?: string | null | undefined;
@@ -274,6 +282,14 @@ export type DeleteAiSkillMutationVariables = Exact<{
 
 export type DeleteAiSkillMutation = { deleteAiSkill: boolean };
 
+export type RemoveFileInSkillMutationVariables = Exact<{
+  id: string | number;
+  path: string;
+}>;
+
+
+export type RemoveFileInSkillMutation = { removeFileInSkill: { description: string | null, id: string, lastModifiedDate: any, name: string } };
+
 export type UpdateAiSkillMutationVariables = Exact<{
   id: string | number;
   name: string;
@@ -291,22 +307,6 @@ export type UpdateAiSkillContentMutationVariables = Exact<{
 
 
 export type UpdateAiSkillContentMutation = { updateAiSkillContent: { description: string | null, id: string, lastModifiedDate: any, name: string } };
-
-export type RemoveFileInSkillMutationVariables = Exact<{
-  id: string | number;
-  path: string;
-}>;
-
-
-export type RemoveFileInSkillMutation = { removeFileInSkill: { description: string | null, id: string, lastModifiedDate: any, name: string } };
-
-export type CreateAdditionalFilesInSkillMutationVariables = Exact<{
-  id: string | number;
-  additionalFiles: any;
-}>;
-
-
-export type CreateAdditionalFilesInSkillMutation = { createAdditionalFilesInSkill: { description: string | null, id: string, lastModifiedDate: any, name: string } };
 
 export type ApprovalTaskQueryVariables = Exact<{
   id: string | number;
@@ -1854,7 +1854,7 @@ export const useAiAgentEvalResultQuery = <
       variables: AiAgentEvalResultQueryVariables,
       options?: Omit<UseQueryOptions<AiAgentEvalResultQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<AiAgentEvalResultQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<AiAgentEvalResultQuery, TError, TData>(
       {
     queryKey: ['aiAgentEvalResult', variables],
@@ -1876,7 +1876,7 @@ export const useAiAgentEvalResultTranscriptQuery = <
       variables: AiAgentEvalResultTranscriptQueryVariables,
       options?: Omit<UseQueryOptions<AiAgentEvalResultTranscriptQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<AiAgentEvalResultTranscriptQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<AiAgentEvalResultTranscriptQuery, TError, TData>(
       {
     queryKey: ['aiAgentEvalResultTranscript', variables],
@@ -1950,7 +1950,7 @@ export const useAiAgentEvalRunQuery = <
       variables: AiAgentEvalRunQueryVariables,
       options?: Omit<UseQueryOptions<AiAgentEvalRunQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<AiAgentEvalRunQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<AiAgentEvalRunQuery, TError, TData>(
       {
     queryKey: ['aiAgentEvalRun', variables],
@@ -1986,7 +1986,7 @@ export const useAiAgentEvalRunsQuery = <
       variables: AiAgentEvalRunsQueryVariables,
       options?: Omit<UseQueryOptions<AiAgentEvalRunsQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<AiAgentEvalRunsQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<AiAgentEvalRunsQuery, TError, TData>(
       {
     queryKey: ['aiAgentEvalRuns', variables],
@@ -2042,7 +2042,7 @@ export const useAiAgentEvalTestQuery = <
       variables: AiAgentEvalTestQueryVariables,
       options?: Omit<UseQueryOptions<AiAgentEvalTestQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<AiAgentEvalTestQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<AiAgentEvalTestQuery, TError, TData>(
       {
     queryKey: ['aiAgentEvalTest', variables],
@@ -2096,7 +2096,7 @@ export const useAiAgentEvalTestsQuery = <
       variables: AiAgentEvalTestsQueryVariables,
       options?: Omit<UseQueryOptions<AiAgentEvalTestsQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<AiAgentEvalTestsQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<AiAgentEvalTestsQuery, TError, TData>(
       {
     queryKey: ['aiAgentEvalTests', variables],
@@ -2125,7 +2125,7 @@ export const useAiAgentJudgesQuery = <
       variables: AiAgentJudgesQueryVariables,
       options?: Omit<UseQueryOptions<AiAgentJudgesQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<AiAgentJudgesQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<AiAgentJudgesQuery, TError, TData>(
       {
     queryKey: ['aiAgentJudges', variables],
@@ -2147,7 +2147,7 @@ export const useCancelAiAgentEvalRunMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<CancelAiAgentEvalRunMutation, TError, CancelAiAgentEvalRunMutationVariables, TContext>) => {
-
+    
     return useMutation<CancelAiAgentEvalRunMutation, TError, CancelAiAgentEvalRunMutationVariables, TContext>(
       {
     mutationKey: ['cancelAiAgentEvalRun'],
@@ -2194,7 +2194,7 @@ export const useCreateAiAgentEvalScenarioMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<CreateAiAgentEvalScenarioMutation, TError, CreateAiAgentEvalScenarioMutationVariables, TContext>) => {
-
+    
     return useMutation<CreateAiAgentEvalScenarioMutation, TError, CreateAiAgentEvalScenarioMutationVariables, TContext>(
       {
     mutationKey: ['createAiAgentEvalScenario'],
@@ -2224,7 +2224,7 @@ export const useCreateAiAgentEvalTestMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<CreateAiAgentEvalTestMutation, TError, CreateAiAgentEvalTestMutationVariables, TContext>) => {
-
+    
     return useMutation<CreateAiAgentEvalTestMutation, TError, CreateAiAgentEvalTestMutationVariables, TContext>(
       {
     mutationKey: ['createAiAgentEvalTest'],
@@ -2256,7 +2256,7 @@ export const useCreateAiAgentJudgeMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<CreateAiAgentJudgeMutation, TError, CreateAiAgentJudgeMutationVariables, TContext>) => {
-
+    
     return useMutation<CreateAiAgentJudgeMutation, TError, CreateAiAgentJudgeMutationVariables, TContext>(
       {
     mutationKey: ['createAiAgentJudge'],
@@ -2287,7 +2287,7 @@ export const useCreateAiAgentScenarioJudgeMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<CreateAiAgentScenarioJudgeMutation, TError, CreateAiAgentScenarioJudgeMutationVariables, TContext>) => {
-
+    
     return useMutation<CreateAiAgentScenarioJudgeMutation, TError, CreateAiAgentScenarioJudgeMutationVariables, TContext>(
       {
     mutationKey: ['createAiAgentScenarioJudge'],
@@ -2316,7 +2316,7 @@ export const useCreateAiAgentScenarioToolSimulationMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<CreateAiAgentScenarioToolSimulationMutation, TError, CreateAiAgentScenarioToolSimulationMutationVariables, TContext>) => {
-
+    
     return useMutation<CreateAiAgentScenarioToolSimulationMutation, TError, CreateAiAgentScenarioToolSimulationMutationVariables, TContext>(
       {
     mutationKey: ['createAiAgentScenarioToolSimulation'],
@@ -2335,7 +2335,7 @@ export const useDeleteAiAgentEvalScenarioMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<DeleteAiAgentEvalScenarioMutation, TError, DeleteAiAgentEvalScenarioMutationVariables, TContext>) => {
-
+    
     return useMutation<DeleteAiAgentEvalScenarioMutation, TError, DeleteAiAgentEvalScenarioMutationVariables, TContext>(
       {
     mutationKey: ['deleteAiAgentEvalScenario'],
@@ -2354,7 +2354,7 @@ export const useDeleteAiAgentEvalTestMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<DeleteAiAgentEvalTestMutation, TError, DeleteAiAgentEvalTestMutationVariables, TContext>) => {
-
+    
     return useMutation<DeleteAiAgentEvalTestMutation, TError, DeleteAiAgentEvalTestMutationVariables, TContext>(
       {
     mutationKey: ['deleteAiAgentEvalTest'],
@@ -2373,7 +2373,7 @@ export const useDeleteAiAgentJudgeMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<DeleteAiAgentJudgeMutation, TError, DeleteAiAgentJudgeMutationVariables, TContext>) => {
-
+    
     return useMutation<DeleteAiAgentJudgeMutation, TError, DeleteAiAgentJudgeMutationVariables, TContext>(
       {
     mutationKey: ['deleteAiAgentJudge'],
@@ -2392,7 +2392,7 @@ export const useDeleteAiAgentScenarioJudgeMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<DeleteAiAgentScenarioJudgeMutation, TError, DeleteAiAgentScenarioJudgeMutationVariables, TContext>) => {
-
+    
     return useMutation<DeleteAiAgentScenarioJudgeMutation, TError, DeleteAiAgentScenarioJudgeMutationVariables, TContext>(
       {
     mutationKey: ['deleteAiAgentScenarioJudge'],
@@ -2411,7 +2411,7 @@ export const useDeleteAiAgentScenarioToolSimulationMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<DeleteAiAgentScenarioToolSimulationMutation, TError, DeleteAiAgentScenarioToolSimulationMutationVariables, TContext>) => {
-
+    
     return useMutation<DeleteAiAgentScenarioToolSimulationMutation, TError, DeleteAiAgentScenarioToolSimulationMutationVariables, TContext>(
       {
     mutationKey: ['deleteAiAgentScenarioToolSimulation'],
@@ -2444,7 +2444,7 @@ export const useStartAiAgentEvalRunMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<StartAiAgentEvalRunMutation, TError, StartAiAgentEvalRunMutationVariables, TContext>) => {
-
+    
     return useMutation<StartAiAgentEvalRunMutation, TError, StartAiAgentEvalRunMutationVariables, TContext>(
       {
     mutationKey: ['startAiAgentEvalRun'],
@@ -2490,7 +2490,7 @@ export const useUpdateAiAgentEvalScenarioMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<UpdateAiAgentEvalScenarioMutation, TError, UpdateAiAgentEvalScenarioMutationVariables, TContext>) => {
-
+    
     return useMutation<UpdateAiAgentEvalScenarioMutation, TError, UpdateAiAgentEvalScenarioMutationVariables, TContext>(
       {
     mutationKey: ['updateAiAgentEvalScenario'],
@@ -2515,7 +2515,7 @@ export const useUpdateAiAgentEvalTestMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<UpdateAiAgentEvalTestMutation, TError, UpdateAiAgentEvalTestMutationVariables, TContext>) => {
-
+    
     return useMutation<UpdateAiAgentEvalTestMutation, TError, UpdateAiAgentEvalTestMutationVariables, TContext>(
       {
     mutationKey: ['updateAiAgentEvalTest'],
@@ -2541,7 +2541,7 @@ export const useUpdateAiAgentJudgeMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<UpdateAiAgentJudgeMutation, TError, UpdateAiAgentJudgeMutationVariables, TContext>) => {
-
+    
     return useMutation<UpdateAiAgentJudgeMutation, TError, UpdateAiAgentJudgeMutationVariables, TContext>(
       {
     mutationKey: ['updateAiAgentJudge'],
@@ -2567,7 +2567,7 @@ export const useUpdateAiAgentScenarioJudgeMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<UpdateAiAgentScenarioJudgeMutation, TError, UpdateAiAgentScenarioJudgeMutationVariables, TContext>) => {
-
+    
     return useMutation<UpdateAiAgentScenarioJudgeMutation, TError, UpdateAiAgentScenarioJudgeMutationVariables, TContext>(
       {
     mutationKey: ['updateAiAgentScenarioJudge'],
@@ -2596,7 +2596,7 @@ export const useUpdateAiAgentScenarioToolSimulationMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<UpdateAiAgentScenarioToolSimulationMutation, TError, UpdateAiAgentScenarioToolSimulationMutationVariables, TContext>) => {
-
+    
     return useMutation<UpdateAiAgentScenarioToolSimulationMutation, TError, UpdateAiAgentScenarioToolSimulationMutationVariables, TContext>(
       {
     mutationKey: ['updateAiAgentScenarioToolSimulation'],
@@ -2624,7 +2624,7 @@ export const useAiSkillQuery = <
       variables: AiSkillQueryVariables,
       options?: Omit<UseQueryOptions<AiSkillQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<AiSkillQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<AiSkillQuery, TError, TData>(
       {
     queryKey: ['aiSkill', variables],
@@ -2646,7 +2646,7 @@ export const useAiSkillFileContentQuery = <
       variables: AiSkillFileContentQueryVariables,
       options?: Omit<UseQueryOptions<AiSkillFileContentQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<AiSkillFileContentQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<AiSkillFileContentQuery, TError, TData>(
       {
     queryKey: ['aiSkillFileContent', variables],
@@ -2668,7 +2668,7 @@ export const useAiSkillFilePathsQuery = <
       variables: AiSkillFilePathsQueryVariables,
       options?: Omit<UseQueryOptions<AiSkillFilePathsQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<AiSkillFilePathsQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<AiSkillFilePathsQuery, TError, TData>(
       {
     queryKey: ['aiSkillFilePaths', variables],
@@ -2696,11 +2696,35 @@ export const useAiSkillsQuery = <
       variables?: AiSkillsQueryVariables,
       options?: Omit<UseQueryOptions<AiSkillsQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<AiSkillsQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<AiSkillsQuery, TError, TData>(
       {
     queryKey: variables === undefined ? ['aiSkills'] : ['aiSkills', variables],
     queryFn: fetcher<AiSkillsQuery, AiSkillsQueryVariables>(AiSkillsDocument, variables),
+    ...options
+  }
+    )};
+
+export const CreateAdditionalFilesInSkillDocument = new TypedDocumentString(`
+    mutation createAdditionalFilesInSkill($id: ID!, $additionalFiles: Map!) {
+  createAdditionalFilesInSkill(id: $id, additionalFiles: $additionalFiles) {
+    description
+    id
+    lastModifiedDate
+    name
+  }
+}
+    `);
+
+export const useCreateAdditionalFilesInSkillMutation = <
+      TError = unknown,
+      TContext = unknown
+    >(options?: UseMutationOptions<CreateAdditionalFilesInSkillMutation, TError, CreateAdditionalFilesInSkillMutationVariables, TContext>) => {
+    
+    return useMutation<CreateAdditionalFilesInSkillMutation, TError, CreateAdditionalFilesInSkillMutationVariables, TContext>(
+      {
+    mutationKey: ['createAdditionalFilesInSkill'],
+    mutationFn: (variables?: CreateAdditionalFilesInSkillMutationVariables) => fetcher<CreateAdditionalFilesInSkillMutation, CreateAdditionalFilesInSkillMutationVariables>(CreateAdditionalFilesInSkillDocument, variables)(),
     ...options
   }
     )};
@@ -2726,7 +2750,7 @@ export const useCreateAiSkillMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<CreateAiSkillMutation, TError, CreateAiSkillMutationVariables, TContext>) => {
-
+    
     return useMutation<CreateAiSkillMutation, TError, CreateAiSkillMutationVariables, TContext>(
       {
     mutationKey: ['createAiSkill'],
@@ -2755,7 +2779,7 @@ export const useCreateAiSkillFromInstructionsMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<CreateAiSkillFromInstructionsMutation, TError, CreateAiSkillFromInstructionsMutationVariables, TContext>) => {
-
+    
     return useMutation<CreateAiSkillFromInstructionsMutation, TError, CreateAiSkillFromInstructionsMutationVariables, TContext>(
       {
     mutationKey: ['createAiSkillFromInstructions'],
@@ -2774,11 +2798,35 @@ export const useDeleteAiSkillMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<DeleteAiSkillMutation, TError, DeleteAiSkillMutationVariables, TContext>) => {
-
+    
     return useMutation<DeleteAiSkillMutation, TError, DeleteAiSkillMutationVariables, TContext>(
       {
     mutationKey: ['deleteAiSkill'],
     mutationFn: (variables?: DeleteAiSkillMutationVariables) => fetcher<DeleteAiSkillMutation, DeleteAiSkillMutationVariables>(DeleteAiSkillDocument, variables)(),
+    ...options
+  }
+    )};
+
+export const RemoveFileInSkillDocument = new TypedDocumentString(`
+    mutation removeFileInSkill($id: ID!, $path: String!) {
+  removeFileInSkill(id: $id, path: $path) {
+    description
+    id
+    lastModifiedDate
+    name
+  }
+}
+    `);
+
+export const useRemoveFileInSkillMutation = <
+      TError = unknown,
+      TContext = unknown
+    >(options?: UseMutationOptions<RemoveFileInSkillMutation, TError, RemoveFileInSkillMutationVariables, TContext>) => {
+    
+    return useMutation<RemoveFileInSkillMutation, TError, RemoveFileInSkillMutationVariables, TContext>(
+      {
+    mutationKey: ['removeFileInSkill'],
+    mutationFn: (variables?: RemoveFileInSkillMutationVariables) => fetcher<RemoveFileInSkillMutation, RemoveFileInSkillMutationVariables>(RemoveFileInSkillDocument, variables)(),
     ...options
   }
     )};
@@ -2799,7 +2847,7 @@ export const useUpdateAiSkillMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<UpdateAiSkillMutation, TError, UpdateAiSkillMutationVariables, TContext>) => {
-
+    
     return useMutation<UpdateAiSkillMutation, TError, UpdateAiSkillMutationVariables, TContext>(
       {
     mutationKey: ['updateAiSkill'],
@@ -2823,59 +2871,11 @@ export const useUpdateAiSkillContentMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<UpdateAiSkillContentMutation, TError, UpdateAiSkillContentMutationVariables, TContext>) => {
-
+    
     return useMutation<UpdateAiSkillContentMutation, TError, UpdateAiSkillContentMutationVariables, TContext>(
       {
     mutationKey: ['updateAiSkillContent'],
     mutationFn: (variables?: UpdateAiSkillContentMutationVariables) => fetcher<UpdateAiSkillContentMutation, UpdateAiSkillContentMutationVariables>(UpdateAiSkillContentDocument, variables)(),
-    ...options
-  }
-    )};
-
-export const RemoveFileInSkillDocument = new TypedDocumentString(`
-    mutation removeFileInSkill($id: ID!, $path: String!) {
-  removeFileInSkill(id: $id, path: $path) {
-    description
-    id
-    lastModifiedDate
-    name
-  }
-}
-    `);
-
-export const useRemoveFileInSkillMutation = <
-      TError = unknown,
-      TContext = unknown
-    >(options?: UseMutationOptions<RemoveFileInSkillMutation, TError, RemoveFileInSkillMutationVariables, TContext>) => {
-
-    return useMutation<RemoveFileInSkillMutation, TError, RemoveFileInSkillMutationVariables, TContext>(
-      {
-    mutationKey: ['removeFileInSkill'],
-    mutationFn: (variables?: RemoveFileInSkillMutationVariables) => fetcher<RemoveFileInSkillMutation, RemoveFileInSkillMutationVariables>(RemoveFileInSkillDocument, variables)(),
-    ...options
-  }
-    )};
-
-export const CreateAdditionalFilesInSkillDocument = new TypedDocumentString(`
-    mutation createAdditionalFilesInSkill($id: ID!, $additionalFiles: Map!) {
-  createAdditionalFilesInSkill(id: $id, additionalFiles: $additionalFiles) {
-    description
-    id
-    lastModifiedDate
-    name
-  }
-}
-    `);
-
-export const useCreateAdditionalFilesInSkillMutation = <
-      TError = unknown,
-      TContext = unknown
-    >(options?: UseMutationOptions<CreateAdditionalFilesInSkillMutation, TError, CreateAdditionalFilesInSkillMutationVariables, TContext>) => {
-
-    return useMutation<CreateAdditionalFilesInSkillMutation, TError, CreateAdditionalFilesInSkillMutationVariables, TContext>(
-      {
-    mutationKey: ['createAdditionalFilesInSkill'],
-    mutationFn: (variables?: CreateAdditionalFilesInSkillMutationVariables) => fetcher<CreateAdditionalFilesInSkillMutation, CreateAdditionalFilesInSkillMutationVariables>(CreateAdditionalFilesInSkillDocument, variables)(),
     ...options
   }
     )};
@@ -2907,7 +2907,7 @@ export const useApprovalTaskQuery = <
       variables: ApprovalTaskQueryVariables,
       options?: Omit<UseQueryOptions<ApprovalTaskQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<ApprovalTaskQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<ApprovalTaskQuery, TError, TData>(
       {
     queryKey: ['approvalTask', variables],
@@ -2943,7 +2943,7 @@ export const useApprovalTasksQuery = <
       variables?: ApprovalTasksQueryVariables,
       options?: Omit<UseQueryOptions<ApprovalTasksQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<ApprovalTasksQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<ApprovalTasksQuery, TError, TData>(
       {
     queryKey: variables === undefined ? ['approvalTasks'] : ['approvalTasks', variables],
@@ -2969,7 +2969,7 @@ export const useCreateApprovalTaskMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<CreateApprovalTaskMutation, TError, CreateApprovalTaskMutationVariables, TContext>) => {
-
+    
     return useMutation<CreateApprovalTaskMutation, TError, CreateApprovalTaskMutationVariables, TContext>(
       {
     mutationKey: ['createApprovalTask'],
@@ -2988,7 +2988,7 @@ export const useDeleteApprovalTaskMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<DeleteApprovalTaskMutation, TError, DeleteApprovalTaskMutationVariables, TContext>) => {
-
+    
     return useMutation<DeleteApprovalTaskMutation, TError, DeleteApprovalTaskMutationVariables, TContext>(
       {
     mutationKey: ['deleteApprovalTask'],
@@ -3016,7 +3016,7 @@ export const useUpdateApprovalTaskMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<UpdateApprovalTaskMutation, TError, UpdateApprovalTaskMutationVariables, TContext>) => {
-
+    
     return useMutation<UpdateApprovalTaskMutation, TError, UpdateApprovalTaskMutationVariables, TContext>(
       {
     mutationKey: ['updateApprovalTask'],
@@ -3040,7 +3040,7 @@ export const useCreateMcpProjectMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<CreateMcpProjectMutation, TError, CreateMcpProjectMutationVariables, TContext>) => {
-
+    
     return useMutation<CreateMcpProjectMutation, TError, CreateMcpProjectMutationVariables, TContext>(
       {
     mutationKey: ['createMcpProject'],
@@ -3063,7 +3063,7 @@ export const useCreateWorkspaceApiKeyMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<CreateWorkspaceApiKeyMutation, TError, CreateWorkspaceApiKeyMutationVariables, TContext>) => {
-
+    
     return useMutation<CreateWorkspaceApiKeyMutation, TError, CreateWorkspaceApiKeyMutationVariables, TContext>(
       {
     mutationKey: ['createWorkspaceApiKey'],
@@ -3088,7 +3088,7 @@ export const useCreateMcpServerMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<CreateMcpServerMutation, TError, CreateMcpServerMutationVariables, TContext>) => {
-
+    
     return useMutation<CreateMcpServerMutation, TError, CreateMcpServerMutationVariables, TContext>(
       {
     mutationKey: ['createMcpServer'],
@@ -3107,7 +3107,7 @@ export const useDeleteMcpProjectMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<DeleteMcpProjectMutation, TError, DeleteMcpProjectMutationVariables, TContext>) => {
-
+    
     return useMutation<DeleteMcpProjectMutation, TError, DeleteMcpProjectMutationVariables, TContext>(
       {
     mutationKey: ['deleteMcpProject'],
@@ -3126,7 +3126,7 @@ export const useDeleteMcpProjectWorkflowMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<DeleteMcpProjectWorkflowMutation, TError, DeleteMcpProjectWorkflowMutationVariables, TContext>) => {
-
+    
     return useMutation<DeleteMcpProjectWorkflowMutation, TError, DeleteMcpProjectWorkflowMutationVariables, TContext>(
       {
     mutationKey: ['deleteMcpProjectWorkflow'],
@@ -3145,7 +3145,7 @@ export const useDeleteSharedProjectMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<DeleteSharedProjectMutation, TError, DeleteSharedProjectMutationVariables, TContext>) => {
-
+    
     return useMutation<DeleteSharedProjectMutation, TError, DeleteSharedProjectMutationVariables, TContext>(
       {
     mutationKey: ['deleteSharedProject'],
@@ -3164,7 +3164,7 @@ export const useDeleteSharedWorkflowMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<DeleteSharedWorkflowMutation, TError, DeleteSharedWorkflowMutationVariables, TContext>) => {
-
+    
     return useMutation<DeleteSharedWorkflowMutation, TError, DeleteSharedWorkflowMutationVariables, TContext>(
       {
     mutationKey: ['deleteSharedWorkflow'],
@@ -3183,7 +3183,7 @@ export const useDeleteWorkspaceApiKeyMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<DeleteWorkspaceApiKeyMutation, TError, DeleteWorkspaceApiKeyMutationVariables, TContext>) => {
-
+    
     return useMutation<DeleteWorkspaceApiKeyMutation, TError, DeleteWorkspaceApiKeyMutationVariables, TContext>(
       {
     mutationKey: ['deleteWorkspaceApiKey'],
@@ -3202,7 +3202,7 @@ export const useDeleteWorkspaceMcpServerMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<DeleteWorkspaceMcpServerMutation, TError, DeleteWorkspaceMcpServerMutationVariables, TContext>) => {
-
+    
     return useMutation<DeleteWorkspaceMcpServerMutation, TError, DeleteWorkspaceMcpServerMutationVariables, TContext>(
       {
     mutationKey: ['deleteWorkspaceMcpServer'],
@@ -3221,7 +3221,7 @@ export const useDisconnectConnectionMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<DisconnectConnectionMutation, TError, DisconnectConnectionMutationVariables, TContext>) => {
-
+    
     return useMutation<DisconnectConnectionMutation, TError, DisconnectConnectionMutationVariables, TContext>(
       {
     mutationKey: ['DisconnectConnection'],
@@ -3240,7 +3240,7 @@ export const useExportSharedProjectMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<ExportSharedProjectMutation, TError, ExportSharedProjectMutationVariables, TContext>) => {
-
+    
     return useMutation<ExportSharedProjectMutation, TError, ExportSharedProjectMutationVariables, TContext>(
       {
     mutationKey: ['exportSharedProject'],
@@ -3259,7 +3259,7 @@ export const useExportSharedWorkflowMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<ExportSharedWorkflowMutation, TError, ExportSharedWorkflowMutationVariables, TContext>) => {
-
+    
     return useMutation<ExportSharedWorkflowMutation, TError, ExportSharedWorkflowMutationVariables, TContext>(
       {
     mutationKey: ['exportSharedWorkflow'],
@@ -3282,7 +3282,7 @@ export const useImportProjectTemplateMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<ImportProjectTemplateMutation, TError, ImportProjectTemplateMutationVariables, TContext>) => {
-
+    
     return useMutation<ImportProjectTemplateMutation, TError, ImportProjectTemplateMutationVariables, TContext>(
       {
     mutationKey: ['importProjectTemplate'],
@@ -3305,7 +3305,7 @@ export const useImportWorkflowTemplateMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<ImportWorkflowTemplateMutation, TError, ImportWorkflowTemplateMutationVariables, TContext>) => {
-
+    
     return useMutation<ImportWorkflowTemplateMutation, TError, ImportWorkflowTemplateMutationVariables, TContext>(
       {
     mutationKey: ['importWorkflowTemplate'],
@@ -3372,7 +3372,7 @@ export const useMcpProjectWorkflowPropertiesQuery = <
       variables: McpProjectWorkflowPropertiesQueryVariables,
       options?: Omit<UseQueryOptions<McpProjectWorkflowPropertiesQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<McpProjectWorkflowPropertiesQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<McpProjectWorkflowPropertiesQuery, TError, TData>(
       {
     queryKey: ['mcpProjectWorkflowProperties', variables],
@@ -3401,7 +3401,7 @@ export const useMcpProjectsQuery = <
       variables?: McpProjectsQueryVariables,
       options?: Omit<UseQueryOptions<McpProjectsQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<McpProjectsQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<McpProjectsQuery, TError, TData>(
       {
     queryKey: variables === undefined ? ['mcpProjects'] : ['mcpProjects', variables],
@@ -3473,7 +3473,7 @@ export const useMcpProjectsByServerIdQuery = <
       variables: McpProjectsByServerIdQueryVariables,
       options?: Omit<UseQueryOptions<McpProjectsByServerIdQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<McpProjectsByServerIdQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<McpProjectsByServerIdQuery, TError, TData>(
       {
     queryKey: ['mcpProjectsByServerId', variables],
@@ -3522,7 +3522,7 @@ export const usePreBuiltProjectTemplatesQuery = <
       variables?: PreBuiltProjectTemplatesQueryVariables,
       options?: Omit<UseQueryOptions<PreBuiltProjectTemplatesQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<PreBuiltProjectTemplatesQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<PreBuiltProjectTemplatesQuery, TError, TData>(
       {
     queryKey: variables === undefined ? ['preBuiltProjectTemplates'] : ['preBuiltProjectTemplates', variables],
@@ -3564,7 +3564,7 @@ export const usePreBuiltWorkflowTemplatesQuery = <
       variables?: PreBuiltWorkflowTemplatesQueryVariables,
       options?: Omit<UseQueryOptions<PreBuiltWorkflowTemplatesQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<PreBuiltWorkflowTemplatesQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<PreBuiltWorkflowTemplatesQuery, TError, TData>(
       {
     queryKey: variables === undefined ? ['preBuiltWorkflowTemplates'] : ['preBuiltWorkflowTemplates', variables],
@@ -3589,7 +3589,7 @@ export const useProjectByIdQuery = <
       variables: ProjectByIdQueryVariables,
       options?: Omit<UseQueryOptions<ProjectByIdQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<ProjectByIdQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<ProjectByIdQuery, TError, TData>(
       {
     queryKey: ['projectById', variables],
@@ -3635,7 +3635,7 @@ export const useProjectTemplateQuery = <
       variables: ProjectTemplateQueryVariables,
       options?: Omit<UseQueryOptions<ProjectTemplateQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<ProjectTemplateQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<ProjectTemplateQuery, TError, TData>(
       {
     queryKey: ['projectTemplate', variables],
@@ -3662,7 +3662,7 @@ export const useSharedProjectQuery = <
       variables: SharedProjectQueryVariables,
       options?: Omit<UseQueryOptions<SharedProjectQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<SharedProjectQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<SharedProjectQuery, TError, TData>(
       {
     queryKey: ['sharedProject', variables],
@@ -3689,7 +3689,7 @@ export const useSharedWorkflowQuery = <
       variables: SharedWorkflowQueryVariables,
       options?: Omit<UseQueryOptions<SharedWorkflowQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<SharedWorkflowQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<SharedWorkflowQuery, TError, TData>(
       {
     queryKey: ['sharedWorkflow', variables],
@@ -3720,7 +3720,7 @@ export const useToolEligibleProjectVersionWorkflowsQuery = <
       variables: ToolEligibleProjectVersionWorkflowsQueryVariables,
       options?: Omit<UseQueryOptions<ToolEligibleProjectVersionWorkflowsQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<ToolEligibleProjectVersionWorkflowsQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<ToolEligibleProjectVersionWorkflowsQuery, TError, TData>(
       {
     queryKey: ['toolEligibleProjectVersionWorkflows', variables],
@@ -3744,7 +3744,7 @@ export const useUpdateMcpProjectMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<UpdateMcpProjectMutation, TError, UpdateMcpProjectMutationVariables, TContext>) => {
-
+    
     return useMutation<UpdateMcpProjectMutation, TError, UpdateMcpProjectMutationVariables, TContext>(
       {
     mutationKey: ['updateMcpProject'],
@@ -3768,7 +3768,7 @@ export const useUpdateMcpProjectWorkflowMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<UpdateMcpProjectWorkflowMutation, TError, UpdateMcpProjectWorkflowMutationVariables, TContext>) => {
-
+    
     return useMutation<UpdateMcpProjectWorkflowMutation, TError, UpdateMcpProjectWorkflowMutationVariables, TContext>(
       {
     mutationKey: ['updateMcpProjectWorkflow'],
@@ -3791,7 +3791,7 @@ export const useUpdateMcpServerMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<UpdateMcpServerMutation, TError, UpdateMcpServerMutationVariables, TContext>) => {
-
+    
     return useMutation<UpdateMcpServerMutation, TError, UpdateMcpServerMutationVariables, TContext>(
       {
     mutationKey: ['updateMcpServer'],
@@ -3812,7 +3812,7 @@ export const useUpdateMcpServerTagsMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<UpdateMcpServerTagsMutation, TError, UpdateMcpServerTagsMutationVariables, TContext>) => {
-
+    
     return useMutation<UpdateMcpServerTagsMutation, TError, UpdateMcpServerTagsMutationVariables, TContext>(
       {
     mutationKey: ['updateMcpServerTags'],
@@ -3831,7 +3831,7 @@ export const useUpdateWorkspaceApiKeyMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<UpdateWorkspaceApiKeyMutation, TError, UpdateWorkspaceApiKeyMutationVariables, TContext>) => {
-
+    
     return useMutation<UpdateWorkspaceApiKeyMutation, TError, UpdateWorkspaceApiKeyMutationVariables, TContext>(
       {
     mutationKey: ['updateWorkspaceApiKey'],
@@ -3860,7 +3860,7 @@ export const useWorkflowChatProjectDeploymentWorkflowQuery = <
       variables: WorkflowChatProjectDeploymentWorkflowQueryVariables,
       options?: Omit<UseQueryOptions<WorkflowChatProjectDeploymentWorkflowQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<WorkflowChatProjectDeploymentWorkflowQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<WorkflowChatProjectDeploymentWorkflowQuery, TError, TData>(
       {
     queryKey: ['workflowChatProjectDeploymentWorkflow', variables],
@@ -3899,7 +3899,7 @@ export const useWorkflowTemplateQuery = <
       variables: WorkflowTemplateQueryVariables,
       options?: Omit<UseQueryOptions<WorkflowTemplateQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<WorkflowTemplateQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<WorkflowTemplateQuery, TError, TData>(
       {
     queryKey: ['workflowTemplate', variables],
@@ -3930,7 +3930,7 @@ export const useWorkspaceApiKeysQuery = <
       variables: WorkspaceApiKeysQueryVariables,
       options?: Omit<UseQueryOptions<WorkspaceApiKeysQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<WorkspaceApiKeysQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<WorkspaceApiKeysQuery, TError, TData>(
       {
     queryKey: ['workspaceApiKeys', variables],
@@ -3958,7 +3958,7 @@ export const useWorkspaceChatWorkflowsQuery = <
       variables: WorkspaceChatWorkflowsQueryVariables,
       options?: Omit<UseQueryOptions<WorkspaceChatWorkflowsQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<WorkspaceChatWorkflowsQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<WorkspaceChatWorkflowsQuery, TError, TData>(
       {
     queryKey: ['workspaceChatWorkflows', variables],
@@ -3999,7 +3999,7 @@ export const useWorkspaceMcpServersQuery = <
       variables: WorkspaceMcpServersQueryVariables,
       options?: Omit<UseQueryOptions<WorkspaceMcpServersQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<WorkspaceMcpServersQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<WorkspaceMcpServersQuery, TError, TData>(
       {
     queryKey: ['workspaceMcpServers', variables],
@@ -4018,7 +4018,7 @@ export const useAddDataTableColumnMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<AddDataTableColumnMutation, TError, AddDataTableColumnMutationVariables, TContext>) => {
-
+    
     return useMutation<AddDataTableColumnMutation, TError, AddDataTableColumnMutationVariables, TContext>(
       {
     mutationKey: ['addDataTableColumn'],
@@ -4037,7 +4037,7 @@ export const useCreateDataTableMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<CreateDataTableMutation, TError, CreateDataTableMutationVariables, TContext>) => {
-
+    
     return useMutation<CreateDataTableMutation, TError, CreateDataTableMutationVariables, TContext>(
       {
     mutationKey: ['createDataTable'],
@@ -4062,7 +4062,7 @@ export const useDataTableRowsQuery = <
       variables: DataTableRowsQueryVariables,
       options?: Omit<UseQueryOptions<DataTableRowsQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<DataTableRowsQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<DataTableRowsQuery, TError, TData>(
       {
     queryKey: ['dataTableRows', variables],
@@ -4096,7 +4096,7 @@ export const useDataTableRowsPageQuery = <
       variables: DataTableRowsPageQueryVariables,
       options?: Omit<UseQueryOptions<DataTableRowsPageQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<DataTableRowsPageQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<DataTableRowsPageQuery, TError, TData>(
       {
     queryKey: ['dataTableRowsPage', variables],
@@ -4121,7 +4121,7 @@ export const useDataTableTagsQuery = <
       variables?: DataTableTagsQueryVariables,
       options?: Omit<UseQueryOptions<DataTableTagsQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<DataTableTagsQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<DataTableTagsQuery, TError, TData>(
       {
     queryKey: variables === undefined ? ['dataTableTags'] : ['dataTableTags', variables],
@@ -4149,7 +4149,7 @@ export const useDataTableTagsByTableQuery = <
       variables?: DataTableTagsByTableQueryVariables,
       options?: Omit<UseQueryOptions<DataTableTagsByTableQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<DataTableTagsByTableQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<DataTableTagsByTableQuery, TError, TData>(
       {
     queryKey: variables === undefined ? ['dataTableTagsByTable'] : ['dataTableTagsByTable', variables],
@@ -4180,7 +4180,7 @@ export const useDataTablesQuery = <
       variables: DataTablesQueryVariables,
       options?: Omit<UseQueryOptions<DataTablesQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<DataTablesQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<DataTablesQuery, TError, TData>(
       {
     queryKey: ['dataTables', variables],
@@ -4199,7 +4199,7 @@ export const useDeleteDataTableRowMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<DeleteDataTableRowMutation, TError, DeleteDataTableRowMutationVariables, TContext>) => {
-
+    
     return useMutation<DeleteDataTableRowMutation, TError, DeleteDataTableRowMutationVariables, TContext>(
       {
     mutationKey: ['deleteDataTableRow'],
@@ -4218,7 +4218,7 @@ export const useDropDataTableMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<DropDataTableMutation, TError, DropDataTableMutationVariables, TContext>) => {
-
+    
     return useMutation<DropDataTableMutation, TError, DropDataTableMutationVariables, TContext>(
       {
     mutationKey: ['dropDataTable'],
@@ -4237,7 +4237,7 @@ export const useDuplicateDataTableMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<DuplicateDataTableMutation, TError, DuplicateDataTableMutationVariables, TContext>) => {
-
+    
     return useMutation<DuplicateDataTableMutation, TError, DuplicateDataTableMutationVariables, TContext>(
       {
     mutationKey: ['duplicateDataTable'],
@@ -4259,7 +4259,7 @@ export const useExportDataTableCsvQuery = <
       variables: ExportDataTableCsvQueryVariables,
       options?: Omit<UseQueryOptions<ExportDataTableCsvQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<ExportDataTableCsvQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<ExportDataTableCsvQuery, TError, TData>(
       {
     queryKey: ['exportDataTableCsv', variables],
@@ -4278,7 +4278,7 @@ export const useImportDataTableCsvMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<ImportDataTableCsvMutation, TError, ImportDataTableCsvMutationVariables, TContext>) => {
-
+    
     return useMutation<ImportDataTableCsvMutation, TError, ImportDataTableCsvMutationVariables, TContext>(
       {
     mutationKey: ['importDataTableCsv'],
@@ -4300,7 +4300,7 @@ export const useInsertDataTableRowMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<InsertDataTableRowMutation, TError, InsertDataTableRowMutationVariables, TContext>) => {
-
+    
     return useMutation<InsertDataTableRowMutation, TError, InsertDataTableRowMutationVariables, TContext>(
       {
     mutationKey: ['insertDataTableRow'],
@@ -4319,7 +4319,7 @@ export const useRemoveDataTableColumnMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<RemoveDataTableColumnMutation, TError, RemoveDataTableColumnMutationVariables, TContext>) => {
-
+    
     return useMutation<RemoveDataTableColumnMutation, TError, RemoveDataTableColumnMutationVariables, TContext>(
       {
     mutationKey: ['removeDataTableColumn'],
@@ -4338,7 +4338,7 @@ export const useRenameDataTableMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<RenameDataTableMutation, TError, RenameDataTableMutationVariables, TContext>) => {
-
+    
     return useMutation<RenameDataTableMutation, TError, RenameDataTableMutationVariables, TContext>(
       {
     mutationKey: ['renameDataTable'],
@@ -4357,7 +4357,7 @@ export const useRenameDataTableColumnMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<RenameDataTableColumnMutation, TError, RenameDataTableColumnMutationVariables, TContext>) => {
-
+    
     return useMutation<RenameDataTableColumnMutation, TError, RenameDataTableColumnMutationVariables, TContext>(
       {
     mutationKey: ['renameDataTableColumn'],
@@ -4379,7 +4379,7 @@ export const useUpdateDataTableRowMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<UpdateDataTableRowMutation, TError, UpdateDataTableRowMutationVariables, TContext>) => {
-
+    
     return useMutation<UpdateDataTableRowMutation, TError, UpdateDataTableRowMutationVariables, TContext>(
       {
     mutationKey: ['updateDataTableRow'],
@@ -4398,7 +4398,7 @@ export const useUpdateDataTableTagsMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<UpdateDataTableTagsMutation, TError, UpdateDataTableTagsMutationVariables, TContext>) => {
-
+    
     return useMutation<UpdateDataTableTagsMutation, TError, UpdateDataTableTagsMutationVariables, TContext>(
       {
     mutationKey: ['updateDataTableTags'],
@@ -4424,7 +4424,7 @@ export const useCreateKnowledgeBaseMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<CreateKnowledgeBaseMutation, TError, CreateKnowledgeBaseMutationVariables, TContext>) => {
-
+    
     return useMutation<CreateKnowledgeBaseMutation, TError, CreateKnowledgeBaseMutationVariables, TContext>(
       {
     mutationKey: ['createKnowledgeBase'],
@@ -4443,7 +4443,7 @@ export const useDeleteKnowledgeBaseMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<DeleteKnowledgeBaseMutation, TError, DeleteKnowledgeBaseMutationVariables, TContext>) => {
-
+    
     return useMutation<DeleteKnowledgeBaseMutation, TError, DeleteKnowledgeBaseMutationVariables, TContext>(
       {
     mutationKey: ['deleteKnowledgeBase'],
@@ -4462,7 +4462,7 @@ export const useDeleteKnowledgeBaseDocumentMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<DeleteKnowledgeBaseDocumentMutation, TError, DeleteKnowledgeBaseDocumentMutationVariables, TContext>) => {
-
+    
     return useMutation<DeleteKnowledgeBaseDocumentMutation, TError, DeleteKnowledgeBaseDocumentMutationVariables, TContext>(
       {
     mutationKey: ['deleteKnowledgeBaseDocument'],
@@ -4481,7 +4481,7 @@ export const useDeleteKnowledgeBaseDocumentChunkMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<DeleteKnowledgeBaseDocumentChunkMutation, TError, DeleteKnowledgeBaseDocumentChunkMutationVariables, TContext>) => {
-
+    
     return useMutation<DeleteKnowledgeBaseDocumentChunkMutation, TError, DeleteKnowledgeBaseDocumentChunkMutationVariables, TContext>(
       {
     mutationKey: ['deleteKnowledgeBaseDocumentChunk'],
@@ -4529,7 +4529,7 @@ export const useKnowledgeBaseQuery = <
       variables: KnowledgeBaseQueryVariables,
       options?: Omit<UseQueryOptions<KnowledgeBaseQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<KnowledgeBaseQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<KnowledgeBaseQuery, TError, TData>(
       {
     queryKey: ['knowledgeBase', variables],
@@ -4556,7 +4556,7 @@ export const useKnowledgeBaseDocumentChunksQuery = <
       variables: KnowledgeBaseDocumentChunksQueryVariables,
       options?: Omit<UseQueryOptions<KnowledgeBaseDocumentChunksQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<KnowledgeBaseDocumentChunksQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<KnowledgeBaseDocumentChunksQuery, TError, TData>(
       {
     queryKey: ['knowledgeBaseDocumentChunks', variables],
@@ -4583,7 +4583,7 @@ export const useKnowledgeBaseDocumentStatusQuery = <
       variables: KnowledgeBaseDocumentStatusQueryVariables,
       options?: Omit<UseQueryOptions<KnowledgeBaseDocumentStatusQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<KnowledgeBaseDocumentStatusQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<KnowledgeBaseDocumentStatusQuery, TError, TData>(
       {
     queryKey: ['knowledgeBaseDocumentStatus', variables],
@@ -4605,7 +4605,7 @@ export const useKnowledgeBaseDocumentTagsQuery = <
       variables?: KnowledgeBaseDocumentTagsQueryVariables,
       options?: Omit<UseQueryOptions<KnowledgeBaseDocumentTagsQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<KnowledgeBaseDocumentTagsQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<KnowledgeBaseDocumentTagsQuery, TError, TData>(
       {
     queryKey: variables === undefined ? ['knowledgeBaseDocumentTags'] : ['knowledgeBaseDocumentTags', variables],
@@ -4630,7 +4630,7 @@ export const useKnowledgeBaseDocumentTagsByDocumentQuery = <
       variables?: KnowledgeBaseDocumentTagsByDocumentQueryVariables,
       options?: Omit<UseQueryOptions<KnowledgeBaseDocumentTagsByDocumentQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<KnowledgeBaseDocumentTagsByDocumentQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<KnowledgeBaseDocumentTagsByDocumentQuery, TError, TData>(
       {
     queryKey: variables === undefined ? ['knowledgeBaseDocumentTagsByDocument'] : ['knowledgeBaseDocumentTagsByDocument', variables],
@@ -4652,7 +4652,7 @@ export const useKnowledgeBaseEmbeddingActiveQuery = <
       variables: KnowledgeBaseEmbeddingActiveQueryVariables,
       options?: Omit<UseQueryOptions<KnowledgeBaseEmbeddingActiveQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<KnowledgeBaseEmbeddingActiveQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<KnowledgeBaseEmbeddingActiveQuery, TError, TData>(
       {
     queryKey: ['knowledgeBaseEmbeddingActive', variables],
@@ -4677,7 +4677,7 @@ export const useKnowledgeBaseTagsQuery = <
       variables?: KnowledgeBaseTagsQueryVariables,
       options?: Omit<UseQueryOptions<KnowledgeBaseTagsQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<KnowledgeBaseTagsQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<KnowledgeBaseTagsQuery, TError, TData>(
       {
     queryKey: variables === undefined ? ['knowledgeBaseTags'] : ['knowledgeBaseTags', variables],
@@ -4705,7 +4705,7 @@ export const useKnowledgeBaseTagsByKnowledgeBaseQuery = <
       variables?: KnowledgeBaseTagsByKnowledgeBaseQueryVariables,
       options?: Omit<UseQueryOptions<KnowledgeBaseTagsByKnowledgeBaseQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<KnowledgeBaseTagsByKnowledgeBaseQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<KnowledgeBaseTagsByKnowledgeBaseQuery, TError, TData>(
       {
     queryKey: variables === undefined ? ['knowledgeBaseTagsByKnowledgeBase'] : ['knowledgeBaseTagsByKnowledgeBase', variables],
@@ -4736,7 +4736,7 @@ export const useKnowledgeBasesQuery = <
       variables: KnowledgeBasesQueryVariables,
       options?: Omit<UseQueryOptions<KnowledgeBasesQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<KnowledgeBasesQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<KnowledgeBasesQuery, TError, TData>(
       {
     queryKey: ['knowledgeBases', variables],
@@ -4764,7 +4764,7 @@ export const useSearchKnowledgeBaseQuery = <
       variables: SearchKnowledgeBaseQueryVariables,
       options?: Omit<UseQueryOptions<SearchKnowledgeBaseQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<SearchKnowledgeBaseQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<SearchKnowledgeBaseQuery, TError, TData>(
       {
     queryKey: ['searchKnowledgeBase', variables],
@@ -4790,7 +4790,7 @@ export const useUpdateKnowledgeBaseMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<UpdateKnowledgeBaseMutation, TError, UpdateKnowledgeBaseMutationVariables, TContext>) => {
-
+    
     return useMutation<UpdateKnowledgeBaseMutation, TError, UpdateKnowledgeBaseMutationVariables, TContext>(
       {
     mutationKey: ['updateKnowledgeBase'],
@@ -4817,7 +4817,7 @@ export const useUpdateKnowledgeBaseDocumentChunkMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<UpdateKnowledgeBaseDocumentChunkMutation, TError, UpdateKnowledgeBaseDocumentChunkMutationVariables, TContext>) => {
-
+    
     return useMutation<UpdateKnowledgeBaseDocumentChunkMutation, TError, UpdateKnowledgeBaseDocumentChunkMutationVariables, TContext>(
       {
     mutationKey: ['updateKnowledgeBaseDocumentChunk'],
@@ -4836,7 +4836,7 @@ export const useUpdateKnowledgeBaseDocumentTagsMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<UpdateKnowledgeBaseDocumentTagsMutation, TError, UpdateKnowledgeBaseDocumentTagsMutationVariables, TContext>) => {
-
+    
     return useMutation<UpdateKnowledgeBaseDocumentTagsMutation, TError, UpdateKnowledgeBaseDocumentTagsMutationVariables, TContext>(
       {
     mutationKey: ['updateKnowledgeBaseDocumentTags'],
@@ -4855,7 +4855,7 @@ export const useUpdateKnowledgeBaseTagsMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<UpdateKnowledgeBaseTagsMutation, TError, UpdateKnowledgeBaseTagsMutationVariables, TContext>) => {
-
+    
     return useMutation<UpdateKnowledgeBaseTagsMutation, TError, UpdateKnowledgeBaseTagsMutationVariables, TContext>(
       {
     mutationKey: ['updateKnowledgeBaseTags'],
@@ -4896,7 +4896,7 @@ export const useAutomationSearchQuery = <
       variables: AutomationSearchQueryVariables,
       options?: Omit<UseQueryOptions<AutomationSearchQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<AutomationSearchQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<AutomationSearchQuery, TError, TData>(
       {
     queryKey: ['automationSearch', variables],
@@ -4921,7 +4921,7 @@ export const useAutomationWorkflowProjectCategoriesQuery = <
       variables?: AutomationWorkflowProjectCategoriesQueryVariables,
       options?: Omit<UseQueryOptions<AutomationWorkflowProjectCategoriesQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<AutomationWorkflowProjectCategoriesQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<AutomationWorkflowProjectCategoriesQuery, TError, TData>(
       {
     queryKey: variables === undefined ? ['automationWorkflowProjectCategories'] : ['automationWorkflowProjectCategories', variables],
@@ -4946,7 +4946,7 @@ export const useAutomationWorkflowProjectTagsQuery = <
       variables?: AutomationWorkflowProjectTagsQueryVariables,
       options?: Omit<UseQueryOptions<AutomationWorkflowProjectTagsQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<AutomationWorkflowProjectTagsQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<AutomationWorkflowProjectTagsQuery, TError, TData>(
       {
     queryKey: variables === undefined ? ['automationWorkflowProjectTags'] : ['automationWorkflowProjectTags', variables],
@@ -4972,7 +4972,7 @@ export const useAutomationWorkflowProjectVersionsQuery = <
       variables: AutomationWorkflowProjectVersionsQueryVariables,
       options?: Omit<UseQueryOptions<AutomationWorkflowProjectVersionsQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<AutomationWorkflowProjectVersionsQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<AutomationWorkflowProjectVersionsQuery, TError, TData>(
       {
     queryKey: ['automationWorkflowProjectVersions', variables],
@@ -5019,7 +5019,7 @@ export const useAutomationWorkflowProjectsQuery = <
       variables?: AutomationWorkflowProjectsQueryVariables,
       options?: Omit<UseQueryOptions<AutomationWorkflowProjectsQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<AutomationWorkflowProjectsQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<AutomationWorkflowProjectsQuery, TError, TData>(
       {
     queryKey: variables === undefined ? ['automationWorkflowProjects'] : ['automationWorkflowProjects', variables],
@@ -5043,7 +5043,7 @@ export const useCreateAutomationWorkflowProjectMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<CreateAutomationWorkflowProjectMutation, TError, CreateAutomationWorkflowProjectMutationVariables, TContext>) => {
-
+    
     return useMutation<CreateAutomationWorkflowProjectMutation, TError, CreateAutomationWorkflowProjectMutationVariables, TContext>(
       {
     mutationKey: ['createAutomationWorkflowProject'],
@@ -5068,7 +5068,7 @@ export const useUpdateAutomationWorkflowProjectMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<UpdateAutomationWorkflowProjectMutation, TError, UpdateAutomationWorkflowProjectMutationVariables, TContext>) => {
-
+    
     return useMutation<UpdateAutomationWorkflowProjectMutation, TError, UpdateAutomationWorkflowProjectMutationVariables, TContext>(
       {
     mutationKey: ['updateAutomationWorkflowProject'],
@@ -5087,7 +5087,7 @@ export const useDeleteAutomationWorkflowProjectMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<DeleteAutomationWorkflowProjectMutation, TError, DeleteAutomationWorkflowProjectMutationVariables, TContext>) => {
-
+    
     return useMutation<DeleteAutomationWorkflowProjectMutation, TError, DeleteAutomationWorkflowProjectMutationVariables, TContext>(
       {
     mutationKey: ['deleteAutomationWorkflowProject'],
@@ -5109,7 +5109,7 @@ export const useCreateAutomationWorkflowProjectWorkflowMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<CreateAutomationWorkflowProjectWorkflowMutation, TError, CreateAutomationWorkflowProjectWorkflowMutationVariables, TContext>) => {
-
+    
     return useMutation<CreateAutomationWorkflowProjectWorkflowMutation, TError, CreateAutomationWorkflowProjectWorkflowMutationVariables, TContext>(
       {
     mutationKey: ['createAutomationWorkflowProjectWorkflow'],
@@ -5128,7 +5128,7 @@ export const useDeleteAutomationWorkflowProjectWorkflowMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<DeleteAutomationWorkflowProjectWorkflowMutation, TError, DeleteAutomationWorkflowProjectWorkflowMutationVariables, TContext>) => {
-
+    
     return useMutation<DeleteAutomationWorkflowProjectWorkflowMutation, TError, DeleteAutomationWorkflowProjectWorkflowMutationVariables, TContext>(
       {
     mutationKey: ['deleteAutomationWorkflowProjectWorkflow'],
@@ -5147,7 +5147,7 @@ export const usePublishAutomationWorkflowProjectMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<PublishAutomationWorkflowProjectMutation, TError, PublishAutomationWorkflowProjectMutationVariables, TContext>) => {
-
+    
     return useMutation<PublishAutomationWorkflowProjectMutation, TError, PublishAutomationWorkflowProjectMutationVariables, TContext>(
       {
     mutationKey: ['publishAutomationWorkflowProject'],
@@ -5183,7 +5183,7 @@ export const useConnectedUserMcpServersQuery = <
       variables: ConnectedUserMcpServersQueryVariables,
       options?: Omit<UseQueryOptions<ConnectedUserMcpServersQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<ConnectedUserMcpServersQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<ConnectedUserMcpServersQuery, TError, TData>(
       {
     queryKey: ['connectedUserMcpServers', variables],
@@ -5237,7 +5237,7 @@ export const useConnectedUserProjectsQuery = <
       variables?: ConnectedUserProjectsQueryVariables,
       options?: Omit<UseQueryOptions<ConnectedUserProjectsQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<ConnectedUserProjectsQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<ConnectedUserProjectsQuery, TError, TData>(
       {
     queryKey: variables === undefined ? ['connectedUserProjects'] : ['connectedUserProjects', variables],
@@ -5262,7 +5262,7 @@ export const useCreateEmbeddedMcpServerMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<CreateEmbeddedMcpServerMutation, TError, CreateEmbeddedMcpServerMutationVariables, TContext>) => {
-
+    
     return useMutation<CreateEmbeddedMcpServerMutation, TError, CreateEmbeddedMcpServerMutationVariables, TContext>(
       {
     mutationKey: ['createEmbeddedMcpServer'],
@@ -5285,7 +5285,7 @@ export const useCreateMcpIntegrationInstanceConfigurationMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<CreateMcpIntegrationInstanceConfigurationMutation, TError, CreateMcpIntegrationInstanceConfigurationMutationVariables, TContext>) => {
-
+    
     return useMutation<CreateMcpIntegrationInstanceConfigurationMutation, TError, CreateMcpIntegrationInstanceConfigurationMutationVariables, TContext>(
       {
     mutationKey: ['createMcpIntegrationInstanceConfiguration'],
@@ -5307,7 +5307,7 @@ export const useDeleteConnectedUserMcpServerMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<DeleteConnectedUserMcpServerMutation, TError, DeleteConnectedUserMcpServerMutationVariables, TContext>) => {
-
+    
     return useMutation<DeleteConnectedUserMcpServerMutation, TError, DeleteConnectedUserMcpServerMutationVariables, TContext>(
       {
     mutationKey: ['deleteConnectedUserMcpServer'],
@@ -5326,7 +5326,7 @@ export const useDeleteConnectedUserProjectWorkflowMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<DeleteConnectedUserProjectWorkflowMutation, TError, DeleteConnectedUserProjectWorkflowMutationVariables, TContext>) => {
-
+    
     return useMutation<DeleteConnectedUserProjectWorkflowMutation, TError, DeleteConnectedUserProjectWorkflowMutationVariables, TContext>(
       {
     mutationKey: ['deleteConnectedUserProjectWorkflow'],
@@ -5345,7 +5345,7 @@ export const useDeleteEmbeddedMcpServerMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<DeleteEmbeddedMcpServerMutation, TError, DeleteEmbeddedMcpServerMutationVariables, TContext>) => {
-
+    
     return useMutation<DeleteEmbeddedMcpServerMutation, TError, DeleteEmbeddedMcpServerMutationVariables, TContext>(
       {
     mutationKey: ['deleteEmbeddedMcpServer'],
@@ -5364,7 +5364,7 @@ export const useDeleteMcpIntegrationInstanceConfigurationMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<DeleteMcpIntegrationInstanceConfigurationMutation, TError, DeleteMcpIntegrationInstanceConfigurationMutationVariables, TContext>) => {
-
+    
     return useMutation<DeleteMcpIntegrationInstanceConfigurationMutation, TError, DeleteMcpIntegrationInstanceConfigurationMutationVariables, TContext>(
       {
     mutationKey: ['deleteMcpIntegrationInstanceConfiguration'],
@@ -5383,7 +5383,7 @@ export const useDeleteMcpIntegrationInstanceConfigurationWorkflowMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<DeleteMcpIntegrationInstanceConfigurationWorkflowMutation, TError, DeleteMcpIntegrationInstanceConfigurationWorkflowMutationVariables, TContext>) => {
-
+    
     return useMutation<DeleteMcpIntegrationInstanceConfigurationWorkflowMutation, TError, DeleteMcpIntegrationInstanceConfigurationWorkflowMutationVariables, TContext>(
       {
     mutationKey: ['deleteMcpIntegrationInstanceConfigurationWorkflow'],
@@ -5402,7 +5402,7 @@ export const useDuplicateAutomationWorkflowProjectMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<DuplicateAutomationWorkflowProjectMutation, TError, DuplicateAutomationWorkflowProjectMutationVariables, TContext>) => {
-
+    
     return useMutation<DuplicateAutomationWorkflowProjectMutation, TError, DuplicateAutomationWorkflowProjectMutationVariables, TContext>(
       {
     mutationKey: ['duplicateAutomationWorkflowProject'],
@@ -5421,7 +5421,7 @@ export const useDuplicateAutomationWorkflowProjectWorkflowMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<DuplicateAutomationWorkflowProjectWorkflowMutation, TError, DuplicateAutomationWorkflowProjectWorkflowMutationVariables, TContext>) => {
-
+    
     return useMutation<DuplicateAutomationWorkflowProjectWorkflowMutation, TError, DuplicateAutomationWorkflowProjectWorkflowMutationVariables, TContext>(
       {
     mutationKey: ['duplicateAutomationWorkflowProjectWorkflow'],
@@ -5471,7 +5471,7 @@ export const useEmbeddedMcpServersQuery = <
       variables?: EmbeddedMcpServersQueryVariables,
       options?: Omit<UseQueryOptions<EmbeddedMcpServersQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<EmbeddedMcpServersQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<EmbeddedMcpServersQuery, TError, TData>(
       {
     queryKey: variables === undefined ? ['embeddedMcpServers'] : ['embeddedMcpServers', variables],
@@ -5494,7 +5494,7 @@ export const useEnableConnectedUserMcpServerMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<EnableConnectedUserMcpServerMutation, TError, EnableConnectedUserMcpServerMutationVariables, TContext>) => {
-
+    
     return useMutation<EnableConnectedUserMcpServerMutation, TError, EnableConnectedUserMcpServerMutationVariables, TContext>(
       {
     mutationKey: ['enableConnectedUserMcpServer'],
@@ -5513,7 +5513,7 @@ export const useEnableConnectedUserMcpToolMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<EnableConnectedUserMcpToolMutation, TError, EnableConnectedUserMcpToolMutationVariables, TContext>) => {
-
+    
     return useMutation<EnableConnectedUserMcpToolMutation, TError, EnableConnectedUserMcpToolMutationVariables, TContext>(
       {
     mutationKey: ['enableConnectedUserMcpTool'],
@@ -5532,7 +5532,7 @@ export const useEnableConnectedUserProjectWorkflowMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<EnableConnectedUserProjectWorkflowMutation, TError, EnableConnectedUserProjectWorkflowMutationVariables, TContext>) => {
-
+    
     return useMutation<EnableConnectedUserProjectWorkflowMutation, TError, EnableConnectedUserProjectWorkflowMutationVariables, TContext>(
       {
     mutationKey: ['enableConnectedUserProjectWorkflow'],
@@ -5566,7 +5566,7 @@ export const useIntegrationWorkflowsQuery = <
       variables?: IntegrationWorkflowsQueryVariables,
       options?: Omit<UseQueryOptions<IntegrationWorkflowsQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<IntegrationWorkflowsQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<IntegrationWorkflowsQuery, TError, TData>(
       {
     queryKey: variables === undefined ? ['integrationWorkflows'] : ['integrationWorkflows', variables],
@@ -5600,7 +5600,7 @@ export const useIntegrationWorkflowsByIntegrationIdQuery = <
       variables: IntegrationWorkflowsByIntegrationIdQueryVariables,
       options?: Omit<UseQueryOptions<IntegrationWorkflowsByIntegrationIdQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<IntegrationWorkflowsByIntegrationIdQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<IntegrationWorkflowsByIntegrationIdQuery, TError, TData>(
       {
     queryKey: ['integrationWorkflowsByIntegrationId', variables],
@@ -5629,7 +5629,7 @@ export const useMcpComponentDefinitionsQuery = <
       variables?: McpComponentDefinitionsQueryVariables,
       options?: Omit<UseQueryOptions<McpComponentDefinitionsQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<McpComponentDefinitionsQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<McpComponentDefinitionsQuery, TError, TData>(
       {
     queryKey: variables === undefined ? ['mcpComponentDefinitions'] : ['mcpComponentDefinitions', variables],
@@ -5698,7 +5698,7 @@ export const useMcpIntegrationInstanceConfigurationWorkflowPropertiesQuery = <
       variables: McpIntegrationInstanceConfigurationWorkflowPropertiesQueryVariables,
       options?: Omit<UseQueryOptions<McpIntegrationInstanceConfigurationWorkflowPropertiesQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<McpIntegrationInstanceConfigurationWorkflowPropertiesQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<McpIntegrationInstanceConfigurationWorkflowPropertiesQuery, TError, TData>(
       {
     queryKey: ['mcpIntegrationInstanceConfigurationWorkflowProperties', variables],
@@ -5733,7 +5733,7 @@ export const useMcpIntegrationInstanceConfigurationsQuery = <
       variables?: McpIntegrationInstanceConfigurationsQueryVariables,
       options?: Omit<UseQueryOptions<McpIntegrationInstanceConfigurationsQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<McpIntegrationInstanceConfigurationsQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<McpIntegrationInstanceConfigurationsQuery, TError, TData>(
       {
     queryKey: variables === undefined ? ['mcpIntegrationInstanceConfigurations'] : ['mcpIntegrationInstanceConfigurations', variables],
@@ -5790,7 +5790,7 @@ export const useMcpIntegrationInstanceConfigurationsByServerIdQuery = <
       variables?: McpIntegrationInstanceConfigurationsByServerIdQueryVariables,
       options?: Omit<UseQueryOptions<McpIntegrationInstanceConfigurationsByServerIdQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<McpIntegrationInstanceConfigurationsByServerIdQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<McpIntegrationInstanceConfigurationsByServerIdQuery, TError, TData>(
       {
     queryKey: variables === undefined ? ['mcpIntegrationInstanceConfigurationsByServerId'] : ['mcpIntegrationInstanceConfigurationsByServerId', variables],
@@ -5818,7 +5818,7 @@ export const useToolEligibleIntegrationInstanceConfigurationWorkflowsQuery = <
       variables: ToolEligibleIntegrationInstanceConfigurationWorkflowsQueryVariables,
       options?: Omit<UseQueryOptions<ToolEligibleIntegrationInstanceConfigurationWorkflowsQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<ToolEligibleIntegrationInstanceConfigurationWorkflowsQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<ToolEligibleIntegrationInstanceConfigurationWorkflowsQuery, TError, TData>(
       {
     queryKey: ['toolEligibleIntegrationInstanceConfigurationWorkflows', variables],
@@ -5847,7 +5847,7 @@ export const useToolEligibleIntegrationVersionWorkflowsQuery = <
       variables: ToolEligibleIntegrationVersionWorkflowsQueryVariables,
       options?: Omit<UseQueryOptions<ToolEligibleIntegrationVersionWorkflowsQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<ToolEligibleIntegrationVersionWorkflowsQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<ToolEligibleIntegrationVersionWorkflowsQuery, TError, TData>(
       {
     queryKey: ['toolEligibleIntegrationVersionWorkflows', variables],
@@ -5870,7 +5870,7 @@ export const useUpdateMcpIntegrationInstanceConfigurationMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<UpdateMcpIntegrationInstanceConfigurationMutation, TError, UpdateMcpIntegrationInstanceConfigurationMutationVariables, TContext>) => {
-
+    
     return useMutation<UpdateMcpIntegrationInstanceConfigurationMutation, TError, UpdateMcpIntegrationInstanceConfigurationMutationVariables, TContext>(
       {
     mutationKey: ['updateMcpIntegrationInstanceConfiguration'],
@@ -5889,7 +5889,7 @@ export const useUpdateMcpIntegrationInstanceConfigurationVersionMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<UpdateMcpIntegrationInstanceConfigurationVersionMutation, TError, UpdateMcpIntegrationInstanceConfigurationVersionMutationVariables, TContext>) => {
-
+    
     return useMutation<UpdateMcpIntegrationInstanceConfigurationVersionMutation, TError, UpdateMcpIntegrationInstanceConfigurationVersionMutationVariables, TContext>(
       {
     mutationKey: ['updateMcpIntegrationInstanceConfigurationVersion'],
@@ -5913,7 +5913,7 @@ export const useUpdateMcpIntegrationInstanceConfigurationWorkflowMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<UpdateMcpIntegrationInstanceConfigurationWorkflowMutation, TError, UpdateMcpIntegrationInstanceConfigurationWorkflowMutationVariables, TContext>) => {
-
+    
     return useMutation<UpdateMcpIntegrationInstanceConfigurationWorkflowMutation, TError, UpdateMcpIntegrationInstanceConfigurationWorkflowMutationVariables, TContext>(
       {
     mutationKey: ['updateMcpIntegrationInstanceConfigurationWorkflow'],
@@ -5938,7 +5938,7 @@ export const useAiDefaultModelQuery = <
       variables: AiDefaultModelQueryVariables,
       options?: Omit<UseQueryOptions<AiDefaultModelQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<AiDefaultModelQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<AiDefaultModelQuery, TError, TData>(
       {
     queryKey: ['aiDefaultModel', variables],
@@ -5970,7 +5970,7 @@ export const useAiProviderCatalogQuery = <
       variables: AiProviderCatalogQueryVariables,
       options?: Omit<UseQueryOptions<AiProviderCatalogQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<AiProviderCatalogQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<AiProviderCatalogQuery, TError, TData>(
       {
     queryKey: ['aiProviderCatalog', variables],
@@ -6014,7 +6014,7 @@ export const useApiConnectorQuery = <
       variables: ApiConnectorQueryVariables,
       options?: Omit<UseQueryOptions<ApiConnectorQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<ApiConnectorQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<ApiConnectorQuery, TError, TData>(
       {
     queryKey: ['apiConnector', variables],
@@ -6058,7 +6058,7 @@ export const useApiConnectorsQuery = <
       variables?: ApiConnectorsQueryVariables,
       options?: Omit<UseQueryOptions<ApiConnectorsQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<ApiConnectorsQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<ApiConnectorsQuery, TError, TData>(
       {
     queryKey: variables === undefined ? ['apiConnectors'] : ['apiConnectors', variables],
@@ -6077,7 +6077,7 @@ export const useCancelGenerationJobMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<CancelGenerationJobMutation, TError, CancelGenerationJobMutationVariables, TContext>) => {
-
+    
     return useMutation<CancelGenerationJobMutation, TError, CancelGenerationJobMutationVariables, TContext>(
       {
     mutationKey: ['cancelGenerationJob'],
@@ -6118,7 +6118,7 @@ export const useCreateApiConnectorMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<CreateApiConnectorMutation, TError, CreateApiConnectorMutationVariables, TContext>) => {
-
+    
     return useMutation<CreateApiConnectorMutation, TError, CreateApiConnectorMutationVariables, TContext>(
       {
     mutationKey: ['createApiConnector'],
@@ -6137,7 +6137,7 @@ export const useDeleteApiConnectorMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<DeleteApiConnectorMutation, TError, DeleteApiConnectorMutationVariables, TContext>) => {
-
+    
     return useMutation<DeleteApiConnectorMutation, TError, DeleteApiConnectorMutationVariables, TContext>(
       {
     mutationKey: ['deleteApiConnector'],
@@ -6156,7 +6156,7 @@ export const useEnableApiConnectorMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<EnableApiConnectorMutation, TError, EnableApiConnectorMutationVariables, TContext>) => {
-
+    
     return useMutation<EnableApiConnectorMutation, TError, EnableApiConnectorMutationVariables, TContext>(
       {
     mutationKey: ['enableApiConnector'],
@@ -6177,7 +6177,7 @@ export const useGenerateSpecificationMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<GenerateSpecificationMutation, TError, GenerateSpecificationMutationVariables, TContext>) => {
-
+    
     return useMutation<GenerateSpecificationMutation, TError, GenerateSpecificationMutationVariables, TContext>(
       {
     mutationKey: ['generateSpecification'],
@@ -6204,7 +6204,7 @@ export const useGenerationJobStatusQuery = <
       variables: GenerationJobStatusQueryVariables,
       options?: Omit<UseQueryOptions<GenerationJobStatusQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<GenerationJobStatusQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<GenerationJobStatusQuery, TError, TData>(
       {
     queryKey: ['generationJobStatus', variables],
@@ -6245,7 +6245,7 @@ export const useImportOpenApiSpecificationMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<ImportOpenApiSpecificationMutation, TError, ImportOpenApiSpecificationMutationVariables, TContext>) => {
-
+    
     return useMutation<ImportOpenApiSpecificationMutation, TError, ImportOpenApiSpecificationMutationVariables, TContext>(
       {
     mutationKey: ['importOpenApiSpecification'],
@@ -6269,7 +6269,7 @@ export const useStartGenerateFromDocumentationPreviewMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<StartGenerateFromDocumentationPreviewMutation, TError, StartGenerateFromDocumentationPreviewMutationVariables, TContext>) => {
-
+    
     return useMutation<StartGenerateFromDocumentationPreviewMutation, TError, StartGenerateFromDocumentationPreviewMutationVariables, TContext>(
       {
     mutationKey: ['startGenerateFromDocumentationPreview'],
@@ -6310,7 +6310,7 @@ export const useUpdateApiConnectorMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<UpdateApiConnectorMutation, TError, UpdateApiConnectorMutationVariables, TContext>) => {
-
+    
     return useMutation<UpdateApiConnectorMutation, TError, UpdateApiConnectorMutationVariables, TContext>(
       {
     mutationKey: ['updateApiConnector'],
@@ -6350,7 +6350,7 @@ export const useEditorJobFileLogsQuery = <
       variables: EditorJobFileLogsQueryVariables,
       options?: Omit<UseQueryOptions<EditorJobFileLogsQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<EditorJobFileLogsQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<EditorJobFileLogsQuery, TError, TData>(
       {
     queryKey: ['editorJobFileLogs', variables],
@@ -6372,7 +6372,7 @@ export const useEditorJobFileLogsExistQuery = <
       variables: EditorJobFileLogsExistQueryVariables,
       options?: Omit<UseQueryOptions<EditorJobFileLogsExistQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<EditorJobFileLogsExistQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<EditorJobFileLogsExistQuery, TError, TData>(
       {
     queryKey: ['editorJobFileLogsExist', variables],
@@ -6404,7 +6404,7 @@ export const useEditorTaskExecutionFileLogsQuery = <
       variables: EditorTaskExecutionFileLogsQueryVariables,
       options?: Omit<UseQueryOptions<EditorTaskExecutionFileLogsQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<EditorTaskExecutionFileLogsQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<EditorTaskExecutionFileLogsQuery, TError, TData>(
       {
     queryKey: ['editorTaskExecutionFileLogs', variables],
@@ -6444,7 +6444,7 @@ export const useJobFileLogsQuery = <
       variables: JobFileLogsQueryVariables,
       options?: Omit<UseQueryOptions<JobFileLogsQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<JobFileLogsQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<JobFileLogsQuery, TError, TData>(
       {
     queryKey: ['jobFileLogs', variables],
@@ -6466,7 +6466,7 @@ export const useJobFileLogsExistQuery = <
       variables: JobFileLogsExistQueryVariables,
       options?: Omit<UseQueryOptions<JobFileLogsExistQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<JobFileLogsExistQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<JobFileLogsExistQuery, TError, TData>(
       {
     queryKey: ['jobFileLogsExist', variables],
@@ -6498,7 +6498,7 @@ export const useTaskExecutionFileLogsQuery = <
       variables: TaskExecutionFileLogsQueryVariables,
       options?: Omit<UseQueryOptions<TaskExecutionFileLogsQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<TaskExecutionFileLogsQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<TaskExecutionFileLogsQuery, TError, TData>(
       {
     queryKey: ['taskExecutionFileLogs', variables],
@@ -6529,7 +6529,7 @@ export const useAdminApiKeysQuery = <
       variables: AdminApiKeysQueryVariables,
       options?: Omit<UseQueryOptions<AdminApiKeysQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<AdminApiKeysQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<AdminApiKeysQuery, TError, TData>(
       {
     queryKey: ['adminApiKeys', variables],
@@ -6560,7 +6560,7 @@ export const useApiKeysQuery = <
       variables: ApiKeysQueryVariables,
       options?: Omit<UseQueryOptions<ApiKeysQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<ApiKeysQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<ApiKeysQuery, TError, TData>(
       {
     queryKey: ['apiKeys', variables],
@@ -6593,7 +6593,7 @@ export const useClusterElementComponentConnectionsQuery = <
       variables: ClusterElementComponentConnectionsQueryVariables,
       options?: Omit<UseQueryOptions<ClusterElementComponentConnectionsQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<ClusterElementComponentConnectionsQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<ClusterElementComponentConnectionsQuery, TError, TData>(
       {
     queryKey: ['clusterElementComponentConnections', variables],
@@ -6925,7 +6925,7 @@ export const useClusterElementDefinitionQuery = <
       variables: ClusterElementDefinitionQueryVariables,
       options?: Omit<UseQueryOptions<ClusterElementDefinitionQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<ClusterElementDefinitionQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<ClusterElementDefinitionQuery, TError, TData>(
       {
     queryKey: ['clusterElementDefinition', variables],
@@ -6952,7 +6952,7 @@ export const useClusterElementMissingRequiredPropertiesQuery = <
       variables: ClusterElementMissingRequiredPropertiesQueryVariables,
       options?: Omit<UseQueryOptions<ClusterElementMissingRequiredPropertiesQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<ClusterElementMissingRequiredPropertiesQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<ClusterElementMissingRequiredPropertiesQuery, TError, TData>(
       {
     queryKey: ['ClusterElementMissingRequiredProperties', variables],
@@ -7254,7 +7254,7 @@ export const useClusterElementDynamicPropertiesQuery = <
       variables: ClusterElementDynamicPropertiesQueryVariables,
       options?: Omit<UseQueryOptions<ClusterElementDynamicPropertiesQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<ClusterElementDynamicPropertiesQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<ClusterElementDynamicPropertiesQuery, TError, TData>(
       {
     queryKey: ['clusterElementDynamicProperties', variables],
@@ -7288,7 +7288,7 @@ export const useClusterElementOptionsQuery = <
       variables: ClusterElementOptionsQueryVariables,
       options?: Omit<UseQueryOptions<ClusterElementOptionsQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<ClusterElementOptionsQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<ClusterElementOptionsQuery, TError, TData>(
       {
     queryKey: ['clusterElementOptions', variables],
@@ -7316,7 +7316,7 @@ export const useClusterElementScriptInputQuery = <
       variables: ClusterElementScriptInputQueryVariables,
       options?: Omit<UseQueryOptions<ClusterElementScriptInputQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<ClusterElementScriptInputQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<ClusterElementScriptInputQuery, TError, TData>(
       {
     queryKey: ['clusterElementScriptInput', variables],
@@ -7367,7 +7367,7 @@ export const useComponentDefinitionSearchQuery = <
       variables: ComponentDefinitionSearchQueryVariables,
       options?: Omit<UseQueryOptions<ComponentDefinitionSearchQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<ComponentDefinitionSearchQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<ComponentDefinitionSearchQuery, TError, TData>(
       {
     queryKey: ['ComponentDefinitionSearch', variables],
@@ -7386,7 +7386,7 @@ export const useCreateApiKeyMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<CreateApiKeyMutation, TError, CreateApiKeyMutationVariables, TContext>) => {
-
+    
     return useMutation<CreateApiKeyMutation, TError, CreateApiKeyMutationVariables, TContext>(
       {
     mutationKey: ['createApiKey'],
@@ -7412,7 +7412,7 @@ export const useCreateMcpComponentMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<CreateMcpComponentMutation, TError, CreateMcpComponentMutationVariables, TContext>) => {
-
+    
     return useMutation<CreateMcpComponentMutation, TError, CreateMcpComponentMutationVariables, TContext>(
       {
     mutationKey: ['createMcpComponent'],
@@ -7443,7 +7443,7 @@ export const useCreateMcpComponentWithToolsMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<CreateMcpComponentWithToolsMutation, TError, CreateMcpComponentWithToolsMutationVariables, TContext>) => {
-
+    
     return useMutation<CreateMcpComponentWithToolsMutation, TError, CreateMcpComponentWithToolsMutationVariables, TContext>(
       {
     mutationKey: ['createMcpComponentWithTools'],
@@ -7467,7 +7467,7 @@ export const useCreateMcpToolMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<CreateMcpToolMutation, TError, CreateMcpToolMutationVariables, TContext>) => {
-
+    
     return useMutation<CreateMcpToolMutation, TError, CreateMcpToolMutationVariables, TContext>(
       {
     mutationKey: ['createMcpTool'],
@@ -7486,7 +7486,7 @@ export const useDeleteApiKeyMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<DeleteApiKeyMutation, TError, DeleteApiKeyMutationVariables, TContext>) => {
-
+    
     return useMutation<DeleteApiKeyMutation, TError, DeleteApiKeyMutationVariables, TContext>(
       {
     mutationKey: ['deleteApiKey'],
@@ -7505,7 +7505,7 @@ export const useDeleteMcpComponentMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<DeleteMcpComponentMutation, TError, DeleteMcpComponentMutationVariables, TContext>) => {
-
+    
     return useMutation<DeleteMcpComponentMutation, TError, DeleteMcpComponentMutationVariables, TContext>(
       {
     mutationKey: ['deleteMcpComponent'],
@@ -7524,7 +7524,7 @@ export const useDeleteMcpToolMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<DeleteMcpToolMutation, TError, DeleteMcpToolMutationVariables, TContext>) => {
-
+    
     return useMutation<DeleteMcpToolMutation, TError, DeleteMcpToolMutationVariables, TContext>(
       {
     mutationKey: ['deleteMcpTool'],
@@ -7549,7 +7549,7 @@ export const useEnvironmentsQuery = <
       variables?: EnvironmentsQueryVariables,
       options?: Omit<UseQueryOptions<EnvironmentsQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<EnvironmentsQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<EnvironmentsQuery, TError, TData>(
       {
     queryKey: variables === undefined ? ['environments'] : ['environments', variables],
@@ -7571,7 +7571,7 @@ export const useManagementMcpServerUrlQuery = <
       variables?: ManagementMcpServerUrlQueryVariables,
       options?: Omit<UseQueryOptions<ManagementMcpServerUrlQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<ManagementMcpServerUrlQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<ManagementMcpServerUrlQuery, TError, TData>(
       {
     queryKey: variables === undefined ? ['managementMcpServerUrl'] : ['managementMcpServerUrl', variables],
@@ -7610,7 +7610,7 @@ export const useMcpComponentsByServerIdQuery = <
       variables: McpComponentsByServerIdQueryVariables,
       options?: Omit<UseQueryOptions<McpComponentsByServerIdQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<McpComponentsByServerIdQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<McpComponentsByServerIdQuery, TError, TData>(
       {
     queryKey: ['mcpComponentsByServerId', variables],
@@ -7635,7 +7635,7 @@ export const useMcpServerTagsQuery = <
       variables: McpServerTagsQueryVariables,
       options?: Omit<UseQueryOptions<McpServerTagsQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<McpServerTagsQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<McpServerTagsQuery, TError, TData>(
       {
     queryKey: ['mcpServerTags', variables],
@@ -7676,7 +7676,7 @@ export const useMcpServersQuery = <
       variables: McpServersQueryVariables,
       options?: Omit<UseQueryOptions<McpServersQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<McpServersQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<McpServersQuery, TError, TData>(
       {
     queryKey: ['mcpServers', variables],
@@ -7705,7 +7705,7 @@ export const useMcpToolsByComponentIdQuery = <
       variables: McpToolsByComponentIdQueryVariables,
       options?: Omit<UseQueryOptions<McpToolsByComponentIdQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<McpToolsByComponentIdQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<McpToolsByComponentIdQuery, TError, TData>(
       {
     queryKey: ['mcpToolsByComponentId', variables],
@@ -7732,7 +7732,7 @@ export const useSaveClusterElementTestConfigurationConnectionMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<SaveClusterElementTestConfigurationConnectionMutation, TError, SaveClusterElementTestConfigurationConnectionMutationVariables, TContext>) => {
-
+    
     return useMutation<SaveClusterElementTestConfigurationConnectionMutation, TError, SaveClusterElementTestConfigurationConnectionMutationVariables, TContext>(
       {
     mutationKey: ['saveClusterElementTestConfigurationConnection'],
@@ -7762,7 +7762,7 @@ export const useSaveClusterElementTestOutputMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<SaveClusterElementTestOutputMutation, TError, SaveClusterElementTestOutputMutationVariables, TContext>) => {
-
+    
     return useMutation<SaveClusterElementTestOutputMutation, TError, SaveClusterElementTestOutputMutationVariables, TContext>(
       {
     mutationKey: ['saveClusterElementTestOutput'],
@@ -7787,7 +7787,7 @@ export const useSaveWorkflowTestConfigurationConnectionMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<SaveWorkflowTestConfigurationConnectionMutation, TError, SaveWorkflowTestConfigurationConnectionMutationVariables, TContext>) => {
-
+    
     return useMutation<SaveWorkflowTestConfigurationConnectionMutation, TError, SaveWorkflowTestConfigurationConnectionMutationVariables, TContext>(
       {
     mutationKey: ['saveWorkflowTestConfigurationConnection'],
@@ -7819,7 +7819,7 @@ export const useTestClusterElementScriptMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<TestClusterElementScriptMutation, TError, TestClusterElementScriptMutationVariables, TContext>) => {
-
+    
     return useMutation<TestClusterElementScriptMutation, TError, TestClusterElementScriptMutationVariables, TContext>(
       {
     mutationKey: ['testClusterElementScript'],
@@ -7849,7 +7849,7 @@ export const useTestWorkflowNodeScriptMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<TestWorkflowNodeScriptMutation, TError, TestWorkflowNodeScriptMutationVariables, TContext>) => {
-
+    
     return useMutation<TestWorkflowNodeScriptMutation, TError, TestWorkflowNodeScriptMutationVariables, TContext>(
       {
     mutationKey: ['testWorkflowNodeScript'],
@@ -7868,7 +7868,7 @@ export const useUpdateApiKeyMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<UpdateApiKeyMutation, TError, UpdateApiKeyMutationVariables, TContext>) => {
-
+    
     return useMutation<UpdateApiKeyMutation, TError, UpdateApiKeyMutationVariables, TContext>(
       {
     mutationKey: ['updateApiKey'],
@@ -7887,7 +7887,7 @@ export const useUpdateManagementMcpServerUrlMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<UpdateManagementMcpServerUrlMutation, TError, UpdateManagementMcpServerUrlMutationVariables, TContext>) => {
-
+    
     return useMutation<UpdateManagementMcpServerUrlMutation, TError, UpdateManagementMcpServerUrlMutationVariables, TContext>(
       {
     mutationKey: ['updateManagementMcpServerUrl'],
@@ -7918,7 +7918,7 @@ export const useUpdateMcpComponentWithToolsMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<UpdateMcpComponentWithToolsMutation, TError, UpdateMcpComponentWithToolsMutationVariables, TContext>) => {
-
+    
     return useMutation<UpdateMcpComponentWithToolsMutation, TError, UpdateMcpComponentWithToolsMutationVariables, TContext>(
       {
     mutationKey: ['updateMcpComponentWithTools'],
@@ -7937,7 +7937,7 @@ export const useUpdateMcpServerUrlMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<UpdateMcpServerUrlMutation, TError, UpdateMcpServerUrlMutationVariables, TContext>) => {
-
+    
     return useMutation<UpdateMcpServerUrlMutation, TError, UpdateMcpServerUrlMutationVariables, TContext>(
       {
     mutationKey: ['updateMcpServerUrl'],
@@ -7962,7 +7962,7 @@ export const useUpdateMcpToolMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<UpdateMcpToolMutation, TError, UpdateMcpToolMutationVariables, TContext>) => {
-
+    
     return useMutation<UpdateMcpToolMutation, TError, UpdateMcpToolMutationVariables, TContext>(
       {
     mutationKey: ['updateMcpTool'],
@@ -7987,7 +7987,7 @@ export const useValidateWorkflowQuery = <
       variables: ValidateWorkflowQueryVariables,
       options?: Omit<UseQueryOptions<ValidateWorkflowQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<ValidateWorkflowQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<ValidateWorkflowQuery, TError, TData>(
       {
     queryKey: ['ValidateWorkflow', variables],
@@ -8012,7 +8012,7 @@ export const useValidateWorkflowByIdQuery = <
       variables: ValidateWorkflowByIdQueryVariables,
       options?: Omit<UseQueryOptions<ValidateWorkflowByIdQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<ValidateWorkflowByIdQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<ValidateWorkflowByIdQuery, TError, TData>(
       {
     queryKey: ['ValidateWorkflowById', variables],
@@ -8043,7 +8043,7 @@ export const useWorkflowNodeComponentConnectionsQuery = <
       variables: WorkflowNodeComponentConnectionsQueryVariables,
       options?: Omit<UseQueryOptions<WorkflowNodeComponentConnectionsQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<WorkflowNodeComponentConnectionsQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<WorkflowNodeComponentConnectionsQuery, TError, TData>(
       {
     queryKey: ['workflowNodeComponentConnections', variables],
@@ -8068,7 +8068,7 @@ export const useWorkflowNodeMissingRequiredPropertiesQuery = <
       variables: WorkflowNodeMissingRequiredPropertiesQueryVariables,
       options?: Omit<UseQueryOptions<WorkflowNodeMissingRequiredPropertiesQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<WorkflowNodeMissingRequiredPropertiesQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<WorkflowNodeMissingRequiredPropertiesQuery, TError, TData>(
       {
     queryKey: ['WorkflowNodeMissingRequiredProperties', variables],
@@ -8094,7 +8094,7 @@ export const useWorkflowNodeScriptInputQuery = <
       variables: WorkflowNodeScriptInputQueryVariables,
       options?: Omit<UseQueryOptions<WorkflowNodeScriptInputQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<WorkflowNodeScriptInputQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<WorkflowNodeScriptInputQuery, TError, TData>(
       {
     queryKey: ['workflowNodeScriptInput', variables],
@@ -8130,7 +8130,7 @@ export const useCustomComponentQuery = <
       variables: CustomComponentQueryVariables,
       options?: Omit<UseQueryOptions<CustomComponentQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<CustomComponentQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<CustomComponentQuery, TError, TData>(
       {
     queryKey: ['customComponent', variables],
@@ -8163,7 +8163,7 @@ export const useCustomComponentDefinitionQuery = <
       variables: CustomComponentDefinitionQueryVariables,
       options?: Omit<UseQueryOptions<CustomComponentDefinitionQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<CustomComponentDefinitionQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<CustomComponentDefinitionQuery, TError, TData>(
       {
     queryKey: ['customComponentDefinition', variables],
@@ -8199,7 +8199,7 @@ export const useCustomComponentsQuery = <
       variables?: CustomComponentsQueryVariables,
       options?: Omit<UseQueryOptions<CustomComponentsQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<CustomComponentsQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<CustomComponentsQuery, TError, TData>(
       {
     queryKey: variables === undefined ? ['customComponents'] : ['customComponents', variables],
@@ -8218,7 +8218,7 @@ export const useDeleteCustomComponentMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<DeleteCustomComponentMutation, TError, DeleteCustomComponentMutationVariables, TContext>) => {
-
+    
     return useMutation<DeleteCustomComponentMutation, TError, DeleteCustomComponentMutationVariables, TContext>(
       {
     mutationKey: ['deleteCustomComponent'],
@@ -8237,7 +8237,7 @@ export const useEnableCustomComponentMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<EnableCustomComponentMutation, TError, EnableCustomComponentMutationVariables, TContext>) => {
-
+    
     return useMutation<EnableCustomComponentMutation, TError, EnableCustomComponentMutationVariables, TContext>(
       {
     mutationKey: ['enableCustomComponent'],
@@ -8259,7 +8259,7 @@ export const useAuthoritiesQuery = <
       variables?: AuthoritiesQueryVariables,
       options?: Omit<UseQueryOptions<AuthoritiesQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<AuthoritiesQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<AuthoritiesQuery, TError, TData>(
       {
     queryKey: variables === undefined ? ['authorities'] : ['authorities', variables],
@@ -8299,7 +8299,7 @@ export const useCreateIdentityProviderMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<CreateIdentityProviderMutation, TError, CreateIdentityProviderMutationVariables, TContext>) => {
-
+    
     return useMutation<CreateIdentityProviderMutation, TError, CreateIdentityProviderMutationVariables, TContext>(
       {
     mutationKey: ['createIdentityProvider'],
@@ -8318,7 +8318,7 @@ export const useDeleteIdentityProviderMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<DeleteIdentityProviderMutation, TError, DeleteIdentityProviderMutationVariables, TContext>) => {
-
+    
     return useMutation<DeleteIdentityProviderMutation, TError, DeleteIdentityProviderMutationVariables, TContext>(
       {
     mutationKey: ['deleteIdentityProvider'],
@@ -8337,7 +8337,7 @@ export const useDeleteUserMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<DeleteUserMutation, TError, DeleteUserMutationVariables, TContext>) => {
-
+    
     return useMutation<DeleteUserMutation, TError, DeleteUserMutationVariables, TContext>(
       {
     mutationKey: ['deleteUser'],
@@ -8380,7 +8380,7 @@ export const useIdentityProviderQuery = <
       variables: IdentityProviderQueryVariables,
       options?: Omit<UseQueryOptions<IdentityProviderQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<IdentityProviderQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<IdentityProviderQuery, TError, TData>(
       {
     queryKey: ['identityProvider', variables],
@@ -8423,7 +8423,7 @@ export const useIdentityProvidersQuery = <
       variables?: IdentityProvidersQueryVariables,
       options?: Omit<UseQueryOptions<IdentityProvidersQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<IdentityProvidersQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<IdentityProvidersQuery, TError, TData>(
       {
     queryKey: variables === undefined ? ['identityProviders'] : ['identityProviders', variables],
@@ -8442,7 +8442,7 @@ export const useInviteUserMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<InviteUserMutation, TError, InviteUserMutationVariables, TContext>) => {
-
+    
     return useMutation<InviteUserMutation, TError, InviteUserMutationVariables, TContext>(
       {
     mutationKey: ['inviteUser'],
@@ -8482,7 +8482,7 @@ export const useUpdateIdentityProviderMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<UpdateIdentityProviderMutation, TError, UpdateIdentityProviderMutationVariables, TContext>) => {
-
+    
     return useMutation<UpdateIdentityProviderMutation, TError, UpdateIdentityProviderMutationVariables, TContext>(
       {
     mutationKey: ['updateIdentityProvider'],
@@ -8509,7 +8509,7 @@ export const useUpdateUserMutation = <
       TError = unknown,
       TContext = unknown
     >(options?: UseMutationOptions<UpdateUserMutation, TError, UpdateUserMutationVariables, TContext>) => {
-
+    
     return useMutation<UpdateUserMutation, TError, UpdateUserMutationVariables, TContext>(
       {
     mutationKey: ['updateUser'],
@@ -8545,7 +8545,7 @@ export const useUsersQuery = <
       variables?: UsersQueryVariables,
       options?: Omit<UseQueryOptions<UsersQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<UsersQuery, TError, TData>['queryKey'] }
     ) => {
-
+    
     return useQuery<UsersQuery, TError, TData>(
       {
     queryKey: variables === undefined ? ['users'] : ['users', variables],

--- a/client/src/shared/middleware/graphql.ts
+++ b/client/src/shared/middleware/graphql.ts
@@ -1515,6 +1515,11 @@ export type EnvironmentsQueryVariables = Exact<{ [key: string]: never; }>;
 
 export type EnvironmentsQuery = { environments: Array<{ id: string, name: string } | null> | null };
 
+export type EvaluatorFunctionDefinitionsQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type EvaluatorFunctionDefinitionsQuery = { evaluatorFunctionDefinitions: Array<{ name: string, title: string, description: string, category: Types.EvaluatorFunctionCategory, returnType: Types.EvaluatorFunctionType, example: string, parameters: Array<{ name: string, description: string, type: Types.EvaluatorFunctionType, required: boolean }> }> };
+
 export type ManagementMcpServerUrlQueryVariables = Exact<{ [key: string]: never; }>;
 
 
@@ -7554,6 +7559,41 @@ export const useEnvironmentsQuery = <
       {
     queryKey: variables === undefined ? ['environments'] : ['environments', variables],
     queryFn: fetcher<EnvironmentsQuery, EnvironmentsQueryVariables>(EnvironmentsDocument, variables),
+    ...options
+  }
+    )};
+
+export const EvaluatorFunctionDefinitionsDocument = new TypedDocumentString(`
+    query evaluatorFunctionDefinitions {
+  evaluatorFunctionDefinitions {
+    name
+    title
+    description
+    category
+    returnType
+    example
+    parameters {
+      name
+      description
+      type
+      required
+    }
+  }
+}
+    `);
+
+export const useEvaluatorFunctionDefinitionsQuery = <
+      TData = EvaluatorFunctionDefinitionsQuery,
+      TError = unknown
+    >(
+      variables?: EvaluatorFunctionDefinitionsQueryVariables,
+      options?: Omit<UseQueryOptions<EvaluatorFunctionDefinitionsQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<EvaluatorFunctionDefinitionsQuery, TError, TData>['queryKey'] }
+    ) => {
+    
+    return useQuery<EvaluatorFunctionDefinitionsQuery, TError, TData>(
+      {
+    queryKey: variables === undefined ? ['evaluatorFunctionDefinitions'] : ['evaluatorFunctionDefinitions', variables],
+    queryFn: fetcher<EvaluatorFunctionDefinitionsQuery, EvaluatorFunctionDefinitionsQueryVariables>(EvaluatorFunctionDefinitionsDocument, variables),
     ...options
   }
     )};


### PR DESCRIPTION
Closes #2897.

> As a Workflow Developer I want a list of available functions shown in the pop-up when writing an
> expression inside the property input, so that I can more easily write expressions.

Adds function autocomplete to the property input in the workflow editor. Typing inside an expression
now offers the evaluator's functions in the suggestion popup, alongside the data pills that were
already there, with a signature tooltip while you fill in the arguments.

## What's in it

- **Function suggestions in the property input.** A `FunctionSuggestion` TipTap extension and
  suggestion list, driven by the evaluator's own function definitions — fetched through a new
  `evaluatorFunctionDefinitions` GraphQL query rather than a hardcoded client-side list, so the
  popup cannot drift from what the evaluator actually supports.
- **A signature tooltip** (`FunctionSignature.extension.ts`, `FunctionSignatureTooltip.tsx`) showing
  the parameters of the function being written.
- **`fromAi` in tool inputs.** Controlled tool inputs get a `fromAi` button, and `fromAi` appears in
  the function autocomplete for tool properties, with the function-mode placeholder reworded.

## Fixes made along the way

Each of these has a test:

- A bare `=` is no longer persisted for an empty formula field.
- The suggestion popup survives the editor content resyncing underneath it.
- A re-entrant update no longer orphans the function signature tooltip.
- The suggestion menu claims pointer events itself rather than relying on the tippy popper.

## Refactoring

- `buildPropertyMentionsContent` extracted into `propertyMentionDom`.
- The RICH_TEXT editor's prose classes narrowed to `prose-sm`.
- GraphQL client types regenerated to match the committed operations.

## Verification

Client-only — no server or docs changes.

- `npx vitest run src/pages/platform/workflow-editor/components/properties` — 62 test files, 699
  tests, all passing.
- `npm run typecheck` clean.
- `eslint` on the touched area clean, 0 warnings.

Nine new test files accompany the change, covering the suggestion utilities, the `fromAi` function
definition, the placeholder, the controlled expression value, the tooltip-orphan regression, and the
suggestion wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XSTbDf2Jj4aasRudEJDdTR
