### PR TITLE
4545 client - Remove the coloured icon from AI Skill list items

### DIFF
--- a/client/src/pages/automation/ai/skills/components/AiSkillListItem.tsx
+++ b/client/src/pages/automation/ai/skills/components/AiSkillListItem.tsx
@@ -11,7 +11,7 @@ import AiSkillDeleteAlertDialog from '@/pages/automation/ai/skills/components/Ai
 import AiSkillEditDialog from '@/pages/automation/ai/skills/components/AiSkillEditDialog';
 import useAiSkillListItem from '@/pages/automation/ai/skills/hooks/useAiSkillListItem';
 import {AiSkill} from '@/shared/middleware/graphql';
-import {DownloadIcon, EllipsisVerticalIcon, PencilIcon, TrashIcon, ZapIcon} from 'lucide-react';
+import {DownloadIcon, EllipsisVerticalIcon, PencilIcon, TrashIcon} from 'lucide-react';
 
 interface AiSkillListItemProps {
     deleteSkill: (id: string) => Promise<void>;
@@ -30,7 +30,6 @@ const AiSkillListItem = ({deleteSkill, onDownload, onUpdate, skill}: AiSkillList
         setShowEditDialog,
         showDeleteDialog,
         showEditDialog,
-        skillColor,
     } = useAiSkillListItem({deleteSkill, onDownload, onUpdate, skill});
 
     return (
@@ -39,20 +38,12 @@ const AiSkillListItem = ({deleteSkill, onDownload, onUpdate, skill}: AiSkillList
                 className="mb-2 flex cursor-pointer items-center justify-between gap-6 rounded border border-border/50 px-2 py-4 hover:bg-destructive-foreground"
                 onClick={handleClick}
             >
-                <div className="flex min-w-0 flex-1 items-center gap-3">
-                    <div className={`flex size-8 items-center justify-center rounded ${skillColor}`}>
-                        <ZapIcon className="size-4 text-white" />
-                    </div>
+                <div className="min-w-0 flex-1">
+                    <div className="text-sm font-semibold">{skill.name}</div>
 
-                    <div className="min-w-0 flex-1">
-                        <div className="text-sm font-semibold">{skill.name}</div>
-
-                        {skill.description && (
-                            <div className="line-clamp-1 text-xs text-content-neutral-secondary">
-                                {skill.description}
-                            </div>
-                        )}
-                    </div>
+                    {skill.description && (
+                        <div className="line-clamp-1 text-xs text-content-neutral-secondary">{skill.description}</div>
+                    )}
                 </div>
 
                 <div className="flex shrink-0 items-center gap-4">

--- a/client/src/pages/automation/ai/skills/components/AiSkillListItem.tsx
+++ b/client/src/pages/automation/ai/skills/components/AiSkillListItem.tsx
@@ -42,7 +42,9 @@ const AiSkillListItem = ({deleteSkill, onDownload, onUpdate, skill}: AiSkillList
                     <div className="text-sm font-semibold">{skill.name}</div>
 
                     {skill.description && (
-                        <div className="line-clamp-1 text-xs text-content-neutral-secondary">{skill.description}</div>
+                        <div className="mt-1 line-clamp-1 text-xs text-content-neutral-secondary">
+                            {skill.description}
+                        </div>
                     )}
                 </div>
 

--- a/client/src/pages/automation/ai/skills/hooks/useAiSkillListItem.ts
+++ b/client/src/pages/automation/ai/skills/hooks/useAiSkillListItem.ts
@@ -1,5 +1,4 @@
 import {useAiSkillsStore} from '@/pages/automation/ai/skills/stores/useAiSkillsStore';
-import getSkillColor from '@/pages/automation/ai/skills/utils/getSkillColor';
 import {AiSkill} from '@/shared/middleware/graphql';
 import {useCallback, useState} from 'react';
 import {useNavigate} from 'react-router-dom';
@@ -48,8 +47,6 @@ export default function useAiSkillListItem({deleteSkill, onDownload, onUpdate, s
         [onUpdate, skill.id]
     );
 
-    const skillColor = getSkillColor(skill.id);
-
     return {
         handleClick,
         handleDeleteClick,
@@ -59,6 +56,5 @@ export default function useAiSkillListItem({deleteSkill, onDownload, onUpdate, s
         setShowEditDialog,
         showDeleteDialog,
         showEditDialog,
-        skillColor,
     };
 }


### PR DESCRIPTION
## What

Removes the coloured square icon from each row of the **AI Skills** list.

Every row rendered a `size-8` rounded square holding a white `ZapIcon`, tinted by `getSkillColor(skill.id)`.

## Why

The colour is `hash(skill.id) % 6` against a fixed palette - it is not a category, a status, or anything the reader can act on. Two skills sharing a colour say nothing about each other, and every skill gets the same lightning glyph, so the icon carries no information the row does not already give. The name and description identify the row on their own.

## Changes

- `AiSkillListItem.tsx` - drop the icon block and the now-unused `ZapIcon` import. The left-hand flex wrapper was left holding a single child, so it collapses into the text block it wrapped; `min-w-0 flex-1` is preserved, so the description still truncates at `line-clamp-1` exactly as before.
- `useAiSkillListItem.ts` - `skillColor` was consumed only by that icon, so the hook stops computing and returning it.

`getSkillColor` itself **stays**: `AiSkillsLeftSidebar` still tints its own `size-5` markers with it. That sidebar is a separate surface and is out of scope here - say the word if you want it stripped too.

## Verification

| Gate | Result |
|---|---|
| `prettier --check` | pass |
| `eslint src --max-warnings=0` | pass |
| `tsc --project tsconfig.json --noEmit` | pass |

The full `vitest run --coverage` was **not** run: no test file references `AiSkillListItem` or `getSkillColor`, and the change is deletion-only with the three static gates green.