### PR TITLE
Allow fullscreen on Gmail docs slideshows #2678

### DIFF
--- a/docs/content/docs/reference/components/google-mail_v1.mdx
+++ b/docs/content/docs/reference/components/google-mail_v1.mdx
@@ -46,7 +46,7 @@ Creation of OAuth 2.0 application is documented [here](/reference/components/goo
 6. Click **Enable**.
 
 <div style={{ position: 'relative', height:0, width: '100%', overflow: 'hidden', zindex: 49, boxSizing: 'border-box', paddingBottom: 'calc(50.05219207% + 32px)'}}>
-    <iframe src="https://www.guidejar.com/embed/2d7279c7-91c3-43c9-9004-99f08d7e30ff?type=1&controls=on" width="100%" height="100%" style={{height:'100%', position:'absolute', inset:0}} allowFullScreen frameBorder="0"></iframe>
+    <iframe src="https://www.guidejar.com/embed/2d7279c7-91c3-43c9-9004-99f08d7e30ff?type=1&controls=on" width="100%" height="100%" style={{height:'100%', position:'absolute', inset:0}} allow="fullscreen" allowFullScreen frameBorder="0"></iframe>
 </div>
 
 
@@ -731,7 +731,7 @@ Setting up Pub/Sub service
 23. This is your **topic name**.
 
 <div style={{ position: 'relative', height:0, width: '100%', overflow: 'hidden', zindex: 49, boxSizing: 'border-box', paddingBottom: 'calc(50.05219207% + 32px)'}}>
-    <iframe src="https://www.guidejar.com/embed/934ccb3b-1052-440e-bcfa-9cd5d27b8a91?type=1&controls=on" width="100%" height="100%" style={{height:'100%', position:'absolute', inset:0}} allowFullScreen frameBorder="0"></iframe>
+    <iframe src="https://www.guidejar.com/embed/934ccb3b-1052-440e-bcfa-9cd5d27b8a91?type=1&controls=on" width="100%" height="100%" style={{height:'100%', position:'absolute', inset:0}} allow="fullscreen" allowFullScreen frameBorder="0"></iframe>
 </div>
 
 
@@ -779,7 +779,7 @@ Gmail doesn’t manage its own time zone; it inherits the time zone from your Go
 6. Done 🚀
 
 <div style={{ position: 'relative', height:0, width: '100%', overflow: 'hidden', zindex: 49, boxSizing: 'border-box', paddingBottom: 'calc(50.05219207% + 32px)'}}>
-    <iframe src="https://www.guidejar.com/embed/157feabc-9dec-4ac4-a538-5aa6a0bb0928?type=1&controls=on" width="100%" height="100%" style={{height:'100%', position:'absolute', inset:0}} allowFullScreen frameBorder="0"></iframe>
+    <iframe src="https://www.guidejar.com/embed/157feabc-9dec-4ac4-a538-5aa6a0bb0928?type=1&controls=on" width="100%" height="100%" style={{height:'100%', position:'absolute', inset:0}} allow="fullscreen" allowFullScreen frameBorder="0"></iframe>
 </div>
 
 


### PR DESCRIPTION
The Gmail docs slideshows already had allowFullScreen. Chromium still needs allow=fullscreen on the iframe or the Guidejar fullscreen button does nothing.

Fixes #2678
