### PR TITLE
3757 Mark formula function autocomplete coming soon on the Data Pills page

### DIFF
--- a/docs/content/docs/platform/automation/build/workflows/data-pills.mdx
+++ b/docs/content/docs/platform/automation/build/workflows/data-pills.mdx
@@ -91,11 +91,14 @@ start the field with an equals sign (`=`) to enter **formula mode**. The leading
 In formula mode you can:
 
 - Reference data pills inside the expression, e.g. `=concat(${trigger_1.body.firstName}, ' ', ${trigger_1.body.lastName})`.
-- Call built-in functions. As you type a function name, an autocomplete list and a signature tooltip
-  appear to guide you.
+- Call built-in functions, e.g. `=length(${trigger_1.body.title})`.
 
-The autocomplete offers the full set of functions as you type. The complete catalog is grouped below
-by category.
+The complete catalog of functions is grouped below by category.
+
+> **Coming soon.** Autocomplete in the formula editor - a suggestion list that narrows as you type a
+> function name, plus a signature tooltip naming the function's parameters - is on the upcoming
+> release track. In the latest released version you type function names yourself, so the catalog
+> below is the reference for what is available.
 
 #### String
 


### PR DESCRIPTION
## What

The **Formula (expression) mode** section of the Data Pills page promised an editor affordance the latest release does not have:

> Call built-in functions. As you type a function name, an autocomplete list and a signature tooltip appear to guide you.

followed by *"The autocomplete offers the full set of functions as you type."*

This wraps that claim in a **Coming soon** callout and repoints the surrounding prose at the function catalog.

## Why

The feature (#2897) shipped in two halves, and only one of them is released:

| Half | Status in `v0.31.4` (latest release, 2026-08-13) |
|---|---|
| Server: `EvaluatorFunctionDsl`, `EvaluatorFunctionDefinition`, `EvaluatorFunctionDefinitionGraphQlController` | **Released** |
| Client: `FunctionSuggestion.extension.ts`, `FunctionSuggestionList.tsx`, `functionSuggestionOptions.ts`, `useEvaluatorFunctionDefinitions.ts`, `evaluatorFunctionDefinitions.graphql` | **Absent** - merged to `master` today in #5581 |

Because the server half shipped, the **function catalog below the callout is accurate** and is left untouched. Only the suggestion list and signature tooltip were undelivered, which is why the page read as correct on a quick check.

Per the docs convention, pages track the **latest released version**, and "on master" is not "released" - so this stays coming-soon until v0.33 ships.

## Approach

Described in a Coming soon callout rather than deleted, matching how the Find Records filtering claims were handled on the Data Tables page in 453180ac2f2 (same ticket). Blockquote callout style, consistent with the sibling pages in this directory.

## Note on #3900

Checked in passing: the `ff-3900` gate is now removed on `master`, but the users pages correctly keep `comingSoon: true` because v0.31.4 still carries the gate. The invite dialog on master is still the pre-generated-password flow the docs describe, so **no change was needed there**.