### PR TITLE
5600 client - Move the environment selector into the app sidebar header

### DIFF
--- a/client/src/ee/pages/automation/api-platform/api-collections/ApiCollections.tsx
+++ b/client/src/ee/pages/automation/api-platform/api-collections/ApiCollections.tsx
@@ -8,7 +8,6 @@ import {useGetApiCollectionTagsQuery} from '@/ee/shared/mutations/automation/api
 import {useGetApiCollectionsQuery} from '@/ee/shared/mutations/automation/apiCollections.queries';
 import {useWorkspaceStore} from '@/pages/automation/stores/useWorkspaceStore';
 import {WorkflowReadOnlyProvider} from '@/pages/platform/workflow-editor/providers/workflowEditorProvider';
-import EnvironmentSelect from '@/shared/components/EnvironmentSelect';
 import ReadOnlyWorkflowSheet from '@/shared/components/read-only-workflow-editor/ReadOnlyWorkflowSheet';
 import Header from '@/shared/layout/Header';
 import LayoutContainer from '@/shared/layout/LayoutContainer';
@@ -77,14 +76,9 @@ const ApiCollections = () => {
                     centerTitle={true}
                     position="main"
                     right={
-                        apiCollections && apiCollections.length > 0 ? (
-                            <div className="flex items-center gap-4">
-                                <EnvironmentSelect />
-
-                                <ApiCollectionDialog triggerNode={<Button label="New API Collection" />} />
-                            </div>
-                        ) : (
-                            <EnvironmentSelect />
+                        apiCollections &&
+                        apiCollections.length > 0 && (
+                            <ApiCollectionDialog triggerNode={<Button label="New API Collection" />} />
                         )
                     }
                     title={

--- a/client/src/ee/pages/embedded/mcp-servers/McpServers.tsx
+++ b/client/src/ee/pages/embedded/mcp-servers/McpServers.tsx
@@ -1,7 +1,6 @@
 import Button from '@/components/Button/Button';
 import EmptyList from '@/components/EmptyList';
 import PageLoader from '@/components/PageLoader';
-import EnvironmentSelect from '@/shared/components/EnvironmentSelect';
 import Header from '@/shared/layout/Header';
 import LayoutContainer from '@/shared/layout/LayoutContainer';
 import {McpServer} from '@/shared/middleware/graphql';
@@ -42,17 +41,8 @@ const McpServers = () => {
                     centerTitle={true}
                     position="main"
                     right={
-                        validMcpServers.length > 0 ? (
-                            <div className="flex items-center gap-4">
-                                <EnvironmentSelect />
-
-                                <McpServerDialog
-                                    mcpServer={undefined}
-                                    triggerNode={<Button label="New MCP Server" />}
-                                />
-                            </div>
-                        ) : (
-                            !(mcpServersIsLoading || tagsIsLoading) && <EnvironmentSelect />
+                        validMcpServers.length > 0 && (
+                            <McpServerDialog mcpServer={undefined} triggerNode={<Button label="New MCP Server" />} />
                         )
                     }
                     title={

--- a/client/src/ee/pages/settings/platform/ai-providers/AiProviders.tsx
+++ b/client/src/ee/pages/settings/platform/ai-providers/AiProviders.tsx
@@ -1,7 +1,6 @@
 import PageLoader from '@/components/PageLoader';
 import AiProviderList from '@/ee/pages/settings/platform/ai-providers/components/AiProviderList';
 import {useGetAiProvidersQuery} from '@/ee/shared/queries/platform/aiProviders.queries';
-import EnvironmentSelect from '@/shared/components/EnvironmentSelect';
 import Header from '@/shared/layout/Header';
 import LayoutContainer from '@/shared/layout/LayoutContainer';
 import {useEnvironmentStore} from '@/shared/stores/useEnvironmentStore';
@@ -23,7 +22,6 @@ const AiProviders = () => {
                         centerTitle
                         description="Enable providers used by Universal AI Connectors"
                         position="main"
-                        right={<EnvironmentSelect />}
                         title="AI Providers"
                     />
                 }

--- a/client/src/ee/shared/components/api-keys/ApiKeysContent.tsx
+++ b/client/src/ee/shared/components/api-keys/ApiKeysContent.tsx
@@ -6,7 +6,6 @@ import ApiKeyDialog from '@/ee/shared/components/api-keys/components/ApiKeyDialo
 import ApiKeyTable from '@/ee/shared/components/api-keys/components/ApiKeyTable';
 import useApiKeys from '@/ee/shared/components/api-keys/hooks/useApiKeys';
 import {useApiKeysStore} from '@/ee/shared/components/api-keys/stores/useApiKeysStore';
-import EnvironmentSelect from '@/shared/components/EnvironmentSelect';
 import Header from '@/shared/layout/Header';
 import LayoutContainer from '@/shared/layout/LayoutContainer';
 import {KeyIcon} from 'lucide-react';
@@ -32,15 +31,7 @@ const ApiKeysContent = ({description, title}: {description: string; title: strin
                         description={description}
                         position="main"
                         right={
-                            apiKeys && apiKeys.length > 0 ? (
-                                <div className="flex items-center gap-4">
-                                    <EnvironmentSelect />
-
-                                    <ApiKeyDialog triggerNode={<Button>New API Key</Button>} />
-                                </div>
-                            ) : (
-                                <EnvironmentSelect />
-                            )
+                            apiKeys && apiKeys.length > 0 && <ApiKeyDialog triggerNode={<Button>New API Key</Button>} />
                         }
                         title={title}
                     />

--- a/client/src/pages/automation/approval-tasks/ApprovalTasks.tsx
+++ b/client/src/pages/automation/approval-tasks/ApprovalTasks.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import EnvironmentSelect from '@/shared/components/EnvironmentSelect';
 import Header from '@/shared/layout/Header';
 
 import ApprovalTaskDetail from './components/ApprovalTaskDetail';
@@ -15,7 +14,7 @@ export default function ApprovalTasks() {
             <ApprovalTaskList />
 
             <div className="flex h-full flex-1 flex-col">
-                <Header position="main" right={<EnvironmentSelect />} title="" />
+                <Header position="main" title="" />
 
                 <div className="min-h-0 flex-1 overflow-hidden">
                     <ApprovalTaskDetail />

--- a/client/src/pages/automation/chats/Chats.tsx
+++ b/client/src/pages/automation/chats/Chats.tsx
@@ -2,7 +2,6 @@ import Button from '@/components/Button/Button';
 import {Tooltip, TooltipContent, TooltipTrigger} from '@/components/ui/tooltip';
 import ChatsSidebar from '@/pages/automation/chats/components/ChatsSidebar';
 import {useChatsStore} from '@/pages/automation/chats/stores/useChatsStore';
-import EnvironmentSelect from '@/shared/components/EnvironmentSelect';
 import Header from '@/shared/layout/Header';
 import LayoutContainer from '@/shared/layout/LayoutContainer';
 import {MessageSquareIcon, MessageSquareXIcon} from 'lucide-react';
@@ -32,8 +31,6 @@ const Chats = () => {
                     position="main"
                     right={
                         <div className="flex items-center gap-4">
-                            <EnvironmentSelect />
-
                             {workflowExecutionId && (
                                 <Tooltip>
                                     <TooltipTrigger asChild>

--- a/client/src/pages/automation/connections/Connections.tsx
+++ b/client/src/pages/automation/connections/Connections.tsx
@@ -3,7 +3,6 @@ import EmptyList from '@/components/EmptyList';
 import PageLoader from '@/components/PageLoader';
 import ConnectionsFilterTitle from '@/pages/automation/connections/components/ConnectionsFilterTitle';
 import {useWorkspaceStore} from '@/pages/automation/stores/useWorkspaceStore';
-import EnvironmentSelect from '@/shared/components/EnvironmentSelect';
 import ConnectionDialog from '@/shared/components/connection/ConnectionDialog';
 import Header from '@/shared/layout/Header';
 import LayoutContainer from '@/shared/layout/LayoutContainer';
@@ -94,26 +93,22 @@ export const Connections = () => {
                     centerTitle={true}
                     position="main"
                     right={
-                        connections && connections.length > 0 && componentDefinitions ? (
-                            <div className="flex items-center gap-4">
-                                <EnvironmentSelect />
-
-                                <ConnectionDialog
-                                    componentDefinitions={componentDefinitions}
-                                    connection={
-                                        {
-                                            environmentId: currentEnvironmentId,
-                                        } as Connection
-                                    }
-                                    connectionTagsQueryKey={ConnectionKeys.connectionTags}
-                                    connectionsQueryKey={ConnectionKeys.connections}
-                                    triggerNode={<Button label="New Connection" />}
-                                    useCreateConnectionMutation={useCreateConnectionMutation}
-                                    useGetConnectionTagsQuery={useGetConnectionTagsQuery}
-                                />
-                            </div>
-                        ) : (
-                            !isAnyLoading && <EnvironmentSelect />
+                        connections &&
+                        connections.length > 0 &&
+                        componentDefinitions && (
+                            <ConnectionDialog
+                                componentDefinitions={componentDefinitions}
+                                connection={
+                                    {
+                                        environmentId: currentEnvironmentId,
+                                    } as Connection
+                                }
+                                connectionTagsQueryKey={ConnectionKeys.connectionTags}
+                                connectionsQueryKey={ConnectionKeys.connections}
+                                triggerNode={<Button label="New Connection" />}
+                                useCreateConnectionMutation={useCreateConnectionMutation}
+                                useGetConnectionTagsQuery={useGetConnectionTagsQuery}
+                            />
                         )
                     }
                     title={

--- a/client/src/pages/automation/datatables/DataTables.tsx
+++ b/client/src/pages/automation/datatables/DataTables.tsx
@@ -6,7 +6,6 @@ import DataTableList from '@/pages/automation/datatables/components/DataTableLis
 import DataTablesFilterTitle from '@/pages/automation/datatables/components/DataTablesFilterTitle';
 import DataTablesLeftSidebarNav from '@/pages/automation/datatables/components/DataTablesLeftSidebarNav';
 import useDataTables from '@/pages/automation/datatables/components/hooks/useDataTables';
-import EnvironmentSelect from '@/shared/components/EnvironmentSelect';
 import Header from '@/shared/layout/Header';
 import LayoutContainer from '@/shared/layout/LayoutContainer';
 import {Table2Icon} from 'lucide-react';
@@ -20,17 +19,7 @@ const DataTables = () => {
                 <Header
                     centerTitle={true}
                     position="main"
-                    right={
-                        tables.length > 0 ? (
-                            <div className="flex items-center gap-4">
-                                <EnvironmentSelect />
-
-                                <CreateDataTableDialog trigger={<Button>New Table</Button>} />
-                            </div>
-                        ) : (
-                            !isLoading && <EnvironmentSelect />
-                        )
-                    }
+                    right={tables.length > 0 && <CreateDataTableDialog trigger={<Button>New Table</Button>} />}
                     title={
                         tables.length > 0 ? (
                             <DataTablesFilterTitle allTags={allTags} tagsByTableData={tagsByTableData} />

--- a/client/src/pages/automation/knowledge-bases/KnowledgeBases.tsx
+++ b/client/src/pages/automation/knowledge-bases/KnowledgeBases.tsx
@@ -8,7 +8,6 @@ import KnowledgeBasesLeftSidebarNav from '@/pages/automation/knowledge-bases/com
 import useKnowledgeBases from '@/pages/automation/knowledge-bases/components/hooks/useKnowledgeBases';
 import KnowledgeBaseList from '@/pages/automation/knowledge-bases/components/knowledge-base-list/KnowledgeBaseList';
 import {useWorkspaceStore} from '@/pages/automation/stores/useWorkspaceStore';
-import EnvironmentSelect from '@/shared/components/EnvironmentSelect';
 import Header from '@/shared/layout/Header';
 import LayoutContainer from '@/shared/layout/LayoutContainer';
 import {useKnowledgeBaseEmbeddingActiveQuery} from '@/shared/middleware/graphql';
@@ -36,17 +35,11 @@ const KnowledgeBases = () => {
                     centerTitle={true}
                     position="main"
                     right={
-                        knowledgeBases.length > 0 ? (
-                            <div className="flex items-center gap-4">
-                                <EnvironmentSelect />
-
-                                <CreateKnowledgeBaseDialog
-                                    trigger={<Button>New Knowledge Base</Button>}
-                                    workspaceId={currentWorkspaceId}
-                                />
-                            </div>
-                        ) : (
-                            !isLoading && <EnvironmentSelect />
+                        knowledgeBases.length > 0 && (
+                            <CreateKnowledgeBaseDialog
+                                trigger={<Button>New Knowledge Base</Button>}
+                                workspaceId={currentWorkspaceId}
+                            />
                         )
                     }
                     title={

--- a/client/src/pages/automation/mcp-servers/McpServers.tsx
+++ b/client/src/pages/automation/mcp-servers/McpServers.tsx
@@ -1,7 +1,6 @@
 import Button from '@/components/Button/Button';
 import EmptyList from '@/components/EmptyList';
 import PageLoader from '@/components/PageLoader';
-import EnvironmentSelect from '@/shared/components/EnvironmentSelect';
 import Header from '@/shared/layout/Header';
 import LayoutContainer from '@/shared/layout/LayoutContainer';
 import {McpServer} from '@/shared/middleware/graphql';
@@ -43,17 +42,8 @@ const McpServers = () => {
                     centerTitle={true}
                     position="main"
                     right={
-                        validMcpServers.length > 0 ? (
-                            <div className="flex items-center gap-4">
-                                <EnvironmentSelect />
-
-                                <McpServerDialog
-                                    mcpServer={undefined}
-                                    triggerNode={<Button label="New MCP Server" />}
-                                />
-                            </div>
-                        ) : (
-                            !(mcpServersIsLoading || tagsIsLoading) && <EnvironmentSelect />
+                        validMcpServers.length > 0 && (
+                            <McpServerDialog mcpServer={undefined} triggerNode={<Button label="New MCP Server" />} />
                         )
                     }
                     title={

--- a/client/src/pages/automation/project-deployments/ProjectDeployments.tsx
+++ b/client/src/pages/automation/project-deployments/ProjectDeployments.tsx
@@ -5,7 +5,6 @@ import {Skeleton} from '@/components/ui/skeleton';
 import ProjectDeploymentFilterTitle from '@/pages/automation/project-deployments/components/ProjectDeploymentFilterTitle';
 import {useWorkspaceStore} from '@/pages/automation/stores/useWorkspaceStore';
 import {WorkflowReadOnlyProvider} from '@/pages/platform/workflow-editor/providers/workflowEditorProvider';
-import EnvironmentSelect from '@/shared/components/EnvironmentSelect';
 import ReadOnlyWorkflowSheet from '@/shared/components/read-only-workflow-editor/ReadOnlyWorkflowSheet';
 import Header from '@/shared/layout/Header';
 import LayoutContainer from '@/shared/layout/LayoutContainer';
@@ -125,25 +124,18 @@ const ProjectDeployments = () => {
                     centerTitle={true}
                     position="main"
                     right={
-                        projectDeployments && projectDeployments.length > 0 ? (
-                            <div className="flex items-center gap-4">
-                                <EnvironmentSelect />
-
-                                <ProjectDeploymentDialog
-                                    onSuccess={(deploymentId) => setNewlyCreatedDeploymentId(deploymentId)}
-                                    projectDeployment={
-                                        {
-                                            environmentId: currentEnvironmentId,
-                                        } as ProjectDeployment
-                                    }
-                                    redirectOnSubmit={false}
-                                    triggerNode={<Button label="New Deployment" />}
-                                />
-                            </div>
-                        ) : (
-                            !(projectsIsLoading || projectDeploymentsIsLoading || tagsIsLoading) && (
-                                <EnvironmentSelect />
-                            )
+                        projectDeployments &&
+                        projectDeployments.length > 0 && (
+                            <ProjectDeploymentDialog
+                                onSuccess={(deploymentId) => setNewlyCreatedDeploymentId(deploymentId)}
+                                projectDeployment={
+                                    {
+                                        environmentId: currentEnvironmentId,
+                                    } as ProjectDeployment
+                                }
+                                redirectOnSubmit={false}
+                                triggerNode={<Button label="New Deployment" />}
+                            />
                         )
                     }
                     title={

--- a/client/src/pages/automation/workflow-executions/WorkflowExecutions.tsx
+++ b/client/src/pages/automation/workflow-executions/WorkflowExecutions.tsx
@@ -8,7 +8,6 @@ import {Label} from '@/components/ui/label';
 import {Tooltip, TooltipContent, TooltipTrigger} from '@/components/ui/tooltip';
 import WorkflowExecutionsFilterTitle from '@/pages/automation/workflow-executions/components/WorkflowExecutionsFilterTitle';
 import {useWorkflowExecutions} from '@/pages/automation/workflow-executions/hooks/useWorkflowExecutions';
-import EnvironmentSelect from '@/shared/components/EnvironmentSelect';
 import Footer from '@/shared/layout/Footer';
 import Header from '@/shared/layout/Header';
 import LayoutContainer from '@/shared/layout/LayoutContainer';
@@ -127,8 +126,6 @@ export const WorkflowExecutions = () => {
 
                                 <TooltipContent>Refresh</TooltipContent>
                             </Tooltip>
-
-                            <EnvironmentSelect />
                         </div>
                     }
                     title={

--- a/client/src/shared/components/EnvironmentSelect.tsx
+++ b/client/src/shared/components/EnvironmentSelect.tsx
@@ -14,6 +14,7 @@ import {useApplicationInfoStore} from '@/shared/stores/useApplicationInfoStore';
 import {useEnvironmentStore} from '@/shared/stores/useEnvironmentStore';
 import {CheckIcon, ChevronDownIcon} from 'lucide-react';
 import {useMemo} from 'react';
+import {twMerge} from 'tailwind-merge';
 import {useShallow} from 'zustand/react/shallow';
 
 interface EnvironmentOptionI {
@@ -23,9 +24,10 @@ interface EnvironmentOptionI {
 
 interface EnvironmentSelectPropsI {
     onChange?: (environmentId: number) => void;
+    variant?: 'compact' | 'default' | 'icon';
 }
 
-const EnvironmentSelect = ({onChange}: EnvironmentSelectPropsI = {}) => {
+const EnvironmentSelect = ({onChange, variant = 'default'}: EnvironmentSelectPropsI = {}) => {
     const application = useApplicationInfoStore((state) => state.application);
 
     const {currentEnvironmentId, setCurrentEnvironmentId} = useEnvironmentStore(
@@ -68,21 +70,40 @@ const EnvironmentSelect = ({onChange}: EnvironmentSelectPropsI = {}) => {
     }
 
     const CurrentIcon = currentConfig.icon;
+    const isCompact = variant === 'compact';
+    const isIcon = variant === 'icon';
 
     return (
         <DropdownMenu>
             <Tooltip>
                 <TooltipTrigger asChild>
                     <DropdownMenuTrigger asChild>
-                        <Button className="h-auto gap-1 p-2" variant="ghost">
-                            <Badge
-                                icon={<CurrentIcon className="size-3" />}
-                                label={currentConfig.label}
-                                styleType={currentConfig.styleType}
-                                weight="semibold"
-                            />
+                        <Button
+                            aria-label={isIcon ? currentConfig.label : undefined}
+                            className={twMerge('h-auto gap-1 p-2', isCompact && 'px-1', isIcon && 'p-1')}
+                            variant="ghost"
+                        >
+                            {isIcon ? (
+                                <Badge
+                                    aria-label={currentConfig.label}
+                                    icon={<CurrentIcon className="size-3" />}
+                                    styleType={currentConfig.styleType}
+                                    weight="semibold"
+                                />
+                            ) : (
+                                <Badge
+                                    icon={<CurrentIcon className="size-3" />}
+                                    label={isCompact ? currentConfig.shortLabel : currentConfig.label}
+                                    styleType={currentConfig.styleType}
+                                    weight="semibold"
+                                />
+                            )}
 
-                            <ChevronDownIcon className="size-4 text-muted-foreground" />
+                            {!isIcon && (
+                                <ChevronDownIcon
+                                    className={twMerge('size-4 text-muted-foreground', isCompact && 'size-3')}
+                                />
+                            )}
                         </Button>
                     </DropdownMenuTrigger>
                 </TooltipTrigger>
@@ -90,7 +111,7 @@ const EnvironmentSelect = ({onChange}: EnvironmentSelectPropsI = {}) => {
                 <TooltipContent>{currentConfig.description}</TooltipContent>
             </Tooltip>
 
-            <DropdownMenuContent align="end" className="w-72">
+            <DropdownMenuContent align={isCompact || isIcon ? 'start' : 'end'} className="w-72">
                 <DropdownMenuRadioGroup
                     onValueChange={(value) => {
                         const nextEnvironmentId = +value;

--- a/client/src/shared/components/tests/EnvironmentSelect.test.tsx
+++ b/client/src/shared/components/tests/EnvironmentSelect.test.tsx
@@ -1,6 +1,6 @@
 import {TooltipProvider} from '@/components/ui/tooltip';
 import EnvironmentSelect from '@/shared/components/EnvironmentSelect';
-import {mockScrollIntoView, render, screen} from '@/shared/util/test-utils';
+import {mockScrollIntoView, render, screen, userEvent} from '@/shared/util/test-utils';
 import {MemoryRouter} from 'react-router-dom';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
 
@@ -38,11 +38,11 @@ vi.mock('@/shared/middleware/graphql', () => ({
     }),
 }));
 
-const renderEnvironmentSelect = () =>
+const renderEnvironmentSelect = (variant?: 'compact' | 'default' | 'icon') =>
     render(
         <MemoryRouter>
             <TooltipProvider>
-                <EnvironmentSelect />
+                <EnvironmentSelect variant={variant} />
             </TooltipProvider>
         </MemoryRouter>
     );
@@ -65,5 +65,29 @@ describe('EnvironmentSelect', () => {
         renderEnvironmentSelect();
 
         expect(screen.queryByText('DEVELOPMENT')).not.toBeInTheDocument();
+    });
+
+    it('should render the short label in the compact variant', () => {
+        renderEnvironmentSelect('compact');
+
+        expect(screen.getByText('DEV')).toBeInTheDocument();
+        expect(screen.queryByText('DEVELOPMENT')).not.toBeInTheDocument();
+    });
+
+    it('should drop the label entirely in the icon variant, keeping the name accessible', () => {
+        renderEnvironmentSelect('icon');
+
+        expect(screen.queryByText('DEV')).not.toBeInTheDocument();
+        expect(screen.queryByText('DEVELOPMENT')).not.toBeInTheDocument();
+        expect(screen.getByRole('button', {name: 'DEVELOPMENT'})).toBeInTheDocument();
+    });
+
+    it('should still offer the full label of every environment in the compact menu', async () => {
+        renderEnvironmentSelect('compact');
+
+        await userEvent.click(screen.getByRole('button'));
+
+        expect(await screen.findByText('STAGING')).toBeInTheDocument();
+        expect(screen.getByText('PRODUCTION')).toBeInTheDocument();
     });
 });

--- a/client/src/shared/constants/environmentConfigs.ts
+++ b/client/src/shared/constants/environmentConfigs.ts
@@ -5,6 +5,8 @@ export interface EnvironmentConfigI {
     description: string;
     icon: LucideIcon;
     label: string;
+    shortLabel: string;
+    sidebarTheme: 'development' | 'production' | 'staging';
     styleType: 'primary-outline' | 'secondary-outline' | 'warning-outline';
 }
 
@@ -13,18 +15,24 @@ export const ENVIRONMENT_CONFIGS: Record<number, EnvironmentConfigI> = {
         description: 'Features are unstable, experimental, and may change or break frequently.',
         icon: WrenchIcon,
         label: 'DEVELOPMENT',
+        shortLabel: 'DEV',
+        sidebarTheme: 'development',
         styleType: 'secondary-outline',
     },
     [PRODUCTION_ENVIRONMENT]: {
         description: 'Live environment used by real users. Optimized for performance with strict safeguards.',
         icon: BoxIcon,
         label: 'PRODUCTION',
+        shortLabel: 'PRD',
+        sidebarTheme: 'production',
         styleType: 'primary-outline',
     },
     [STAGING_ENVIRONMENT]: {
         description: 'Used for final testing, QA, and validation before release.',
         icon: FlaskConicalIcon,
         label: 'STAGING',
+        shortLabel: 'STG',
+        sidebarTheme: 'staging',
         styleType: 'warning-outline',
     },
 };

--- a/client/src/shared/layout/app-sidebar/AppSidebar.test.tsx
+++ b/client/src/shared/layout/app-sidebar/AppSidebar.test.tsx
@@ -2,13 +2,24 @@ import {SidebarProvider} from '@/components/ui/sidebar';
 import {render, screen} from '@/shared/util/test-utils';
 import {FolderIcon, MessagesSquareIcon} from 'lucide-react';
 import {MemoryRouter} from 'react-router-dom';
-import {describe, expect, it, vi} from 'vitest';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
 
 import {AppSidebar} from './AppSidebar';
+
+const hoisted = vi.hoisted(() => ({currentEnvironmentId: 0}));
 
 // AppSidebarFooter pulls in stores/queries; stub it so this test stays focused on nav.
 vi.mock('./AppSidebarFooter', () => ({
     AppSidebarFooter: () => null,
+}));
+
+vi.mock('@/shared/components/EnvironmentSelect', () => ({
+    default: ({variant}: {variant?: string}) => <div data-testid="environment-select">{variant}</div>,
+}));
+
+vi.mock('@/shared/stores/useEnvironmentStore', () => ({
+    useEnvironmentStore: (selector: (state: Record<string, unknown>) => unknown) =>
+        selector({currentEnvironmentId: hoisted.currentEnvironmentId}),
 }));
 
 const navigation = [
@@ -26,6 +37,10 @@ const renderSidebar = (open = true) =>
     );
 
 describe('AppSidebar', () => {
+    beforeEach(() => {
+        hoisted.currentEnvironmentId = 0;
+    });
+
     it('renders a menu item for each navigation entry', () => {
         renderSidebar(true);
 
@@ -37,5 +52,49 @@ describe('AppSidebar', () => {
         renderSidebar(true);
 
         expect(screen.getByRole('link', {name: 'AI Hub'})).toHaveAttribute('href', '/automation/ai-hub');
+    });
+
+    describe('environment', () => {
+        it('renders the compact selector beside the wordmark when the rail is expanded', () => {
+            renderSidebar(true);
+
+            expect(screen.getByTestId('environment-select')).toHaveTextContent('compact');
+        });
+
+        it('falls back to the icon-only selector on the collapsed rail', () => {
+            renderSidebar(false);
+
+            expect(screen.getByTestId('environment-select')).toHaveTextContent('icon');
+        });
+
+        it('tints the document element with the selected environment', () => {
+            renderSidebar(true);
+
+            expect(document.documentElement).toHaveAttribute('data-environment', 'development');
+        });
+
+        it('retints when the selected environment changes', () => {
+            const {rerender} = renderSidebar(true);
+
+            hoisted.currentEnvironmentId = 2;
+
+            rerender(
+                <MemoryRouter initialEntries={['/automation/projects']}>
+                    <SidebarProvider defaultOpen>
+                        <AppSidebar navigation={navigation} />
+                    </SidebarProvider>
+                </MemoryRouter>
+            );
+
+            expect(document.documentElement).toHaveAttribute('data-environment', 'production');
+        });
+
+        it('clears the tint when the sidebar unmounts', () => {
+            const {unmount} = renderSidebar(true);
+
+            unmount();
+
+            expect(document.documentElement).not.toHaveAttribute('data-environment');
+        });
     });
 });

--- a/client/src/shared/layout/app-sidebar/AppSidebar.tsx
+++ b/client/src/shared/layout/app-sidebar/AppSidebar.tsx
@@ -10,8 +10,13 @@ import {
     SidebarMenuButton,
     SidebarMenuItem,
     SidebarRail,
+    useSidebar,
 } from '@/components/ui/sidebar';
+import EnvironmentSelect from '@/shared/components/EnvironmentSelect';
+import {ENVIRONMENT_CONFIGS} from '@/shared/constants/environmentConfigs';
+import {useEnvironmentStore} from '@/shared/stores/useEnvironmentStore';
 import {type LucideIcon} from 'lucide-react';
+import {useEffect} from 'react';
 import {Link, useLocation} from 'react-router-dom';
 
 import {AppSidebarFooter} from './AppSidebarFooter';
@@ -29,18 +34,43 @@ interface AppSidebarProps {
 export function AppSidebar({navigation}: AppSidebarProps) {
     const {pathname} = useLocation();
 
+    const {isMobile, state} = useSidebar();
+
+    const currentEnvironmentId = useEnvironmentStore((environmentState) => environmentState.currentEnvironmentId);
+
+    const collapsed = state === 'collapsed' && !isMobile;
+
     const isActive = (href: string) => pathname === href || pathname.startsWith(`${href}/`);
 
-    return (
-        <Sidebar className="h-full bg-muted" collapsible="icon">
-            <SidebarHeader>
-                <Link className="flex items-center gap-2 py-1" to="/">
-                    <span className="flex size-10 shrink-0 items-center justify-center">
-                        <img alt="ByteChef" className="size-8 max-w-none shrink-0" src={reactLogo} />
-                    </span>
+    useEffect(() => {
+        const {documentElement} = document;
+        const sidebarTheme = ENVIRONMENT_CONFIGS[currentEnvironmentId]?.sidebarTheme;
 
-                    <span className="text-lg font-semibold group-data-[collapsible=icon]:hidden">ByteChef</span>
-                </Link>
+        if (!sidebarTheme) {
+            documentElement.removeAttribute('data-environment');
+
+            return;
+        }
+
+        documentElement.setAttribute('data-environment', sidebarTheme);
+
+        return () => documentElement.removeAttribute('data-environment');
+    }, [currentEnvironmentId]);
+
+    return (
+        <Sidebar className="h-full" collapsible="icon">
+            <SidebarHeader>
+                <div className="flex items-center justify-between gap-2 group-data-[collapsible=icon]:flex-col group-data-[collapsible=icon]:gap-1">
+                    <Link className="flex items-center gap-2 py-1" to="/">
+                        <span className="flex size-10 shrink-0 items-center justify-center">
+                            <img alt="ByteChef" className="size-8 max-w-none shrink-0" src={reactLogo} />
+                        </span>
+
+                        <span className="text-lg font-semibold group-data-[collapsible=icon]:hidden">ByteChef</span>
+                    </Link>
+
+                    <EnvironmentSelect variant={collapsed ? 'icon' : 'compact'} />
+                </div>
             </SidebarHeader>
 
             <SidebarContent>

--- a/client/src/shared/layout/app-sidebar/AppSidebarFooter.tsx
+++ b/client/src/shared/layout/app-sidebar/AppSidebarFooter.tsx
@@ -23,7 +23,6 @@ import {useAuthenticationStore} from '@/shared/stores/useAuthenticationStore';
 import {useEnvironmentStore} from '@/shared/stores/useEnvironmentStore';
 import {useQueryClient} from '@tanstack/react-query';
 import {
-    AudioLinesIcon,
     BlendIcon,
     ChevronsUpDownIcon,
     DiamondIcon,
@@ -98,16 +97,6 @@ export function AppSidebarFooter() {
             navigate(
                 `/embedded${currentEnvironmentId === DEVELOPMENT_ENVIRONMENT ? '/integrations' : '/configurations'}`
             );
-        }
-    };
-
-    const handleEnvironmentValueChange = (value: string) => {
-        setCurrentEnvironmentId(+value);
-
-        if (currentType === PlatformType.AUTOMATION) {
-            navigate(`/automation${+value === DEVELOPMENT_ENVIRONMENT ? '/projects' : '/deployments'}`);
-        } else if (currentType === PlatformType.EMBEDDED) {
-            navigate(`/embedded${+value === DEVELOPMENT_ENVIRONMENT ? '/integrations' : '/configurations'}`);
         }
     };
 
@@ -249,35 +238,6 @@ export function AppSidebarFooter() {
                                     >
                                         <PlusIcon /> <span>New Workspace</span>
                                     </DropdownMenuItem>
-                                </DropdownMenuSubContent>
-                            </DropdownMenuPortal>
-                        </DropdownMenuSub>
-
-                        <DropdownMenuSeparator />
-                    </>
-                )}
-
-                {application?.edition === 'EE' && environmentsQuery?.environments && (
-                    <>
-                        <DropdownMenuSub>
-                            <DropdownMenuSubTrigger className="cursor-pointer font-semibold">
-                                <AudioLinesIcon className="size-5" />
-
-                                {`Environment: ${environmentsQuery?.environments.find((w) => +w?.id! === currentEnvironmentId)?.name}`}
-                            </DropdownMenuSubTrigger>
-
-                            <DropdownMenuPortal>
-                                <DropdownMenuSubContent>
-                                    <DropdownMenuRadioGroup
-                                        onValueChange={handleEnvironmentValueChange}
-                                        value={currentEnvironmentId?.toString()}
-                                    >
-                                        {environmentsQuery?.environments.map((environment) => (
-                                            <DropdownMenuRadioItem key={environment?.id} value={environment?.id!}>
-                                                {environment?.name}
-                                            </DropdownMenuRadioItem>
-                                        ))}
-                                    </DropdownMenuRadioGroup>
                                 </DropdownMenuSubContent>
                             </DropdownMenuPortal>
                         </DropdownMenuSub>

--- a/client/src/styles/index.css
+++ b/client/src/styles/index.css
@@ -336,6 +336,46 @@
         --rdg-color-scheme: dark;
     }
 
+    [data-environment='development'] {
+        --sidebar: 220 14.3% 95.9%;
+        --sidebar-accent: 220 13% 91%;
+        --sidebar-border: 220 13% 89%;
+    }
+
+    [data-environment='staging'] {
+        --sidebar: 48 70% 95%;
+        --sidebar-accent: 48 75% 89%;
+        --sidebar-border: 48 60% 84%;
+    }
+
+    [data-environment='production'] {
+        --sidebar: 215 55% 95%;
+        --sidebar-accent: 215 60% 89%;
+        --sidebar-border: 215 50% 84%;
+    }
+
+    .dark [data-environment='development'],
+    .dark[data-environment='development'] {
+        --sidebar: 215 27.9% 16.9%;
+        --sidebar-accent: 215 27.9% 22%;
+        --sidebar-border: 215 27.9% 25%;
+    }
+
+    .dark [data-environment='staging'],
+    .dark[data-environment='staging'] {
+        --sidebar: 43 40% 15%;
+        --sidebar-accent: 43 40% 22%;
+        --sidebar-border: 43 35% 27%;
+    }
+
+    .dark [data-environment='production'],
+    .dark[data-environment='production'] {
+        --sidebar: 217 40% 16%;
+        --sidebar-accent: 217 42% 23%;
+        --sidebar-border: 217 38% 28%;
+    }
+
+
     * {
         @apply border-border;
     }


### PR DESCRIPTION
Closes #5600

## Problem

`EnvironmentSelect` was rendered in 10 separate page headers, and again as an "Environment: …" submenu
inside the avatar dropdown at the bottom of the app sidebar. The same control therefore appeared twice on
most pages, and once the header scrolled past, nothing on screen said which environment the page was
scoped to.

## Change

Render it once, in the app sidebar header beside the ByteChef wordmark, and give the rail a
per-environment tint so the selected environment stays visible after the selector is out of view.

- **Placement** — right of the wordmark, with a compact `DEV` / `STG` / `PRD` label; a 256px rail shared
  with the wordmark has no room for the full pill, which the tooltip and the dropdown still carry.
  Collapsed to the 56px rail the header stacks and the selector becomes the environment's icon alone.
- **Tint** — `data-environment` on the document element drives `--sidebar`, `--sidebar-accent` and
  `--sidebar-border`. Development keeps today's neutral; staging is an amber wash, production brand-blue;
  light and dark both. It is applied to the document element rather than to `<Sidebar>` because the mobile
  sidebar is a Radix `Sheet`: the primitive spreads its props onto a root that renders no DOM node, and
  portals the sheet out of the subtree, so an attribute on the rail would have tinted desktop only. Nothing
  outside the sidebar reads the `--sidebar-*` tokens, so the override stays scoped in effect.
  `bg-muted` comes off the sidebar with it — it painted the positioning wrapper that `bg-sidebar` fully
  covers, so it was dead paint that would have contradicted the tint.
- **Removed** — the pill from the page headers, and the duplicate submenu from the avatar dropdown. Where
  the selector was a ternary's entire else-branch (API Collections, MCP Servers, Data Tables, Knowledge
  Bases, Connections, Project Deployments), the ternary collapses to `cond && (…)`, which also retires the
  single-child flex wrappers.

## Behaviour change

The avatar submenu also **navigated** to `/projects` / `/deployments` (automation) or
`/integrations` / `/configurations` (embedded) on switch. That navigation goes with it; the page header
pill it replaces never did this.

## Testing

`npm run check` passes — prettier, eslint, tsc, 370 test files / 3942 tests. New coverage: the compact,
default and icon selector variants; the selector's presence in the rail header expanded and its icon-only
form collapsed; and the tint being set, retinted on change, and cleared on unmount.

🤖 Generated with [Claude Code](https://claude.com/claude-code)