### PR TITLE
3757 Document and tier the EE observability module

### DIFF
--- a/docs/content/docs/platform/use-bytechef/self-hosted/management/observability.mdx
+++ b/docs/content/docs/platform/use-bytechef/self-hosted/management/observability.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Observability"
 description: "Turn on OpenTelemetry traces, logs, and metrics - the exact properties, default OTLP endpoints, sampling, and collector wiring, grounded in the shipped configuration."
+ee: true
 ---
 
 ByteChef is built on the standard JVM observability triad - **traces, logs, and metrics** - over open protocols, so it wires into the stack you already operate. Nothing in the pipeline is ByteChef-specific: if your tooling speaks OTLP, you point ByteChef at it and you are done.

--- a/docs/content/docs/platform/use-bytechef/self-hosted/management/observability.mdx
+++ b/docs/content/docs/platform/use-bytechef/self-hosted/management/observability.mdx
@@ -113,6 +113,29 @@ traceable across every hop:
 - **JVM metrics follow OpenTelemetry naming**, so they line up with the rest of your telemetry rather
   than needing per-name translation.
 
+## What the EE module installs
+
+Everything above is standard Spring Boot - Actuator, Micrometer, Micrometer Tracing. The Enterprise
+`observability-config` module supplies the parts that make those signals OpenTelemetry-shaped and keep
+them correlated:
+
+- **The Logback OTLP appender.** `OpenTelemetryAppender.install(...)` runs at startup. This is what
+  puts log records onto the OTLP pipeline - the appender is not wired by autoconfiguration, so log
+  export depends on this bean existing.
+- **OpenTelemetry semantic conventions for meters.** Micrometer's default naming is replaced with the
+  OpenTelemetry conventions for HTTP server requests, CPU, memory, threads and class loading, so the
+  meters arrive under the names an OTLP backend expects rather than Micrometer's own.
+- **Trace context across thread pools.** A `ContextPropagatingTaskDecorator` carries the active trace
+  onto work handed to an executor, which is what keeps one trace whole when a request fans out to a
+  background thread.
+- **The `X-Trace-Id` response header.** A servlet filter copies the current trace id onto every HTTP
+  response.
+- **Request headers at DEBUG.** A second filter logs each request's incoming headers, which costs
+  nothing until you turn that logger up.
+
+Without the module the platform still starts and still serves metrics through Actuator; the signals
+are plainer, and log export does not happen at all.
+
 ## Actuator endpoints
 
 Observability also exposes the Spring Boot Actuator surface. Health probes are split into Kubernetes-friendly `liveness` and `readiness` groups. Note which endpoints are open:


### PR DESCRIPTION
## What

Two small fixes to `platform/use-bytechef/self-hosted/management/observability.mdx`.

**The page linked to a section that did not exist.** Line 16 pointed at
`#what-the-ee-module-installs`, so the one sentence distinguishing the Enterprise module
from the Spring Boot baseline led nowhere. The section is now written, from
`observability-config` itself:

- the Logback OTLP appender — `OpenTelemetryAppender.install(...)`, which is what puts log
  records onto the pipeline at all, since the appender is not wired by autoconfiguration
- OpenTelemetry semantic conventions replacing Micrometer's default meter naming for HTTP
  server requests, CPU, memory, threads and class loading
- a `ContextPropagatingTaskDecorator`, so a trace survives a thread-pool hop
- the `X-Trace-Id` response filter
- request-header logging at DEBUG

It also names what the three bullets in *What you get end to end* are actually produced by.

**The page was not marked Enterprise.** It carried no `ee` field, so it read as Community —
while `runtime-job.mdx`, the same tier, carries `ee: true`. The pipeline it documents is
installed by `observability-config`, which lives under `server/ee/` and will be disabled
without a licence once enforcement lands.

## Why it came up

Writing the marketing site's enterprise page, I could not tell from the docs whether OTLP
observability was a Community or an Enterprise capability, and inferred the wrong answer
twice: the module has no `@ConditionalOnEEVersion` and `server-app` compiles it in, which
reads as Community until you notice the package path.

## Note

The absent licence guard is real today — a Community deployment currently gets the OTLP
pipeline, because `server-app` compiles the module in and nothing switches it off. This PR
only makes the documentation match the intended tier; it does not add the guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FY2xBGVVRTyUbj7gRMg8iC