### PR TITLE
5600 Document the environment selector's move to the app sidebar

### DIFF
--- a/docs/content/docs/platform/automation/ai/memories.mdx
+++ b/docs/content/docs/platform/automation/ai/memories.mdx
@@ -32,13 +32,13 @@ Memories live under **AI → Memories** in the automation navigation, alongside 
 - The **AI section nav** - switch between **Skills** and **Memories**.
 - The **Type** filter - narrow the table to a single memory type (see [Filtering by type](#filtering-by-type)).
 
-At the top of the page a header shows the active filter as the title, the total memory count, an **environment selector**, and a **search** box.
+At the top of the page a header shows the active filter as the title, the total memory count, and a **search** box.
 
 {/* TODO screenshot: Left sidebar with the AI section nav (Skills, Memories) above the Type filter (All, User, Feedback, Project, Reference) */}
 
 ### Selecting an environment
 
-Memories are **environment-scoped** so that facts learned in one environment do not bleed into another (for example, DEVELOPMENT preferences do not surface in PRODUCTION). Use the **environment selector** in the header to switch environments; the table reloads to show only the memories stored for that environment.
+Memories are **environment-scoped** so that facts learned in one environment do not bleed into another (for example, DEVELOPMENT preferences do not surface in PRODUCTION). Use the **environment selector** in the left sidebar header to switch environments; the table reloads to show only the memories stored for that environment.
 
 ---
 
@@ -171,7 +171,7 @@ Memories are written by agents, not by hand. An agent stores a fact by calling t
 
 <Accordion title="Why don't I see any memories?">
 
-Memories are scoped to a workspace **and** an environment. Confirm you have the right environment selected in the header, and clear the type filter and search box. During editor test runs the Auto Memory tool is inert - nothing is written until the workflow runs under a real deployment.
+Memories are scoped to a workspace **and** an environment. Confirm you have the right environment selected in the left sidebar header, and clear the type filter and search box. During editor test runs the Auto Memory tool is inert - nothing is written until the workflow runs under a real deployment.
 
 </Accordion>
 

--- a/docs/content/docs/platform/automation/build/connections/index.mdx
+++ b/docs/content/docs/platform/automation/build/connections/index.mdx
@@ -32,7 +32,7 @@ Setting up a connection is a quick process:
   External credential stores are on the upcoming release track and are not yet available in the latest released version of ByteChef. Once available: if your administrator has configured an external secret backend, the create dialog shows a **Credential storage** selector. Choosing a non-default store lets you toggle **Register existing credential** and reference a secret that already lives in that store by its path or UUID, instead of typing the credentials into ByteChef. The selector only appears when more than one credential store is available, and it cannot be changed after the connection is created.
 </Callout>
 
-Connections are scoped to the currently selected **environment** (development, staging, or production). Use the environment selector in the page header to switch between them.
+Connections are scoped to the currently selected **environment** (development, staging, or production). Use the environment selector in the left sidebar header to switch between them.
 
 ## Managing Connections
 

--- a/docs/content/docs/platform/automation/build/connections/troubleshooting.mdx
+++ b/docs/content/docs/platform/automation/build/connections/troubleshooting.mdx
@@ -35,7 +35,7 @@ The **Delete** action is disabled while a connection is still in use.
 
 ### Wrong Environment
 Connections are scoped per environment, so a connection created in *development* will not appear when a project is deployed to *production*.
-- **Solution**: Use the environment selector in the page header to confirm you are viewing (and creating) connections in the correct environment.
+- **Solution**: Use the environment selector in the left sidebar header to confirm you are viewing (and creating) connections in the correct environment.
 
 ---
 

--- a/docs/content/docs/platform/automation/data/asset-files.mdx
+++ b/docs/content/docs/platform/automation/data/asset-files.mdx
@@ -6,7 +6,7 @@ comingSoon: true
 
 **Asset Files** is the workspace's file library - a place to upload files once and reuse them across automations, and to find the files your runs produce.
 
-Asset Files are **workspace-scoped** and **per-environment**: use the environment selector in the page header to switch between Development, Staging, and Production.
+Asset Files are **workspace-scoped** and **per-environment**: use the environment selector in the left sidebar header to switch between Development, Staging, and Production.
 
 ## Upload files
 

--- a/docs/content/docs/platform/automation/deploy/environments.mdx
+++ b/docs/content/docs/platform/automation/deploy/environments.mdx
@@ -24,8 +24,11 @@ record.
 
 ## Choosing an environment
 
-The selector sits in the page header wherever environment matters. Switching it changes what the page
-lists - it never migrates anything.
+The selector sits in the left sidebar header, beside the ByteChef name, and applies to the whole
+application rather than to one page. Switching it changes what the pages below it list - it never
+migrates anything. The sidebar takes on a colour for the selected environment, so the current one stays
+visible after you have looked away; collapse the sidebar and the selector shrinks to the environment's
+icon.
 
 | Environment | Intended for |
 |---|---|
@@ -39,7 +42,7 @@ Development is the default for a new session.
 
 ## What carries an environment
 
-Practically everything with an environment selector on its page:
+Practically everything you can create:
 
 - **Connections** - a connection belongs to one environment, so the Stripe connection you pick in
   Development is a different record, with different keys, from the one in Production.

--- a/docs/content/docs/platform/automation/monitor/workflow-executions.mdx
+++ b/docs/content/docs/platform/automation/monitor/workflow-executions.mdx
@@ -37,7 +37,7 @@ Executions can be narrowed by any combination of these filters:
 | **Workflow** | Runs of one workflow |
 
 The **Status** filter offers `STARTED`, `COMPLETED`, `CREATED`, `STOPPED`, and `FAILED`. The
-**Environment** selector in the page header scopes the whole list, and is available on Enterprise
+**Environment** selector in the left sidebar header scopes the whole list, and is available on Enterprise
 Edition only - a Community Edition instance works in a single environment and shows no selector.
 
 Use the **Refresh** button in the page header to reload the executions list with the latest runs.

--- a/docs/content/docs/platform/automation/settings/api-keys.mdx
+++ b/docs/content/docs/platform/automation/settings/api-keys.mdx
@@ -21,7 +21,7 @@ For account-scoped keys used for administration and the management MCP server, s
 
 ## The page
 
-**Settings → API Keys** is headed "Do not share your API key with others or expose it in the browser or other client-side code.", with an **Environment** selector and - once at least one key exists - a **New API Key** button. With no keys yet, the body shows an empty state titled **No API Keys** with the message "Get started by creating a new API key."
+**Settings → API Keys** is headed "Do not share your API key with others or expose it in the browser or other client-side code.", with - once at least one key exists - a **New API Key** button. A key belongs to the environment selected in the left sidebar header. With no keys yet, the body shows an empty state titled **No API Keys** with the message "Get started by creating a new API key."
 
 | Column | Description |
 |---|---|
@@ -33,7 +33,7 @@ For account-scoped keys used for administration and the management MCP server, s
 
 Each row ends with an **edit** (pencil) and a **delete** (trash) icon.
 
-{/* TODO screenshot: Settings → API Keys page - header with the Environment selector and the New API Key button, and the keys table below */}
+{/* TODO screenshot: Settings → API Keys page - header with the New API Key button, and the keys table below */}
 
 ## Workspace and environment binding
 

--- a/docs/content/docs/platform/embedded/administration/api-keys.md
+++ b/docs/content/docs/platform/embedded/administration/api-keys.md
@@ -9,7 +9,7 @@ description: Manage API Keys for your embedded integration.
 
 ## API Keys
 
-<!-- TODO screenshot: Embedded → Settings → API Keys - the keys table with the environment selector and the New API Key button -->
+<!-- TODO screenshot: Embedded → Settings → API Keys - the keys table and the New API Key button -->
 
 API Keys are bearer tokens for **server-to-server** calls from your backend to the embedded public API - for example listing a user's integrations, executing a component action, or reading their workflow executions.
 

--- a/docs/content/docs/platform/embedded/build/connections.md
+++ b/docs/content/docs/platform/embedded/build/connections.md
@@ -56,7 +56,7 @@ Use the left sidebar to filter the connection list:
 
 ### Environment Selection
 
-Connections are scoped to environments. Use the environment selector in the left sidebar (next to the user menu) to switch between Development, Staging, and Production. Each environment maintains its own set of connections, allowing you to use different credentials for testing and production.
+Connections are scoped to environments. Use the environment selector in the left sidebar header to switch between Development, Staging, and Production. Each environment maintains its own set of connections, allowing you to use different credentials for testing and production.
 
 ### Connection Status
 

--- a/docs/content/docs/platform/embedded/configure/instance-configurations.md
+++ b/docs/content/docs/platform/embedded/configure/instance-configurations.md
@@ -73,4 +73,4 @@ Use the left sidebar to narrow the list:
 
 ### Environment Selection
 
-Configurations are scoped to environments. Use the environment selector in the left sidebar (next to the user menu) to switch between Development, Staging, and Production. Each environment maintains its own set of configurations independently.
+Configurations are scoped to environments. Use the environment selector in the left sidebar header to switch between Development, Staging, and Production. Each environment maintains its own set of configurations independently.

--- a/docs/content/docs/platform/embedded/configure/mcp-servers.md
+++ b/docs/content/docs/platform/embedded/configure/mcp-servers.md
@@ -15,7 +15,7 @@ comingSoon: true
 | Component filtering | Filter MCP servers by the components they expose using the left sidebar. |
 | Integration filtering | Filter by the integrations associated with the server. |
 | Tag filtering | Organize and filter servers by assigned tags. |
-| Environment selector | Choose the environment (e.g., Development) in the header. |
+| Environment selector | Choose the environment (e.g., Development) in the left sidebar header. |
 | Enable/Disable toggle | Activate or deactivate an MCP server without removing it. |
 
 ### MCP Server Details
@@ -75,7 +75,7 @@ Use the left sidebar to filter the server list:
 
 ### Environment Selection
 
-Use the environment selector at the top of the page (or the global one in the left sidebar) to switch between environments. MCP server configurations are scoped per environment.
+Use the environment selector in the left sidebar header to switch between environments. MCP server configurations are scoped per environment.
 
 ---
 

--- a/docs/content/docs/platform/embedded/monitor/connected-users.md
+++ b/docs/content/docs/platform/embedded/monitor/connected-users.md
@@ -79,4 +79,4 @@ Each table row has an ellipsis (⋮) menu with the same three actions available 
 
 ### Environment Selection
 
-Connected users are scoped to the current environment. Use the environment selector in the left sidebar (next to the user menu) to switch between Development, Staging, and Production to see users in each environment.
+Connected users are scoped to the current environment. Use the environment selector in the left sidebar header, beside the ByteChef name, to switch between Development, Staging, and Production to see users in each environment.

--- a/docs/content/docs/platform/embedded/monitor/workflow-executions.md
+++ b/docs/content/docs/platform/embedded/monitor/workflow-executions.md
@@ -69,4 +69,4 @@ In **Automations** mode, the execution detail sheet reuses the automation execut
 
 ### Environment Selection
 
-Executions are scoped to the current environment. Use the environment selector in the left sidebar (next to the user menu) to switch between Development, Staging, and Production.
+Executions are scoped to the current environment. Use the environment selector in the left sidebar header to switch between Development, Staging, and Production.

--- a/docs/content/docs/platform/settings/admin-api-keys.mdx
+++ b/docs/content/docs/platform/settings/admin-api-keys.mdx
@@ -25,11 +25,11 @@ ByteChef issues a second kind of key as well: workspace API keys, scoped to a wo
 
 ## The page
 
-**Settings → Admin API Keys** is headed "Use Admin keys for programmatic administration of your account. Do not share your API key with others or expose it.", with an **Environment** selector and - once at least one key exists - a **New API Key** button.
+**Settings → Admin API Keys** is headed "Use Admin keys for programmatic administration of your account. Do not share your API key with others or expose it.", with - once at least one key exists - a **New API Key** button. A key belongs to the environment selected in the left sidebar header.
 
 With no keys yet, the body shows an empty state titled **No API Keys** with the message "Get started by creating a new API key." and a **New API Key** button.
 
-![The Admin API Keys page - the environment selector, New API Key button, and the keys table](admin-api-keys/admin-api-keys.png)
+![The Admin API Keys page - the New API Key button and the keys table](admin-api-keys/admin-api-keys.png)
 
 | Column | Description |
 |---|---|

--- a/docs/content/docs/platform/settings/connections.mdx
+++ b/docs/content/docs/platform/settings/connections.mdx
@@ -13,7 +13,7 @@ The page requires the `ADMIN` authority, and both it and the visibility model ar
 
 ## Organization Connections
 
-The page is headed **Organization Connections**, described as "Manage organization-wide shared connections.", with an **Environment** selector and a **New Connection** button.
+The page is headed **Organization Connections**, described as "Manage organization-wide shared connections.", with a **New Connection** button. Connections belong to the environment selected in the left sidebar header.
 
 | Column | Description |
 |---|---|
@@ -25,7 +25,7 @@ The page is headed **Organization Connections**, described as "Manage organizati
 
 Creating one opens the standard connection dialog, so an organization connection gets the same component picker, the component's real connection properties, and the same OAuth2 flow as any other connection. Organization connections are **deleted rather than demoted** - this scope is terminal.
 
-{/* TODO screenshot: Settings → Connections - the Organization Connections table with Name / Component / Environment / Created By / Last Modified columns, the Environment selector, and the New Connection button */}
+{/* TODO screenshot: Settings → Connections - the Organization Connections table with Name / Component / Environment / Created By / Last Modified columns, and the New Connection button */}
 
 ## The visibility model
 


### PR DESCRIPTION
Follows #5602, which moved `EnvironmentSelect` out of the page headers and into the app sidebar header.

## Why now

The docs site publishes from `stable`, not from `master`, so this reaches readers at the same release cut
as the code it describes. Merging it now is what keeps the two in step.

## What changed

Fifteen pages described the old placement, in three flavours:

- **"in the page header"** — environments, connections (index and troubleshooting), asset files, memories,
  workflow executions
- **"at the top of the page"** — embedded MCP servers
- **"in the left sidebar (next to the user menu)"** — embedded connected users, instance configurations,
  connections, workflow executions. This one described the environment submenu inside the avatar dropdown,
  which #5602 removed entirely, so it was doubly stale.

`environments.mdx` gets the fuller description, since it is the page that explains the concept: the
selector applies to the whole application rather than to one page, the sidebar takes on a colour for the
selected environment, and the collapsed sidebar shows the environment's icon alone.

Four screenshot placeholders that listed the selector as part of a page header are corrected to match.

## Deliberately not changed

- Mentions that name the selector without asserting where it is (`admin-api-keys.mdx:46,50`,
  `automation/settings/api-keys.mdx:40,44`) — still accurate.
- `settings/admin-api-keys/admin-api-keys.png`, which still shows the old header. Re-capturing needs a
  running instance, and the new layout has not had a visual check yet — worth doing once rather than twice.
  Its alt text no longer claims the selector is in the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)