### PR TITLE
5590 client - Say so when there are no templates to import

### DIFF
--- a/client/sonar-project.properties
+++ b/client/sonar-project.properties
@@ -4,6 +4,7 @@ sonar.projectKey=bytechef_client
 sonar.projectName=client
 
 sonar.exclusions=**/node_modules/**,**/middleware/**
+sonar.coverage.exclusions=**/*.test.ts,**/*.test.tsx,**/*.spec.ts,**/*.spec.tsx
 sonar.javascript.lcov.reportPaths=./coverage/lcov.info
 sonar.sources=src/
 sonar.test.inclusions=**/*.spec.ts,**/*test.ts

--- a/client/src/pages/automation/templates/project-templates/ProjectTemplates.tsx
+++ b/client/src/pages/automation/templates/project-templates/ProjectTemplates.tsx
@@ -1,8 +1,10 @@
+import EmptyList from '@/components/EmptyList';
 import {Skeleton} from '@/components/ui/skeleton';
 import {TemplateCard} from '@/pages/automation/templates/components/TemplateCard';
 import TemplatesLayoutContainer from '@/pages/automation/templates/components/layout-container/TemplatesLayoutContainer';
 import {useTemplatesStore} from '@/pages/automation/templates/stores/useTemplatesStore';
 import {usePreBuiltProjectTemplatesQuery} from '@/shared/middleware/graphql';
+import {LayoutTemplateIcon} from 'lucide-react';
 import {useShallow} from 'zustand/react/shallow';
 
 const ProjectTemplates = () => {
@@ -18,21 +20,24 @@ const ProjectTemplates = () => {
         query,
     });
 
+    const filtered = !!category || !!query;
+    const hasTemplates = !!preBuiltProjectTemplates?.length;
+
     return (
         <TemplatesLayoutContainer searchPlaceholder="Search projects..." title="Explore Project Templates">
-            <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
-                {isLoading && (
-                    <>
-                        <Skeleton className="h-60 w-96" />
-                        <Skeleton className="h-60 w-96" />
-                        <Skeleton className="h-60 w-96" />
-                    </>
-                )}
+            {isLoading && (
+                <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+                    <Skeleton className="h-60 w-96" />
 
-                {!isLoading &&
-                    preBuiltProjectTemplates &&
-                    preBuiltProjectTemplates.length > 0 &&
-                    preBuiltProjectTemplates.map((template) => {
+                    <Skeleton className="h-60 w-96" />
+
+                    <Skeleton className="h-60 w-96" />
+                </div>
+            )}
+
+            {!isLoading && hasTemplates && (
+                <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+                    {preBuiltProjectTemplates!.map((template) => {
                         const icons = template!.components.flatMap((templateComponent) =>
                             templateComponent!.value.map((component) => component!.icon)
                         );
@@ -49,11 +54,20 @@ const ProjectTemplates = () => {
                             />
                         );
                     })}
+                </div>
+            )}
 
-                {!isLoading && !preBuiltProjectTemplates && (
-                    <span className="text-muted-foreground">No project templates found.</span>
-                )}
-            </div>
+            {!isLoading && !hasTemplates && (
+                <EmptyList
+                    icon={<LayoutTemplateIcon className="size-12 text-content-neutral-tertiary" />}
+                    message={
+                        filtered
+                            ? 'Try a different search term or category.'
+                            : 'There are no project templates available to import yet.'
+                    }
+                    title={filtered ? 'No matching project templates' : 'No project templates'}
+                />
+            )}
         </TemplatesLayoutContainer>
     );
 };

--- a/client/src/pages/automation/templates/project-templates/ProjectTemplates.tsx
+++ b/client/src/pages/automation/templates/project-templates/ProjectTemplates.tsx
@@ -21,7 +21,8 @@ const ProjectTemplates = () => {
     });
 
     const filtered = !!category || !!query;
-    const hasTemplates = !!preBuiltProjectTemplates?.length;
+    const projectTemplates = preBuiltProjectTemplates ?? [];
+    const hasTemplates = projectTemplates.length > 0;
 
     return (
         <TemplatesLayoutContainer searchPlaceholder="Search projects..." title="Explore Project Templates">
@@ -37,20 +38,21 @@ const ProjectTemplates = () => {
 
             {!isLoading && hasTemplates && (
                 <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
-                    {preBuiltProjectTemplates!.map((template) => {
-                        const icons = template!.components.flatMap((templateComponent) =>
-                            templateComponent!.value.map((component) => component!.icon)
-                        );
+                    {projectTemplates.map((template) => {
+                        const icons = template.components
+                            .flatMap((templateComponent) => templateComponent.value)
+                            .map((component) => component?.icon)
+                            .filter((icon): icon is string => icon != null);
 
                         return (
                             <TemplateCard
-                                authorName={template!.authorName}
-                                categories={template!.categories}
-                                description={template!.project!.description}
-                                icons={icons as string[]}
+                                authorName={template.authorName}
+                                categories={template.categories}
+                                description={template.project!.description}
+                                icons={icons}
                                 key={template.id}
-                                templateId={template!.id!}
-                                title={template!.project!.name}
+                                templateId={template.id!}
+                                title={template.project!.name}
                             />
                         );
                     })}

--- a/client/src/pages/automation/templates/project-templates/tests/ProjectTemplates.test.tsx
+++ b/client/src/pages/automation/templates/project-templates/tests/ProjectTemplates.test.tsx
@@ -1,0 +1,133 @@
+import {useTemplatesStore} from '@/pages/automation/templates/stores/useTemplatesStore';
+import {render, screen} from '@/shared/util/test-utils';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+
+import ProjectTemplates from '../ProjectTemplates';
+
+import type {PreBuiltProjectTemplatesQuery} from '@/shared/middleware/graphql';
+
+type ProjectTemplateType = PreBuiltProjectTemplatesQuery['preBuiltProjectTemplates'][number];
+type ProjectTemplateComponentType = ProjectTemplateType['components'][number]['value'][number];
+
+const hoisted = vi.hoisted(() => ({
+    hasData: true,
+    isLoading: false,
+    templates: [] as Array<unknown>,
+}));
+
+vi.mock('@/shared/middleware/graphql', () => ({
+    usePreBuiltProjectTemplatesQuery: () => ({
+        data: hoisted.hasData ? {preBuiltProjectTemplates: hoisted.templates} : undefined,
+        error: null,
+        isLoading: hoisted.isLoading,
+    }),
+}));
+
+vi.mock('@/pages/automation/templates/components/TemplateCard', () => ({
+    TemplateCard: ({icons, title}: {icons: Array<string>; title: string}) => (
+        <div data-icons={icons.join('|')} data-testid="template-card">
+            {title}
+        </div>
+    ),
+}));
+
+const makeComponent = (icon: string | null): ProjectTemplateComponentType => ({
+    connection: null,
+    icon,
+    name: 'component',
+    title: 'Component',
+    version: 1,
+});
+
+const makeTemplate = (overrides: Partial<ProjectTemplateType> = {}): ProjectTemplateType => ({
+    authorName: 'ByteChef',
+    categories: [],
+    components: [],
+    description: null,
+    id: 'template-1',
+    project: {description: 'Alpha description', name: 'Alpha Project'},
+    projectVersion: 1,
+    publicUrl: null,
+    workflows: [],
+    ...overrides,
+});
+
+describe('ProjectTemplates', () => {
+    beforeEach(() => {
+        hoisted.hasData = true;
+        hoisted.isLoading = false;
+        hoisted.templates = [];
+
+        useTemplatesStore.setState({category: undefined, query: undefined});
+    });
+
+    it('renders skeletons instead of an empty state while loading', () => {
+        hoisted.isLoading = true;
+
+        const {container} = render(<ProjectTemplates />);
+
+        expect(container.querySelectorAll('[data-slot="skeleton"]')).toHaveLength(3);
+        expect(screen.queryByText('No project templates')).not.toBeInTheDocument();
+    });
+
+    it('renders a card for every template', () => {
+        hoisted.templates = [
+            makeTemplate({id: 'template-1', project: {description: null, name: 'Alpha Project'}}),
+            makeTemplate({id: 'template-2', project: {description: null, name: 'Beta Project'}}),
+        ];
+
+        render(<ProjectTemplates />);
+
+        expect(screen.getAllByTestId('template-card')).toHaveLength(2);
+        expect(screen.getByText('Alpha Project')).toBeInTheDocument();
+        expect(screen.getByText('Beta Project')).toBeInTheDocument();
+        expect(screen.queryByText('No project templates')).not.toBeInTheDocument();
+    });
+
+    it('passes only non-null icons of every component to the card', () => {
+        hoisted.templates = [
+            makeTemplate({
+                components: [
+                    {key: 'first', value: [makeComponent('alpha.svg'), makeComponent(null)]},
+                    {key: 'second', value: [null, makeComponent('beta.svg')]},
+                ],
+            }),
+        ];
+
+        render(<ProjectTemplates />);
+
+        expect(screen.getByTestId('template-card')).toHaveAttribute('data-icons', 'alpha.svg|beta.svg');
+    });
+
+    it('says there is nothing to import when no template is returned', () => {
+        render(<ProjectTemplates />);
+
+        expect(screen.getByText('No project templates')).toBeInTheDocument();
+        expect(screen.getByText('There are no project templates available to import yet.')).toBeInTheDocument();
+    });
+
+    it('shows the empty state when the query resolves without data', () => {
+        hoisted.hasData = false;
+
+        render(<ProjectTemplates />);
+
+        expect(screen.getByText('No project templates')).toBeInTheDocument();
+    });
+
+    it('says nothing matched when a search query is active', () => {
+        useTemplatesStore.setState({query: 'nothing matches this'});
+
+        render(<ProjectTemplates />);
+
+        expect(screen.getByText('No matching project templates')).toBeInTheDocument();
+        expect(screen.getByText('Try a different search term or category.')).toBeInTheDocument();
+    });
+
+    it('says nothing matched when a category is selected', () => {
+        useTemplatesStore.setState({category: 'marketing'});
+
+        render(<ProjectTemplates />);
+
+        expect(screen.getByText('No matching project templates')).toBeInTheDocument();
+    });
+});

--- a/client/src/pages/automation/templates/workflow-templates/WorkflowTemplates.tsx
+++ b/client/src/pages/automation/templates/workflow-templates/WorkflowTemplates.tsx
@@ -1,8 +1,10 @@
+import EmptyList from '@/components/EmptyList';
 import {Skeleton} from '@/components/ui/skeleton';
 import {TemplateCard} from '@/pages/automation/templates/components/TemplateCard';
 import TemplatesLayoutContainer from '@/pages/automation/templates/components/layout-container/TemplatesLayoutContainer';
 import {useTemplatesStore} from '@/pages/automation/templates/stores/useTemplatesStore';
 import {usePreBuiltWorkflowTemplatesQuery} from '@/shared/middleware/graphql';
+import {LayoutTemplateIcon} from 'lucide-react';
 import {useShallow} from 'zustand/react/shallow';
 
 const WorkflowTemplates = () => {
@@ -18,19 +20,24 @@ const WorkflowTemplates = () => {
         query,
     });
 
+    const filtered = !!category || !!query;
+    const hasTemplates = !!preBuiltWorkflowTemplates?.length;
+
     return (
         <TemplatesLayoutContainer searchPlaceholder="Search workflows..." title="Explore Workflow Templates">
-            <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
-                {isLoading ? (
-                    <>
-                        <Skeleton className="h-60 w-96" />
+            {isLoading && (
+                <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+                    <Skeleton className="h-60 w-96" />
 
-                        <Skeleton className="h-60 w-96" />
+                    <Skeleton className="h-60 w-96" />
 
-                        <Skeleton className="h-60 w-96" />
-                    </>
-                ) : preBuiltWorkflowTemplates && preBuiltWorkflowTemplates.length > 0 ? (
-                    preBuiltWorkflowTemplates.map((template) => {
+                    <Skeleton className="h-60 w-96" />
+                </div>
+            )}
+
+            {!isLoading && hasTemplates && (
+                <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+                    {preBuiltWorkflowTemplates!.map((template) => {
                         const icons = template.components.map((component) => component!.icon);
 
                         return (
@@ -44,11 +51,21 @@ const WorkflowTemplates = () => {
                                 title={template.workflow.label}
                             />
                         );
-                    })
-                ) : (
-                    <div className="text-muted-foreground">No workflow templates found.</div>
-                )}
-            </div>
+                    })}
+                </div>
+            )}
+
+            {!isLoading && !hasTemplates && (
+                <EmptyList
+                    icon={<LayoutTemplateIcon className="size-12 text-content-neutral-tertiary" />}
+                    message={
+                        filtered
+                            ? 'Try a different search term or category.'
+                            : 'There are no workflow templates available to import yet.'
+                    }
+                    title={filtered ? 'No matching workflow templates' : 'No workflow templates'}
+                />
+            )}
         </TemplatesLayoutContainer>
     );
 };

--- a/client/src/pages/automation/templates/workflow-templates/WorkflowTemplates.tsx
+++ b/client/src/pages/automation/templates/workflow-templates/WorkflowTemplates.tsx
@@ -21,7 +21,8 @@ const WorkflowTemplates = () => {
     });
 
     const filtered = !!category || !!query;
-    const hasTemplates = !!preBuiltWorkflowTemplates?.length;
+    const workflowTemplates = preBuiltWorkflowTemplates ?? [];
+    const hasTemplates = workflowTemplates.length > 0;
 
     return (
         <TemplatesLayoutContainer searchPlaceholder="Search workflows..." title="Explore Workflow Templates">
@@ -37,15 +38,17 @@ const WorkflowTemplates = () => {
 
             {!isLoading && hasTemplates && (
                 <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
-                    {preBuiltWorkflowTemplates!.map((template) => {
-                        const icons = template.components.map((component) => component!.icon);
+                    {workflowTemplates.map((template) => {
+                        const icons = template.components
+                            .map((component) => component.icon)
+                            .filter((icon): icon is string => icon != null);
 
                         return (
                             <TemplateCard
                                 authorName={template.authorName}
                                 categories={template.categories}
                                 description={template.workflow.description}
-                                icons={icons as string[]}
+                                icons={icons}
                                 key={template.id}
                                 templateId={template.id!}
                                 title={template.workflow.label}

--- a/client/src/pages/automation/templates/workflow-templates/tests/WorkflowTemplates.test.tsx
+++ b/client/src/pages/automation/templates/workflow-templates/tests/WorkflowTemplates.test.tsx
@@ -1,0 +1,129 @@
+import {useTemplatesStore} from '@/pages/automation/templates/stores/useTemplatesStore';
+import {render, screen} from '@/shared/util/test-utils';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+
+import WorkflowTemplates from '../WorkflowTemplates';
+
+import type {PreBuiltWorkflowTemplatesQuery} from '@/shared/middleware/graphql';
+
+type WorkflowTemplateType = PreBuiltWorkflowTemplatesQuery['preBuiltWorkflowTemplates'][number];
+type WorkflowTemplateComponentType = WorkflowTemplateType['components'][number];
+
+const hoisted = vi.hoisted(() => ({
+    hasData: true,
+    isLoading: false,
+    templates: [] as Array<unknown>,
+}));
+
+vi.mock('@/shared/middleware/graphql', () => ({
+    usePreBuiltWorkflowTemplatesQuery: () => ({
+        data: hoisted.hasData ? {preBuiltWorkflowTemplates: hoisted.templates} : undefined,
+        error: null,
+        isLoading: hoisted.isLoading,
+    }),
+}));
+
+vi.mock('@/pages/automation/templates/components/TemplateCard', () => ({
+    TemplateCard: ({icons, title}: {icons: Array<string>; title: string}) => (
+        <div data-icons={icons.join('|')} data-testid="template-card">
+            {title}
+        </div>
+    ),
+}));
+
+const makeComponent = (icon: string | null): WorkflowTemplateComponentType => ({
+    connection: null,
+    icon,
+    name: 'component',
+    title: 'Component',
+    version: 1,
+});
+
+const makeTemplate = (overrides: Partial<WorkflowTemplateType> = {}): WorkflowTemplateType => ({
+    authorName: 'ByteChef',
+    categories: [],
+    components: [],
+    description: null,
+    id: 'template-1',
+    projectVersion: 1,
+    publicUrl: null,
+    workflow: {description: 'Alpha description', label: 'Alpha Workflow'},
+    ...overrides,
+});
+
+describe('WorkflowTemplates', () => {
+    beforeEach(() => {
+        hoisted.hasData = true;
+        hoisted.isLoading = false;
+        hoisted.templates = [];
+
+        useTemplatesStore.setState({category: undefined, query: undefined});
+    });
+
+    it('renders skeletons instead of an empty state while loading', () => {
+        hoisted.isLoading = true;
+
+        const {container} = render(<WorkflowTemplates />);
+
+        expect(container.querySelectorAll('[data-slot="skeleton"]')).toHaveLength(3);
+        expect(screen.queryByText('No workflow templates')).not.toBeInTheDocument();
+    });
+
+    it('renders a card for every template', () => {
+        hoisted.templates = [
+            makeTemplate({id: 'template-1', workflow: {description: null, label: 'Alpha Workflow'}}),
+            makeTemplate({id: 'template-2', workflow: {description: null, label: 'Beta Workflow'}}),
+        ];
+
+        render(<WorkflowTemplates />);
+
+        expect(screen.getAllByTestId('template-card')).toHaveLength(2);
+        expect(screen.getByText('Alpha Workflow')).toBeInTheDocument();
+        expect(screen.getByText('Beta Workflow')).toBeInTheDocument();
+        expect(screen.queryByText('No workflow templates')).not.toBeInTheDocument();
+    });
+
+    it('passes only non-null icons to the card', () => {
+        hoisted.templates = [
+            makeTemplate({
+                components: [makeComponent('alpha.svg'), makeComponent(null), makeComponent('beta.svg')],
+            }),
+        ];
+
+        render(<WorkflowTemplates />);
+
+        expect(screen.getByTestId('template-card')).toHaveAttribute('data-icons', 'alpha.svg|beta.svg');
+    });
+
+    it('says there is nothing to import when no template is returned', () => {
+        render(<WorkflowTemplates />);
+
+        expect(screen.getByText('No workflow templates')).toBeInTheDocument();
+        expect(screen.getByText('There are no workflow templates available to import yet.')).toBeInTheDocument();
+    });
+
+    it('shows the empty state when the query resolves without data', () => {
+        hoisted.hasData = false;
+
+        render(<WorkflowTemplates />);
+
+        expect(screen.getByText('No workflow templates')).toBeInTheDocument();
+    });
+
+    it('says nothing matched when a search query is active', () => {
+        useTemplatesStore.setState({query: 'nothing matches this'});
+
+        render(<WorkflowTemplates />);
+
+        expect(screen.getByText('No matching workflow templates')).toBeInTheDocument();
+        expect(screen.getByText('Try a different search term or category.')).toBeInTheDocument();
+    });
+
+    it('says nothing matched when a category is selected', () => {
+        useTemplatesStore.setState({category: 'marketing'});
+
+        render(<WorkflowTemplates />);
+
+        expect(screen.getByText('No matching workflow templates')).toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
An empty result set left the project templates page completely blank. The
empty-state branch tested the array for existence rather than for contents,
and GraphQL returns an empty array rather than null, so the card branch and
the message branch both fell through and nothing rendered at all.

Both pages now key off the length, and the message uses the shared EmptyList
so it sits centred under the heading instead of in the first grid cell. An
active search or category filter gets its own wording, since "nothing here
yet" and "nothing matched" are different things to tell someone.
