### PR TITLE
3900 client - Hide the invite Role dropdown and invite as admin in CE

### DIFF
--- a/client/sonar-project.properties
+++ b/client/sonar-project.properties
@@ -6,4 +6,4 @@ sonar.projectName=client
 sonar.exclusions=**/node_modules/**,**/middleware/**
 sonar.javascript.lcov.reportPaths=./coverage/lcov.info
 sonar.sources=src/
-sonar.test.inclusions=**/*.spec.ts,**/*test.ts
+sonar.test.inclusions=**/*.spec.ts,**/*.spec.tsx,**/*test.ts,**/*test.tsx

--- a/client/src/pages/settings/platform/users/components/InviteUserDialog.tsx
+++ b/client/src/pages/settings/platform/users/components/InviteUserDialog.tsx
@@ -27,6 +27,7 @@ const InviteUserDialog = () => {
         invitePassword,
         inviteRole,
         open,
+        roleSelectVisible,
     } = useInviteUserDialog();
 
     return (
@@ -73,23 +74,28 @@ const InviteUserDialog = () => {
                             </p>
                         </div>
 
-                        <div className="space-y-2">
-                            <label className="text-sm font-medium">Role</label>
+                        {roleSelectVisible && (
+                            <div className="space-y-2">
+                                <label className="text-sm font-medium">Role</label>
 
-                            <Select onValueChange={(value) => handleRoleChange(value)} value={inviteRole ?? undefined}>
-                                <SelectTrigger>
-                                    <SelectValue placeholder="Select role" />
-                                </SelectTrigger>
+                                <Select
+                                    onValueChange={(value) => handleRoleChange(value)}
+                                    value={inviteRole ?? undefined}
+                                >
+                                    <SelectTrigger>
+                                        <SelectValue placeholder="Select role" />
+                                    </SelectTrigger>
 
-                                <SelectContent>
-                                    {authorities.map((authority) => (
-                                        <SelectItem key={authority} value={authority}>
-                                            {authority}
-                                        </SelectItem>
-                                    ))}
-                                </SelectContent>
-                            </Select>
-                        </div>
+                                    <SelectContent>
+                                        {authorities.map((authority) => (
+                                            <SelectItem key={authority} value={authority}>
+                                                {authority}
+                                            </SelectItem>
+                                        ))}
+                                    </SelectContent>
+                                </Select>
+                            </div>
+                        )}
                     </div>
 
                     <DialogFooter>

--- a/client/src/pages/settings/platform/users/components/hooks/tests/useInviteUserDialog.test.tsx
+++ b/client/src/pages/settings/platform/users/components/hooks/tests/useInviteUserDialog.test.tsx
@@ -5,6 +5,7 @@ import useInviteUserDialog from '../useInviteUserDialog';
 
 const hoisted = vi.hoisted(() => {
     return {
+        application: {edition: 'EE'} as {edition: string} | null,
         inviteUserMutate: vi.fn(),
         storeState: {
             inviteEmail: '',
@@ -70,6 +71,12 @@ vi.mock('@/shared/middleware/graphql', () => ({
     })),
 }));
 
+vi.mock('@/shared/stores/useApplicationInfoStore', () => ({
+    EditionType: {CE: 'CE', EE: 'EE'},
+    useApplicationInfoStore: (selector: (state: Record<string, unknown>) => unknown) =>
+        selector({application: hoisted.application}),
+}));
+
 vi.mock('@tanstack/react-query', () => ({
     useQueryClient: vi.fn(() => ({
         invalidateQueries: vi.fn(),
@@ -83,6 +90,7 @@ describe('useInviteUserDialog', () => {
         hoisted.storeState.invitePassword = 'GeneratedPass1';
         hoisted.storeState.inviteRole = null;
         hoisted.storeState.open = false;
+        hoisted.application = {edition: 'EE'};
     });
 
     describe('initial state', () => {
@@ -181,6 +189,24 @@ describe('useInviteUserDialog', () => {
             });
         });
 
+        it('invites as admin with no selected role when edition is CE', () => {
+            hoisted.application = {edition: 'CE'};
+            hoisted.storeState.open = true;
+            hoisted.storeState.inviteEmail = 'newuser@test.com';
+            hoisted.storeState.inviteRole = null;
+            const {result} = renderHook(() => useInviteUserDialog());
+
+            act(() => {
+                result.current.handleInvite();
+            });
+
+            expect(hoisted.inviteUserMutate).toHaveBeenCalledWith({
+                email: 'newuser@test.com',
+                password: 'GeneratedPass1',
+                role: 'ROLE_ADMIN',
+            });
+        });
+
         it('closes dialog after successful invite', () => {
             hoisted.storeState.open = true;
             hoisted.storeState.inviteEmail = 'newuser@test.com';
@@ -194,6 +220,48 @@ describe('useInviteUserDialog', () => {
             rerender();
 
             expect(result.current.open).toBe(false);
+        });
+    });
+
+    describe('edition', () => {
+        it('shows the role select when edition is EE', () => {
+            hoisted.application = {edition: 'EE'};
+            const {result} = renderHook(() => useInviteUserDialog());
+
+            expect(result.current.roleSelectVisible).toBe(true);
+        });
+
+        it('hides the role select when edition is CE', () => {
+            hoisted.application = {edition: 'CE'};
+            const {result} = renderHook(() => useInviteUserDialog());
+
+            expect(result.current.roleSelectVisible).toBe(false);
+        });
+
+        it('shows the role select while the application info is still loading', () => {
+            hoisted.application = null;
+            const {result} = renderHook(() => useInviteUserDialog());
+
+            expect(result.current.roleSelectVisible).toBe(true);
+        });
+
+        it('does not require a role when edition is CE', () => {
+            hoisted.application = {edition: 'CE'};
+            hoisted.storeState.open = true;
+            hoisted.storeState.inviteEmail = 'newuser@test.com';
+            hoisted.storeState.inviteRole = null;
+            const {result} = renderHook(() => useInviteUserDialog());
+
+            expect(result.current.inviteDisabled).toBe(false);
+        });
+
+        it('still requires a role when edition is EE', () => {
+            hoisted.application = {edition: 'EE'};
+            hoisted.storeState.inviteEmail = 'newuser@test.com';
+            hoisted.storeState.inviteRole = null;
+            const {result} = renderHook(() => useInviteUserDialog());
+
+            expect(result.current.inviteDisabled).toBe(true);
         });
     });
 });

--- a/client/src/pages/settings/platform/users/components/hooks/useInviteUserDialog.ts
+++ b/client/src/pages/settings/platform/users/components/hooks/useInviteUserDialog.ts
@@ -1,6 +1,8 @@
 import {useInviteUserDialogStore} from '@/pages/settings/platform/users/stores/useInviteUserDialogStore';
 import {isValidPassword} from '@/pages/settings/platform/users/util/password-utils';
+import {AUTHORITIES} from '@/shared/constants';
 import {useAuthoritiesQuery, useInviteUserMutation} from '@/shared/middleware/graphql';
+import {EditionType, useApplicationInfoStore} from '@/shared/stores/useApplicationInfoStore';
 import {useQueryClient} from '@tanstack/react-query';
 import {useEffect, useMemo} from 'react';
 
@@ -18,6 +20,7 @@ interface UseInviteUserDialogI {
     invitePassword: string;
     inviteRole: string | null;
     open: boolean;
+    roleSelectVisible: boolean;
 }
 
 export default function useInviteUserDialog(): UseInviteUserDialogI {
@@ -33,6 +36,8 @@ export default function useInviteUserDialog(): UseInviteUserDialogI {
         setOpen,
     } = useInviteUserDialogStore();
 
+    const application = useApplicationInfoStore((state) => state.application);
+
     const {data: authoritiesData} = useAuthoritiesQuery({});
 
     const queryClient = useQueryClient();
@@ -45,13 +50,15 @@ export default function useInviteUserDialog(): UseInviteUserDialogI {
     });
 
     const authorities = useMemo(() => authoritiesData?.authorities ?? [], [authoritiesData]);
-    const inviteDisabled = !inviteEmail || !inviteRole || !isValidPassword(invitePassword);
+    const ceEdition = application?.edition === EditionType.CE;
+    const roleSelectVisible = !ceEdition;
+    const inviteDisabled = !inviteEmail || (roleSelectVisible && !inviteRole) || !isValidPassword(invitePassword);
 
     useEffect(() => {
-        if (open && !inviteRole && authorities.length > 0) {
+        if (roleSelectVisible && open && !inviteRole && authorities.length > 0) {
             setInviteRole(authorities[0]);
         }
-    }, [open, inviteRole, authorities, setInviteRole]);
+    }, [roleSelectVisible, open, inviteRole, authorities, setInviteRole]);
 
     const handleClose = () => {
         reset();
@@ -80,11 +87,13 @@ export default function useInviteUserDialog(): UseInviteUserDialogI {
     };
 
     const handleInvite = () => {
-        if (inviteEmail && inviteRole) {
+        const role = ceEdition ? AUTHORITIES.ADMIN : inviteRole;
+
+        if (inviteEmail && role) {
             inviteUserMutation.mutate({
                 email: inviteEmail,
                 password: invitePassword,
-                role: inviteRole,
+                role,
             });
         }
     };
@@ -103,5 +112,6 @@ export default function useInviteUserDialog(): UseInviteUserDialogI {
         invitePassword,
         inviteRole,
         open,
+        roleSelectVisible,
     };
 }

--- a/client/src/pages/settings/platform/users/components/tests/InviteUserDialog.test.tsx
+++ b/client/src/pages/settings/platform/users/components/tests/InviteUserDialog.test.tsx
@@ -31,6 +31,7 @@ const defaultMockReturn = {
     invitePassword: 'GeneratedPass1',
     inviteRole: 'ROLE_ADMIN',
     open: true,
+    roleSelectVisible: true,
 };
 
 beforeEach(() => {
@@ -154,6 +155,7 @@ describe('InviteUserDialog closed state', () => {
             invitePassword: 'GeneratedPass1',
             inviteRole: null,
             open: false,
+            roleSelectVisible: true,
         });
     });
 
@@ -179,6 +181,7 @@ describe('InviteUserDialog inviteDisabled state', () => {
             invitePassword: 'GeneratedPass1',
             inviteRole: 'ROLE_ADMIN',
             open: true,
+            roleSelectVisible: true,
         });
     });
 
@@ -188,5 +191,23 @@ describe('InviteUserDialog inviteDisabled state', () => {
         const inviteButton = screen.getByRole('button', {name: 'Invite'});
 
         expect(inviteButton).toBeDisabled();
+    });
+});
+
+describe('InviteUserDialog Community Edition', () => {
+    beforeEach(() => {
+        hoisted.mockUseInviteUserDialog.mockReturnValue({...defaultMockReturn, roleSelectVisible: false});
+    });
+
+    it('should not display Role label when the role select is hidden', () => {
+        renderInviteUserDialog();
+
+        expect(screen.queryByText('Role')).not.toBeInTheDocument();
+    });
+
+    it('should still display Email label when the role select is hidden', () => {
+        renderInviteUserDialog();
+
+        expect(screen.getByText('Email')).toBeInTheDocument();
     });
 });


### PR DESCRIPTION
## What

On the **Invite User** dialog, the **Role** dropdown is hidden in Community Edition and the invite is submitted as `AUTHORITIES.ADMIN`. EE is unchanged.

## The one judgment call worth reviewing

The gate is on **positively knowing the edition is CE**, not on "not EE":

```ts
const ceEdition = application?.edition === EditionType.CE;
const roleSelectVisible = !ceEdition;
```

`application` is fetched from `/actuator/info` after startup, so `useApplicationInfoStore` holds `application === null` until it resolves. Gating on `!== 'EE'` would make every pre-resolution render look like CE — and in EE that means the dropdown vanishes and the invite **silently grants `ROLE_ADMIN`**. That is the wrong direction to fail for a control that hands out admin.

Gating on `=== 'CE'` fails the other way: an unknown edition keeps the dropdown and keeps requiring an explicit role. Worst case is a dropdown that flickers in, which is the same behaviour `EnvironmentSelect` already has.

## Supporting changes

- `inviteDisabled` no longer demands a role when the dropdown is hidden — otherwise **Invite** could never enable in CE.
- The effect that seeds the first authority is skipped when the dropdown is hidden, for the same reason.

## Verification

| Gate | Result |
|---|---|
| `vitest run src/pages/settings/platform/users` | 13 files, **141 tests** pass |
| `prettier --check` | pass |
| `eslint src --max-warnings=0` | pass |
| `tsc --noEmit` | pass |

New coverage: CE, EE, and the still-loading (`application === null`) case; plus CE submitting `ROLE_ADMIN` with no role selected, and EE still requiring one.

Note: the existing `InviteUserDialog` component tests hand-build the hook's return value rather than mocking the module, so all three mock objects needed `roleSelectVisible`. One of them (`should display Role label`) caught the omission on the first run.

## Ticket

Filed under **3900** (User invitations) since that owns this dialog — say the word if you'd rather it sat under the RBAC umbrella (#1051) and I'll relabel.