### PR TITLE
5591 Scope the knowledge base name uniqueness to its environment

### DIFF
--- a/server/libs/platform/platform-knowledge-base/platform-knowledge-base-service/src/main/resources/config/liquibase/changelog/platform/knowledge_base/20260831000001_platform_knowledge_base_name_unique_per_environment.xml
+++ b/server/libs/platform/platform-knowledge-base/platform-knowledge-base-service/src/main/resources/config/liquibase/changelog/platform/knowledge_base/20260831000001_platform_knowledge_base_name_unique_per_environment.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd"
+                   logicalFilePath="config/liquibase/changelog/platform/knowledge_base/20260831000001_platform_knowledge_base_name_unique_per_environment.xml">
+
+    <changeSet id="20260831000001-1" author="Ivica Cardic">
+        <preConditions onFail="MARK_RAN">
+            <uniqueConstraintExists tableName="knowledge_base" constraintName="uk_knowledge_base_name"/>
+        </preConditions>
+
+        <dropUniqueConstraint tableName="knowledge_base" constraintName="uk_knowledge_base_name"/>
+        <rollback/>
+    </changeSet>
+
+    <changeSet id="20260831000001-2" author="Ivica Cardic">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <uniqueConstraintExists tableName="knowledge_base"
+                                        constraintName="uk_knowledge_base_name_environment"/>
+            </not>
+        </preConditions>
+
+        <addUniqueConstraint tableName="knowledge_base" columnNames="name, environment"
+                             constraintName="uk_knowledge_base_name_environment"/>
+        <rollback/>
+    </changeSet>
+</databaseChangeLog>

--- a/server/libs/platform/platform-knowledge-base/platform-knowledge-base-service/src/test/java/com/bytechef/platform/knowledgebase/service/KnowledgeBaseServiceIntTest.java
+++ b/server/libs/platform/platform-knowledge-base/platform-knowledge-base-service/src/test/java/com/bytechef/platform/knowledgebase/service/KnowledgeBaseServiceIntTest.java
@@ -19,6 +19,7 @@ package com.bytechef.platform.knowledgebase.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.bytechef.platform.configuration.domain.Environment;
 import com.bytechef.platform.knowledgebase.config.KnowledgeBaseIntTestConfiguration;
 import com.bytechef.platform.knowledgebase.config.KnowledgeBaseIntTestConfigurationSharedMocks;
 import com.bytechef.platform.knowledgebase.domain.KnowledgeBase;
@@ -31,6 +32,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.dao.DataIntegrityViolationException;
 
 /**
  * Integration tests for {@link KnowledgeBaseService}.
@@ -150,6 +152,35 @@ class KnowledgeBaseServiceIntTest {
         assertThat(savedKnowledgeBase.getMaxChunkSize()).isEqualTo(2048);
         assertThat(savedKnowledgeBase.getMinChunkSizeChars()).isEqualTo(256);
         assertThat(savedKnowledgeBase.getOverlap()).isEqualTo(128);
+    }
+
+    @Test
+    void testCreateKnowledgeBaseWithSameNameInAnotherEnvironment() {
+        knowledgeBaseService.createKnowledgeBase(createKnowledgeBase("support-docs", Environment.DEVELOPMENT));
+
+        KnowledgeBase productionKnowledgeBase =
+            knowledgeBaseService.createKnowledgeBase(createKnowledgeBase("support-docs", Environment.PRODUCTION));
+
+        assertThat(productionKnowledgeBase.getId()).isNotNull();
+        assertThat(productionKnowledgeBase.getEnvironment()).isEqualTo(Environment.PRODUCTION);
+    }
+
+    @Test
+    void testCreateKnowledgeBaseWithDuplicateNameInSameEnvironment() {
+        knowledgeBaseService.createKnowledgeBase(createKnowledgeBase("support-docs", Environment.DEVELOPMENT));
+
+        KnowledgeBase duplicateKnowledgeBase = createKnowledgeBase("support-docs", Environment.DEVELOPMENT);
+
+        assertThatThrownBy(() -> knowledgeBaseService.createKnowledgeBase(duplicateKnowledgeBase))
+            .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    private KnowledgeBase createKnowledgeBase(String name, Environment environment) {
+        KnowledgeBase knowledgeBase = createKnowledgeBase(name);
+
+        knowledgeBase.setEnvironment(environment);
+
+        return knowledgeBase;
     }
 
     private KnowledgeBase createKnowledgeBase(String name) {


### PR DESCRIPTION
Closes #5591

## Problem

`knowledge_base` carries an `environment` column and `getKnowledgeBases(environment, ...)` filters on it —
the row *is* the per-environment resource. But the table also carried a global unique constraint on `name`
alone, added in the released init changelog:

```xml
<addUniqueConstraint tableName="knowledge_base" columnNames="name" constraintName="uk_knowledge_base_name"/>
```

Creating a knowledge base named `support-docs` in DEVELOPMENT and then again in PRODUCTION failed with a
duplicate-key violation. A given name was usable in exactly one environment.

## Change

A new changeset drops `uk_knowledge_base_name` and adds `uk_knowledge_base_name_environment` on
`(name, environment)`. It is a new changeset rather than an edit to the init changelog, which is released
and must not be rewritten.

The name is now unique *within* an environment, matching how the resource itself is scoped.

## Not applied to `data_table`

`data_table` has a superficially similar `uk_data_table_name` that deliberately keeps its shape. That
registry row is environment-agnostic — one logical table with one physical `dt_<envId>_<name>` instance per
environment — and `dropTable` only removes the row once no physical instance remains in any environment.
Adding `environment` there would break that.

## Testing

Two integration tests in `KnowledgeBaseServiceIntTest`, written before the changeset and confirmed failing
against it:

- `testCreateKnowledgeBaseWithSameNameInAnotherEnvironment` — previously failed with `DuplicateKeyException`,
  which is the reported bug.
- `testCreateKnowledgeBaseWithDuplicateNameInSameEnvironment` — guards the other half, that a duplicate name
  *within* one environment is still rejected.

`:platform-knowledge-base-service:check` and `:testIntegration` both pass — 40 tests across all seven test
classes in the module, 0 failures, 0 errors.

## Note

Task 6 of the embedded/automation resource pool split would supersede this with a
`(name, platform_type, environment)` key. That work is unstarted, and this is a live bug on `master`, so it
ships on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)