### PR TITLE
3757 Document the Users page as Community Edition with Enterprise roles

### DIFF
--- a/docs/content/docs/platform/settings/users.mdx
+++ b/docs/content/docs/platform/settings/users.mdx
@@ -75,11 +75,13 @@ Community Edition has one level of access. There is nothing to assign, so the co
 | **edit** action / **Edit User** dialog | Not shown | Change the role |
 | Workspace roles and permission scopes | Not available | See below |
 
-Everything below this point - the workspace role model, permission scopes, and per-workspace membership - is Enterprise Edition.
+The workspace role model below - roles, permission scopes and per-workspace membership - is Enterprise Edition throughout, and each section carries the badge.
 
 ---
 
 ## Roles and permissions
+
+<EEBadge />
 
 <Callout type="warn" title="Coming soon">
     Role-based access control is on the upcoming release track and is not yet available in the latest released version of ByteChef.
@@ -94,6 +96,8 @@ Permissions are scoped to **workspaces**. There are no per-project roles and no 
 
 ### The built-in workspace roles
 
+<EEBadge />
+
 | Role | Rank |
 |---|---|
 | **Admin** | Most privileged. |
@@ -103,6 +107,8 @@ Permissions are scoped to **workspaces**. There are no per-project roles and no 
 The roles are ranked rather than enumerated: a role is granted every permission scope whose declared minimum role it is at least as privileged as, so `VIEWER ⊆ EDITOR ⊆ ADMIN` holds by construction. Adding a scope means declaring its minimum role once, not editing three role definitions.
 
 ### Permission scopes
+
+<EEBadge />
 
 Scopes are contributed per module at startup rather than listed in a central enum. The built-in set and its minimum role:
 
@@ -130,6 +136,8 @@ Declaring the same scope name with two different minimum roles fails the applica
 
 ### Managing workspace membership
 
+<EEBadge />
+
 Workspace membership has two surfaces. The current workspace's members are managed on its own page, **Settings → Current Workspace → [Users](/platform/automation/settings/users)**. To reach *another* workspace's members without switching to it, use **Settings → [Workspaces](/platform/settings/workspaces)**: each workspace row's **⋮** menu has a **Members** entry that opens the **Workspace Members** dialog. The dialog lists members with **User**, **Role**, and **Added** columns. An admin changes a member's role inline through the **Role** dropdown, removes a member with the trash action, and adds one through the **Add user** row - search by email, pick a role, confirm. The role dropdown is derived from the server-side role enum, so a role added server-side appears without a client change.
 
 Only a workspace **Admin** sees the role dropdown, the remove action, and the add row; everyone else sees the membership list read-only. Removing a user at the workspace level revokes their access to every project in that workspace at once.
@@ -138,9 +146,13 @@ Only a workspace **Admin** sees the role dropdown, the remove action, and the ad
 
 ### Federated identity
 
+<EEBadge />
+
 If you federate authentication through an external identity provider, group claims can drive workspace roles automatically. See [Identity Providers](/platform/settings/identity-providers).
 
 ### What gets logged
+
+<EEBadge />
 
 Membership and role changes are recorded in the [audit log](/platform/settings/audit-events) as `WORKSPACE_USER_ADDED`, `WORKSPACE_USER_REMOVED`, and `WORKSPACE_USER_ROLE_UPDATED`; account lifecycle as `USER_CREATED`, `USER_ACTIVATED`, `USER_PASSWORD_CHANGED`, and `USER_DELETED`.
 

--- a/docs/content/docs/platform/settings/users.mdx
+++ b/docs/content/docs/platform/settings/users.mdx
@@ -1,15 +1,12 @@
 ---
 title: Users
-description: Organization members and their roles; invite people, change a role, and remove access.
-comingSoon: true
+description: Organization members - invite people, remove access, and, in Enterprise Edition, assign roles.
 ---
 
-<EEBadge />
-
-Organization membership is managed from **Settings → Users**. From this page an administrator invites new people by email, assigns each one an organization role, changes a role later, and removes people who should no longer have access.
+Organization membership is managed from **Settings → Users**. From this page an administrator invites new people by email and removes people who should no longer have access. In Enterprise Edition the same page assigns each account an organization role and changes it later.
 
 <Callout title="Availability">
-    User management is an Enterprise Edition feature behind the `ff-3900` feature flag, and the route requires the `ADMIN` authority. The page is not available in Community Edition, and non-admins cannot open it.
+    The page is available in both editions and requires the `ADMIN` authority, so non-admins cannot open it. Listing, inviting and removing users work the same either way. **Roles are Enterprise Edition only**: Community Edition has a single level of access, so every account is an administrator and the role controls described below are not rendered there.
 </Callout>
 
 ---
@@ -24,9 +21,9 @@ The header reads **Users**, described as "Manage organization users: invite or d
 |---|---|
 | **Email** | The user's email address. |
 | **Name** | First and last name, when set. |
-| **Role** | The organization authority, shown verbatim - `ROLE_ADMIN` or `ROLE_USER`. |
+| **Role** | The organization authority, shown verbatim - `ROLE_ADMIN` or `ROLE_USER`. Every Community Edition account reads `ROLE_ADMIN`. |
 | **Status** | **Active** when the account is activated, **Pending** otherwise. |
-| *(actions)* | Per-row **edit** (pencil) and **delete** (trash) buttons. |
+| *(actions)* | Per-row **edit** (pencil) and **delete** (trash) buttons. The edit button is Enterprise Edition only - it exists to change a role, and Community Edition has none to change. |
 
 When there are more users than fit on one page, pagination controls appear in the footer. If no users match, the table shows **No users found.**
 
@@ -35,10 +32,10 @@ When there are more users than fit on one page, pagination controls appear in th
 1. Click **Invite User**. The dialog explains: "Enter the user email. A strong password is pre-generated according to the security rules. This password will be included in the invitation email."
 2. Enter the **Email** address.
 3. A **Password** is generated for you and shown read-only. **Regenerate** produces a different one. The rule beneath the field states it: "Password must be at least 8 characters and include at least 1 uppercase letter and 1 number."
-4. Choose a **Role**. The options come from the organization's configured authorities; the first one is preselected.
+4. Choose a **Role**. The options come from the organization's configured authorities; the first one is preselected. This step is Enterprise Edition only - Community Edition shows no **Role** field and invites every account as an administrator.
 5. Click **Invite**.
 
-The **Invite** button stays disabled until an email address and a role are set *and* the generated password satisfies the password rules. An invalid role is rejected before any account row is created, so a bad request cannot leave an orphaned user behind.
+The **Invite** button stays disabled until an email address is set *and* the generated password satisfies the password rules; in Enterprise Edition a role must be chosen too. An invalid role is rejected before any account row is created, so a bad request cannot leave an orphaned user behind.
 
 ![The Invite User dialog](users/invite-user.png)
 
@@ -52,6 +49,10 @@ An invited account occupies a seat against the deployment's member quota from th
 
 ## Change a user's role
 
+<Callout title="Enterprise Edition">
+    Community Edition does not render the **edit** action. It exists only to change a role, and every Community Edition account is already an administrator.
+</Callout>
+
 1. Click the **edit** (pencil) icon on the user's row to open the **Edit User** dialog, described as "Change the user role."
 2. The dialog shows the selected **User** (their email) and a **Role** dropdown set to their current role.
 3. Pick a new **Role** and click **Save**.
@@ -61,6 +62,20 @@ Only the organization role is editable here - email and name are not. Workspace 
 ## Remove a user
 
 Click the **delete** (trash) icon on the row and confirm. The confirmation warns that the action cannot be undone. Removing a user revokes their access to the organization.
+
+## What differs between editions
+
+Community Edition has one level of access. There is nothing to assign, so the controls that would assign it are absent rather than disabled:
+
+| | Community Edition | Enterprise Edition |
+|---|---|---|
+| List, invite, remove users | Yes | Yes |
+| **Role** field in the invite dialog | Not shown - invites as administrator | Choose from the configured authorities |
+| **Role** column in the table | Always `ROLE_ADMIN` | The account's authority |
+| **edit** action / **Edit User** dialog | Not shown | Change the role |
+| Workspace roles and permission scopes | Not available | See below |
+
+Everything below this point - the workspace role model, permission scopes, and per-workspace membership - is Enterprise Edition.
 
 ---
 


### PR DESCRIPTION
> **Draft — do not merge until the v0.33 cut.** Docs track the latest *released* version. In v0.31.4 the Users page is still Enterprise-only and behind `ff-3900`, so the text on master is correct today. This becomes correct when #5599 ships.

## Why

#5599 moves user management out of `server/ee`, which makes this page describe a surface that is **split** rather than uniformly Enterprise:

| | Edition after #5599 |
|---|---|
| List, invite, remove users | **Community** |
| Authorities, invite **Role** field, **edit** action | Enterprise |
| Workspace roles, permission scopes, per-workspace membership | Enterprise |

So the page stops being an EE page and becomes a CE page with EE sections inside it. That's a restructuring, not a find-and-replace.

## Changes

1. **`comingSoon: true` and `<EEBadge />` removed** — the page is no longer wholly Enterprise.
2. **Availability callout rewritten.** It was wrong on all three of its claims: "Enterprise Edition feature", "behind the `ff-3900` feature flag", and "not available in Community Edition". It now states what is shared, what is Enterprise, and keeps the `ADMIN` requirement.
3. **Per-section edition markers** on the parts that render conditionally — the invite dialog's **Role** step, the **Role** column, the `(actions)` column, and the whole *Change a user's role* section.
4. **New "What differs between editions" table.** The CE controls are *absent*, not disabled, so a reader comparing against a screenshot would otherwise assume something was broken.
5. **Intro paragraph** no longer asserts role assignment unconditionally.

The *Roles and permissions* section **keeps** its own coming-soon callout — workspace roles and permission scopes are unreleased regardless of edition.

## Not included

- **Screenshots.** [users.png](docs/content/docs/platform/settings/users/users.png) and [invite-user.png](docs/content/docs/platform/settings/users/invite-user.png) are both EE captures and still accurate for EE. A CE pair (no Role field, no edit pencil) would be worth adding, but should be captured from the running CE app rather than inferred.
- **[platform/automation/settings/users.mdx](docs/content/docs/platform/automation/settings/users.mdx).** Its contrast table still reads correctly — organization Users does grant the organization authority — and the page stays `ee: true` + `comingSoon: true`. Worth a re-read at the cut, but it needs no change now.

## Convention checks

Hyphens not em dashes (per the 3757 sweep); Callout components match the surrounding pages.