### PR TITLE
5578 Do not require the parameters field on nodes without parameters

### DIFF
--- a/server/libs/platform/platform-workflow/platform-workflow-validator/platform-workflow-validator-service/src/main/java/com/bytechef/platform/workflow/validator/TaskValidator.java
+++ b/server/libs/platform/platform-workflow/platform-workflow-validator/platform-workflow-validator-service/src/main/java/com/bytechef/platform/workflow/validator/TaskValidator.java
@@ -252,7 +252,7 @@ class TaskValidator {
         FieldValidator.validateOptionalStringField(taskJsonNode, "label", errors, warnings);
         FieldValidator.validateRequiredStringField(taskJsonNode, "name", errors);
         appendErrorTaskTypeField(taskJsonNode, errors);
-        appendErrorRequiredObjectField(taskJsonNode, errors);
+        appendErrorParametersField(taskJsonNode, errors);
     }
 
     /**
@@ -354,15 +354,11 @@ class TaskValidator {
         }
     }
 
-    private static void appendErrorRequiredObjectField(JsonNode jsonNode, StringBuilder errors) {
-        if (!jsonNode.has("parameters")) {
-            StringUtils.appendWithNewline("Missing required field: " + "parameters", errors);
-        } else {
-            JsonNode fieldJsonNode = jsonNode.get("parameters");
+    private static void appendErrorParametersField(JsonNode jsonNode, StringBuilder errors) {
+        JsonNode parametersJsonNode = jsonNode.get("parameters");
 
-            if (!fieldJsonNode.isObject()) {
-                StringUtils.appendWithNewline("Field '" + "parameters" + "' must be an object", errors);
-            }
+        if (parametersJsonNode != null && !parametersJsonNode.isObject()) {
+            StringUtils.appendWithNewline("Field 'parameters' must be an object", errors);
         }
     }
 

--- a/server/libs/platform/platform-workflow/platform-workflow-validator/platform-workflow-validator-service/src/test/java/com/bytechef/platform/workflow/validator/WorkflowValidatorOptionalParametersTest.java
+++ b/server/libs/platform/platform-workflow/platform-workflow-validator/platform-workflow-validator-service/src/test/java/com/bytechef/platform/workflow/validator/WorkflowValidatorOptionalParametersTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2025 ByteChef
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.bytechef.platform.workflow.validator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.bytechef.platform.workflow.validator.model.PropertyInfo;
+import com.bytechef.test.extension.ObjectMapperSetupExtension;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * @author Ivica Cardic
+ */
+@ExtendWith(ObjectMapperSetupExtension.class)
+class WorkflowValidatorOptionalParametersTest {
+
+    private static final Map<String, List<PropertyInfo>> TASK_DEFINITION_MAP = Map.of(
+        "component/v1/optionalPropertyAction", List.of(
+            new PropertyInfo("name", "STRING", null, false, true, null, null)),
+        "component/v1/requiredPropertyAction", List.of(
+            new PropertyInfo("name", "STRING", null, true, true, null, null)));
+
+    @Test
+    void validateWorkflowTriggerWithoutParametersHasNoErrors() {
+        String workflow = """
+            {
+                "label": "DateTime condition bug",
+                "description": "",
+                "inputs": [],
+                "triggers": [
+                    {
+                        "description": "",
+                        "label": "Manual",
+                        "name": "trigger_1",
+                        "type": "manual/v1/manual"
+                    }
+                ],
+                "tasks": []
+            }
+            """;
+
+        StringBuilder errors = new StringBuilder();
+        StringBuilder warnings = new StringBuilder();
+
+        validateWorkflow(workflow, errors, warnings);
+
+        assertEquals("", errors.toString());
+        assertEquals("", warnings.toString());
+    }
+
+    @Test
+    void validateWorkflowTaskWithoutParametersHasNoErrorsWhenNoPropertyIsRequired() {
+        String workflow = """
+            {
+                "label": "Test Workflow",
+                "description": "Test workflow description",
+                "inputs": [],
+                "triggers": [],
+                "tasks": [
+                    {
+                        "label": "Test Task",
+                        "name": "testTask",
+                        "type": "component/v1/optionalPropertyAction"
+                    }
+                ]
+            }
+            """;
+
+        StringBuilder errors = new StringBuilder();
+        StringBuilder warnings = new StringBuilder();
+
+        validateWorkflow(workflow, errors, warnings);
+
+        assertEquals("", errors.toString());
+        assertEquals("", warnings.toString());
+    }
+
+    @Test
+    void validateWorkflowTaskWithoutParametersReportsMissingRequiredPropertyByName() {
+        String workflow = """
+            {
+                "label": "Test Workflow",
+                "description": "Test workflow description",
+                "inputs": [],
+                "triggers": [],
+                "tasks": [
+                    {
+                        "label": "Test Task",
+                        "name": "testTask",
+                        "type": "component/v1/requiredPropertyAction"
+                    }
+                ]
+            }
+            """;
+
+        StringBuilder errors = new StringBuilder();
+        StringBuilder warnings = new StringBuilder();
+
+        validateWorkflow(workflow, errors, warnings);
+
+        assertEquals("[testTask] Missing required property: name", errors.toString());
+    }
+
+    @Test
+    void validateTaskStructureNonObjectParametersStillAddsError() {
+        String task = """
+            {
+                "label": "Test Task",
+                "name": "testTask",
+                "type": "component/v1/optionalPropertyAction",
+                "parameters": "notAnObject"
+            }
+            """;
+
+        StringBuilder errors = new StringBuilder();
+
+        TaskValidator.validateTaskStructure(task, errors, new StringBuilder());
+
+        assertEquals("[testTask] Field 'parameters' must be an object", errors.toString());
+    }
+
+    private static void validateWorkflow(String workflow, StringBuilder errors, StringBuilder warnings) {
+        WorkflowValidator.TaskDefinitionProvider taskDefinitionProvider =
+            (taskType, kind) -> TASK_DEFINITION_MAP.get(taskType);
+        WorkflowValidator.TaskOutputProvider taskOutputProvider =
+            (taskType, kind, warningsBuilder) -> null;
+        WorkflowValidator.ClusterTypesProvider clusterTypesProvider = taskType -> null;
+
+        WorkflowValidator.validateWorkflow(
+            workflow, taskDefinitionProvider, taskOutputProvider, clusterTypesProvider, new HashMap<>(),
+            new HashMap<>(), new HashMap<>(), errors, warnings);
+    }
+}

--- a/server/libs/platform/platform-workflow/platform-workflow-validator/platform-workflow-validator-service/src/test/java/com/bytechef/platform/workflow/validator/WorkflowValidatorTest.java
+++ b/server/libs/platform/platform-workflow/platform-workflow-validator/platform-workflow-validator-service/src/test/java/com/bytechef/platform/workflow/validator/WorkflowValidatorTest.java
@@ -766,8 +766,8 @@ class WorkflowValidatorTest {
     }
 
     @Test
-    void validateTaskStructureMissingParametersAddsError() {
-        String invalidTask = """
+    void validateTaskStructureMissingParametersNoErrors() {
+        String task = """
             {
                 "label": "Test Task",
                 "name": "testTask",
@@ -777,9 +777,9 @@ class WorkflowValidatorTest {
 
         StringBuilder errors = new StringBuilder();
 
-        TaskValidator.validateTaskStructure(invalidTask, errors, new StringBuilder());
+        TaskValidator.validateTaskStructure(task, errors, new StringBuilder());
 
-        assertEquals("[testTask] Missing required field: parameters", errors.toString());
+        assertEquals("", errors.toString());
     }
 
     @Test
@@ -3248,7 +3248,7 @@ class WorkflowValidatorTest {
     }
 
     @Test
-    void validateWorkflowTasksTaskWithMissingParametersFieldHandlesCorrectly() {
+    void validateWorkflowTasksTaskWithMissingParametersFieldHasNoErrors() {
         String tasksJson = """
             [
                 {
@@ -3279,11 +3279,7 @@ class WorkflowValidatorTest {
             WorkflowValidator.validateWorkflowTasks(
                 taskJsonNodes, taskDefinitionMap, taskOutputMap, new HashMap<>(), errors, warnings);
 
-            String string = errors.toString();
-
-            assertTrue(
-                string.contains("Missing required field: parameters") ||
-                    string.contains("Task definition must have a 'parameters' object"));
+            assertEquals("", errors.toString());
         } catch (Exception e) {
             fail("Should handle missing parameters field: " + e.getMessage());
         }


### PR DESCRIPTION
Closes #5578

## Problem

`TaskValidator` treated `parameters` as a required field on every task node, so a node that genuinely has
nothing to configure failed validation with `Missing required field: parameters` — it had to carry an
empty `parameters: {}` to pass.

## Change

`parameters` is now optional. When it is present it must still be an object; when it is absent the node
validates. `appendErrorRequiredObjectField` becomes `appendErrorParametersField`, dropping the
presence check and keeping the type check:

```java
private static void appendErrorParametersField(JsonNode jsonNode, StringBuilder errors) {
    JsonNode parametersJsonNode = jsonNode.get("parameters");

    if (parametersJsonNode != null && !parametersJsonNode.isObject()) {
        StringUtils.appendWithNewline("Field 'parameters' must be an object", errors);
    }
}
```

## Testing

`:platform-workflow-validator-service:check` passes on master — 160 tests, 0 failures, 0 errors, across
all eight validator test classes. That includes the new `WorkflowValidatorOptionalParametersTest` (4 tests)
and `WorkflowValidatorTest`, which was updated where it previously asserted the now-removed
missing-`parameters` error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)