### PR TITLE
5575 Preserve task-output value types and surface formula evaluation failures

### DIFF
--- a/server/libs/atlas/atlas-file-storage/atlas-file-storage-impl/build.gradle.kts
+++ b/server/libs/atlas/atlas-file-storage/atlas-file-storage-impl/build.gradle.kts
@@ -5,4 +5,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-autoconfigure")
     implementation(project(":server:libs:config:app-config"))
     implementation(project(":server:libs:core:commons:commons-util"))
+
+    testImplementation(project(":server:libs:core:file-storage:file-storage-base64-service"))
+    testImplementation(project(":server:libs:test:test-support"))
 }

--- a/server/libs/atlas/atlas-file-storage/atlas-file-storage-impl/src/main/java/com/bytechef/atlas/file/storage/TaskFileStorageImpl.java
+++ b/server/libs/atlas/atlas-file-storage/atlas-file-storage-impl/src/main/java/com/bytechef/atlas/file/storage/TaskFileStorageImpl.java
@@ -43,23 +43,21 @@ public class TaskFileStorageImpl implements TaskFileStorage {
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public Map<String, ?> readContextValue(FileEntry fileEntry) {
         Map<String, ?> value = JsonUtils.read(
             CompressionUtils.decompressToString(fileStorageService.readFileToBytes(CONTEXT_FILES_DIR, fileEntry)),
             new TypeReference<>() {});
 
-        return (Map<String, ?>) ValueTagUtils.untag(value);
+        return ValueTagUtils.untagMap(value);
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public Map<String, ?> readJobOutputs(FileEntry fileEntry) {
         Map<String, ?> value = JsonUtils.read(
             CompressionUtils.decompressToString(fileStorageService.readFileToBytes(JOB_FILES_DIR, fileEntry)),
             new TypeReference<>() {});
 
-        return (Map<String, ?>) ValueTagUtils.untag(value);
+        return ValueTagUtils.untagMap(value);
     }
 
     @Override

--- a/server/libs/atlas/atlas-file-storage/atlas-file-storage-impl/src/main/java/com/bytechef/atlas/file/storage/TaskFileStorageImpl.java
+++ b/server/libs/atlas/atlas-file-storage/atlas-file-storage-impl/src/main/java/com/bytechef/atlas/file/storage/TaskFileStorageImpl.java
@@ -19,6 +19,7 @@ package com.bytechef.atlas.file.storage;
 import com.bytechef.atlas.execution.domain.Context;
 import com.bytechef.commons.util.CompressionUtils;
 import com.bytechef.commons.util.JsonUtils;
+import com.bytechef.commons.util.ValueTagUtils;
 import com.bytechef.file.storage.domain.FileEntry;
 import com.bytechef.file.storage.service.FileStorageService;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -42,31 +43,40 @@ public class TaskFileStorageImpl implements TaskFileStorage {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public Map<String, ?> readContextValue(FileEntry fileEntry) {
-        return JsonUtils.read(
+        Map<String, ?> value = JsonUtils.read(
             CompressionUtils.decompressToString(fileStorageService.readFileToBytes(CONTEXT_FILES_DIR, fileEntry)),
             new TypeReference<>() {});
+
+        return (Map<String, ?>) ValueTagUtils.untag(value);
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public Map<String, ?> readJobOutputs(FileEntry fileEntry) {
-        return JsonUtils.read(
+        Map<String, ?> value = JsonUtils.read(
             CompressionUtils.decompressToString(fileStorageService.readFileToBytes(JOB_FILES_DIR, fileEntry)),
             new TypeReference<>() {});
+
+        return (Map<String, ?>) ValueTagUtils.untag(value);
     }
 
     @Override
     public Object readTaskExecutionOutput(FileEntry fileEntry) {
-        return JsonUtils.read(
+        Object value = JsonUtils.read(
             CompressionUtils.decompressToString(
                 fileStorageService.readFileToBytes(TASK_EXECUTION_FILES_DIR, fileEntry)),
             Object.class);
+
+        return ValueTagUtils.untag(value);
     }
 
     @Override
     public FileEntry storeContextValue(long stackId, Context.Classname classname, Map<String, ?> value) {
         return fileStorageService.storeFileContent(
-            CONTEXT_FILES_DIR, classname + "_" + stackId + ".json", CompressionUtils.compress(JsonUtils.write(value)));
+            CONTEXT_FILES_DIR, classname + "_" + stackId + ".json",
+            CompressionUtils.compress(JsonUtils.write(ValueTagUtils.tag(value))));
     }
 
     @Override
@@ -75,18 +85,20 @@ public class TaskFileStorageImpl implements TaskFileStorage {
 
         return fileStorageService.storeFileContent(
             CONTEXT_FILES_DIR, classname + "_" + stackId + "_" + subStackId + ".json",
-            CompressionUtils.compress(JsonUtils.write(value)));
+            CompressionUtils.compress(JsonUtils.write(ValueTagUtils.tag(value))));
     }
 
     @Override
     public FileEntry storeJobOutputs(long jobId, Map<String, ?> outputs) {
         return fileStorageService.storeFileContent(
-            JOB_FILES_DIR, jobId + ".json", CompressionUtils.compress(JsonUtils.write(outputs)));
+            JOB_FILES_DIR, jobId + ".json",
+            CompressionUtils.compress(JsonUtils.write(ValueTagUtils.tag(outputs))));
     }
 
     @Override
     public FileEntry storeTaskExecutionOutput(long jobId, long taskExecutionId, Object output) {
         return fileStorageService.storeFileContent(
-            TASK_EXECUTION_FILES_DIR, taskExecutionId + ".json", CompressionUtils.compress(JsonUtils.write(output)));
+            TASK_EXECUTION_FILES_DIR, taskExecutionId + ".json",
+            CompressionUtils.compress(JsonUtils.write(ValueTagUtils.tag(output))));
     }
 }

--- a/server/libs/atlas/atlas-file-storage/atlas-file-storage-impl/src/test/java/com/bytechef/atlas/file/storage/TaskFileStorageSerializationTest.java
+++ b/server/libs/atlas/atlas-file-storage/atlas-file-storage-impl/src/test/java/com/bytechef/atlas/file/storage/TaskFileStorageSerializationTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2025 ByteChef
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.bytechef.atlas.file.storage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.bytechef.commons.util.JsonUtils;
+import com.bytechef.file.storage.base64.service.Base64FileStorageService;
+import com.bytechef.file.storage.domain.FileEntry;
+import com.bytechef.test.extension.ObjectMapperSetupExtension;
+import java.sql.Date;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * @author Ivica Cardic
+ */
+@ExtendWith(ObjectMapperSetupExtension.class)
+public class TaskFileStorageSerializationTest {
+
+    private final TaskFileStorage taskFileStorage = new TaskFileStorageImpl(new Base64FileStorageService());
+
+    @Test
+    public void testSerializedOutputNeverLeaksTheValueTag() {
+        Object secondPrecisionOutput =
+            List.of(Map.of("APPLYDATE", Timestamp.from(Instant.parse("2026-08-26T00:00:00Z"))));
+
+        FileEntry secondPrecisionFileEntry = taskFileStorage.storeTaskExecutionOutput(1L, 1L, secondPrecisionOutput);
+
+        assertEquals(
+            "[{\"APPLYDATE\":\"2026-08-26T00:00:00Z\"}]",
+            JsonUtils.write(taskFileStorage.readTaskExecutionOutput(secondPrecisionFileEntry)));
+
+        Object nanosecondPrecisionOutput =
+            List.of(Map.of("APPLYDATE", Timestamp.from(Instant.parse("2026-08-26T00:00:00.123456789Z"))));
+
+        FileEntry nanosecondPrecisionFileEntry =
+            taskFileStorage.storeTaskExecutionOutput(1L, 2L, nanosecondPrecisionOutput);
+
+        assertEquals(
+            "[{\"APPLYDATE\":\"2026-08-26T00:00:00.123456789Z\"}]",
+            JsonUtils.write(taskFileStorage.readTaskExecutionOutput(nanosecondPrecisionFileEntry)));
+
+        Object sqlDateOutput = List.of(Map.of("APPLYDATE", Date.valueOf("2026-08-26")));
+
+        FileEntry sqlDateFileEntry = taskFileStorage.storeTaskExecutionOutput(1L, 3L, sqlDateOutput);
+
+        assertEquals(
+            "[{\"APPLYDATE\":\"2026-08-26\"}]",
+            JsonUtils.write(taskFileStorage.readTaskExecutionOutput(sqlDateFileEntry)));
+    }
+}

--- a/server/libs/atlas/atlas-file-storage/atlas-file-storage-impl/src/test/java/com/bytechef/atlas/file/storage/TaskFileStorageTest.java
+++ b/server/libs/atlas/atlas-file-storage/atlas-file-storage-impl/src/test/java/com/bytechef/atlas/file/storage/TaskFileStorageTest.java
@@ -79,4 +79,31 @@ public class TaskFileStorageTest {
             Map.of("result", ZonedDateTime.parse("2026-08-26T00:00:00Z")),
             taskFileStorage.readJobOutputs(fileEntry));
     }
+
+    @Test
+    public void testContextValueSurvivesAMapThatLooksLikeATag() {
+        Map<String, ?> context = Map.of("@bytechefType", "LONG", "@bytechefValue", "5");
+
+        FileEntry fileEntry = taskFileStorage.storeContextValue(1L, Context.Classname.JOB, context);
+
+        assertEquals(context, taskFileStorage.readContextValue(fileEntry));
+    }
+
+    @Test
+    public void testJobOutputsSurviveAMapThatLooksLikeATag() {
+        Map<String, ?> outputs = Map.of("@bytechefType", "LONG", "@bytechefValue", "5");
+
+        FileEntry fileEntry = taskFileStorage.storeJobOutputs(1L, outputs);
+
+        assertEquals(outputs, taskFileStorage.readJobOutputs(fileEntry));
+    }
+
+    @Test
+    public void testTaskExecutionOutputSurvivesAMapThatLooksLikeATag() {
+        Object output = List.of(Map.of("@bytechefType", "ZONED_DATE_TIME", "@bytechefValue", "2026-08-26T00:00:00Z"));
+
+        FileEntry fileEntry = taskFileStorage.storeTaskExecutionOutput(1L, 1L, output);
+
+        assertEquals(output, taskFileStorage.readTaskExecutionOutput(fileEntry));
+    }
 }

--- a/server/libs/atlas/atlas-file-storage/atlas-file-storage-impl/src/test/java/com/bytechef/atlas/file/storage/TaskFileStorageTest.java
+++ b/server/libs/atlas/atlas-file-storage/atlas-file-storage-impl/src/test/java/com/bytechef/atlas/file/storage/TaskFileStorageTest.java
@@ -16,16 +16,67 @@
 
 package com.bytechef.atlas.file.storage;
 
-import org.junit.jupiter.api.Disabled;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.bytechef.atlas.execution.domain.Context;
+import com.bytechef.file.storage.base64.service.Base64FileStorageService;
+import com.bytechef.file.storage.domain.FileEntry;
+import com.bytechef.test.extension.ObjectMapperSetupExtension;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * @author Ivica Cardic
  */
+@ExtendWith(ObjectMapperSetupExtension.class)
 public class TaskFileStorageTest {
 
-    @Disabled
+    private final TaskFileStorage taskFileStorage = new TaskFileStorageImpl(new Base64FileStorageService());
+
     @Test
-    public void test() {
+    public void testTaskExecutionOutputPreservesTemporalValues() {
+        Object output = List.of(Map.of("APPLYDATE", Timestamp.from(Instant.parse("2026-08-26T00:00:00Z"))));
+
+        FileEntry fileEntry = taskFileStorage.storeTaskExecutionOutput(1L, 1L, output);
+
+        assertEquals(
+            List.of(Map.of("APPLYDATE", ZonedDateTime.parse("2026-08-26T00:00:00Z"))),
+            taskFileStorage.readTaskExecutionOutput(fileEntry));
+    }
+
+    @Test
+    public void testTaskExecutionOutputLeavesStringsAsStrings() {
+        Object output = Map.of("latestModifyDate", "2026-08-24T22:00:00Z");
+
+        FileEntry fileEntry = taskFileStorage.storeTaskExecutionOutput(1L, 2L, output);
+
+        assertEquals(output, taskFileStorage.readTaskExecutionOutput(fileEntry));
+    }
+
+    @Test
+    public void testContextValuePreservesTemporalValues() {
+        Map<String, ?> context = Map.of("dbDate", Timestamp.from(Instant.parse("2026-08-26T00:00:00Z")));
+
+        FileEntry fileEntry = taskFileStorage.storeContextValue(1L, Context.Classname.JOB, context);
+
+        assertEquals(
+            Map.of("dbDate", ZonedDateTime.parse("2026-08-26T00:00:00Z")),
+            taskFileStorage.readContextValue(fileEntry));
+    }
+
+    @Test
+    public void testJobOutputsPreserveTemporalValues() {
+        Map<String, ?> outputs = Map.of("result", Timestamp.from(Instant.parse("2026-08-26T00:00:00Z")));
+
+        FileEntry fileEntry = taskFileStorage.storeJobOutputs(1L, outputs);
+
+        assertEquals(
+            Map.of("result", ZonedDateTime.parse("2026-08-26T00:00:00Z")),
+            taskFileStorage.readJobOutputs(fileEntry));
     }
 }

--- a/server/libs/core/commons/commons-util/src/main/java/com/bytechef/commons/util/TemporalValueUtils.java
+++ b/server/libs/core/commons/commons-util/src/main/java/com/bytechef/commons/util/TemporalValueUtils.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025 ByteChef
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.bytechef.commons.util;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Normalizes temporal values so that every value fixing a point on the timeline is represented as a
+ * {@link ZonedDateTime} at UTC, which is the type {@code parseDate} returns and therefore the one workflow expressions
+ * can compare against.
+ *
+ * @author Ivica Cardic
+ */
+public final class TemporalValueUtils {
+
+    private TemporalValueUtils() {
+    }
+
+    public static @Nullable Object normalize(@Nullable Object value) {
+        return switch (value) {
+            case null -> null;
+            case java.sql.Date sqlDate -> sqlDate.toLocalDate();
+            case java.sql.Time sqlTime -> sqlTime.toLocalTime();
+            case Date date -> date.toInstant()
+                .atZone(ZoneOffset.UTC);
+            case Instant instant -> instant.atZone(ZoneOffset.UTC);
+            case OffsetDateTime offsetDateTime -> offsetDateTime.toInstant()
+                .atZone(ZoneOffset.UTC);
+            case ZonedDateTime zonedDateTime -> zonedDateTime.withZoneSameInstant(ZoneOffset.UTC);
+            case LocalDate localDate -> localDate;
+            case LocalDateTime localDateTime -> localDateTime;
+            case LocalTime localTime -> localTime;
+            case OffsetTime offsetTime -> offsetTime;
+            case Map<?, ?> map -> normalizeMap(map);
+            case List<?> list -> normalizeList(list);
+            default -> value;
+        };
+    }
+
+    private static Map<String, @Nullable Object> normalizeMap(Map<?, ?> map) {
+        Map<String, @Nullable Object> normalizedMap = new LinkedHashMap<>();
+
+        for (Map.Entry<?, ?> entry : map.entrySet()) {
+            normalizedMap.put(String.valueOf(entry.getKey()), normalize(entry.getValue()));
+        }
+
+        return normalizedMap;
+    }
+
+    private static List<@Nullable Object> normalizeList(List<?> list) {
+        List<@Nullable Object> normalizedList = new ArrayList<>(list.size());
+
+        for (Object item : list) {
+            normalizedList.add(normalize(item));
+        }
+
+        return normalizedList;
+    }
+}

--- a/server/libs/core/commons/commons-util/src/main/java/com/bytechef/commons/util/ValueTagUtils.java
+++ b/server/libs/core/commons/commons-util/src/main/java/com/bytechef/commons/util/ValueTagUtils.java
@@ -74,7 +74,7 @@ public final class ValueTagUtils {
     public static @Nullable Object untag(@Nullable Object value) {
         return switch (value) {
             case null -> null;
-            case Map<?, ?> map -> untagMap(map);
+            case Map<?, ?> map -> untagScalarOrMap(map);
             case List<?> list -> {
                 List<@Nullable Object> untaggedList = new ArrayList<>(list.size());
 
@@ -86,6 +86,17 @@ public final class ValueTagUtils {
             }
             default -> value;
         };
+    }
+
+    /**
+     * Reads back a value that was stored as a map. Unlike {@link #untag(Object)} this never reconstructs the map itself
+     * into a scalar: what was written as a map is a map, so a top-level tag shape here can only be payload data, and
+     * reconstructing it would both lose that data and break the caller's return type.
+     */
+    public static Map<String, @Nullable Object> untagMap(Map<String, ?> value) {
+        Map<?, ?> escaped = escapedMap(value);
+
+        return untagEntries(escaped == null ? value : escaped);
     }
 
     private static @Nullable Object tagNormalized(@Nullable Object value) {
@@ -134,8 +145,10 @@ public final class ValueTagUtils {
         return tag;
     }
 
-    private static Object untagMap(Map<?, ?> map) {
-        if (isTagShaped(map) && MAP_TYPE.equals(map.get(TYPE_KEY)) && map.get(VALUE_KEY) instanceof Map<?, ?> escaped) {
+    private static Object untagScalarOrMap(Map<?, ?> map) {
+        Map<?, ?> escaped = escapedMap(map);
+
+        if (escaped != null) {
             return untagEntries(escaped);
         }
 
@@ -158,13 +171,21 @@ public final class ValueTagUtils {
         return untaggedMap;
     }
 
+    private static @Nullable Map<?, ?> escapedMap(Map<?, ?> map) {
+        if (isTagShaped(map) && MAP_TYPE.equals(map.get(TYPE_KEY)) && map.get(VALUE_KEY) instanceof Map<?, ?> escaped) {
+            return escaped;
+        }
+
+        return null;
+    }
+
     private static boolean isTagShaped(Map<?, ?> map) {
         return map.size() == 2 && map.containsKey(TYPE_KEY) && map.containsKey(VALUE_KEY);
     }
 
     /**
-     * Whether {@link #untagMap(Map)} would read this map back as something other than a plain map, which is exactly
-     * when a map carrying user data of the same shape has to be escaped on write.
+     * Whether {@link #untagScalarOrMap(Map)} would read this map back as something other than a plain map, which is
+     * exactly when a map carrying user data of the same shape has to be escaped on write.
      */
     private static boolean isReconstructable(Map<?, ?> map) {
         if (!isTagShaped(map) || !(map.get(TYPE_KEY) instanceof String type)) {

--- a/server/libs/core/commons/commons-util/src/main/java/com/bytechef/commons/util/ValueTagUtils.java
+++ b/server/libs/core/commons/commons-util/src/main/java/com/bytechef/commons/util/ValueTagUtils.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2025 ByteChef
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.bytechef.commons.util;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetTime;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Encodes and decodes values whose Java type would otherwise be erased by a round trip through untyped JSON, wrapping
+ * each such value in a {@code {"@bytechefType": ..., "@bytechefValue": ...}} tag that {@link #untag(Object)}
+ * reconstructs. Temporal values are normalized via {@link TemporalValueUtils#normalize(Object)} before being tagged;
+ * numeric values are tagged as-is.
+ *
+ * @author Ivica Cardic
+ */
+public final class ValueTagUtils {
+
+    private static final String TYPE_KEY = "@bytechefType";
+    private static final String VALUE_KEY = "@bytechefValue";
+
+    private static final Map<String, Function<String, Object>> PARSERS = Map.ofEntries(
+        Map.entry("ZONED_DATE_TIME", ZonedDateTime::parse),
+        Map.entry("LOCAL_DATE", LocalDate::parse),
+        Map.entry("LOCAL_DATE_TIME", LocalDateTime::parse),
+        Map.entry("LOCAL_TIME", LocalTime::parse),
+        Map.entry("OFFSET_TIME", OffsetTime::parse),
+        Map.entry("BIG_DECIMAL", BigDecimal::new),
+        Map.entry("BIG_INTEGER", BigInteger::new),
+        Map.entry("LONG", Long::parseLong),
+        Map.entry("FLOAT", Float::parseFloat),
+        Map.entry("SHORT", Short::parseShort),
+        Map.entry("BYTE", Byte::parseByte));
+
+    private ValueTagUtils() {
+    }
+
+    public static @Nullable Object tag(@Nullable Object value) {
+        return tagNormalized(TemporalValueUtils.normalize(value));
+    }
+
+    public static @Nullable Object untag(@Nullable Object value) {
+        return switch (value) {
+            case null -> null;
+            case Map<?, ?> map -> untagMap(map);
+            case List<?> list -> {
+                List<@Nullable Object> untaggedList = new ArrayList<>(list.size());
+
+                for (Object item : list) {
+                    untaggedList.add(untag(item));
+                }
+
+                yield untaggedList;
+            }
+            default -> value;
+        };
+    }
+
+    private static @Nullable Object tagNormalized(@Nullable Object value) {
+        return switch (value) {
+            case null -> null;
+            case ZonedDateTime zonedDateTime -> tagOf("ZONED_DATE_TIME", zonedDateTime.toInstant()
+                .toString());
+            case LocalDate localDate -> tagOf("LOCAL_DATE", localDate.toString());
+            case LocalDateTime localDateTime -> tagOf("LOCAL_DATE_TIME", localDateTime.toString());
+            case LocalTime localTime -> tagOf("LOCAL_TIME", localTime.toString());
+            case OffsetTime offsetTime -> tagOf("OFFSET_TIME", offsetTime.toString());
+            case BigDecimal bigDecimal -> tagOf("BIG_DECIMAL", bigDecimal.toPlainString());
+            case BigInteger bigInteger -> tagOf("BIG_INTEGER", bigInteger.toString());
+            case Long longValue -> tagOf("LONG", longValue.toString());
+            case Float floatValue -> tagOf("FLOAT", floatValue.toString());
+            case Short shortValue -> tagOf("SHORT", shortValue.toString());
+            case Byte byteValue -> tagOf("BYTE", byteValue.toString());
+            case Map<?, ?> map -> {
+                Map<String, @Nullable Object> taggedMap = new LinkedHashMap<>();
+
+                for (Map.Entry<?, ?> entry : map.entrySet()) {
+                    taggedMap.put(String.valueOf(entry.getKey()), tagNormalized(entry.getValue()));
+                }
+
+                yield taggedMap;
+            }
+            case List<?> list -> {
+                List<@Nullable Object> taggedList = new ArrayList<>(list.size());
+
+                for (Object item : list) {
+                    taggedList.add(tagNormalized(item));
+                }
+
+                yield taggedList;
+            }
+            default -> value;
+        };
+    }
+
+    private static Map<String, Object> tagOf(String type, String value) {
+        Map<String, Object> tag = new LinkedHashMap<>();
+
+        tag.put(TYPE_KEY, type);
+        tag.put(VALUE_KEY, value);
+
+        return tag;
+    }
+
+    private static Object untagMap(Map<?, ?> map) {
+        Object reconstructed = reconstruct(map);
+
+        if (reconstructed != null) {
+            return reconstructed;
+        }
+
+        Map<String, @Nullable Object> untaggedMap = new LinkedHashMap<>();
+
+        for (Map.Entry<?, ?> entry : map.entrySet()) {
+            untaggedMap.put(String.valueOf(entry.getKey()), untag(entry.getValue()));
+        }
+
+        return untaggedMap;
+    }
+
+    private static @Nullable Object reconstruct(Map<?, ?> map) {
+        if (map.size() != 2 || !map.containsKey(TYPE_KEY) || !map.containsKey(VALUE_KEY)) {
+            return null;
+        }
+
+        if (!(map.get(TYPE_KEY) instanceof String type) || !(map.get(VALUE_KEY) instanceof String value)) {
+            return null;
+        }
+
+        Function<String, Object> parser = PARSERS.get(type);
+
+        if (parser == null) {
+            return null;
+        }
+
+        try {
+            return parser.apply(value);
+        } catch (DateTimeParseException | NumberFormatException exception) {
+            return null;
+        }
+    }
+}

--- a/server/libs/core/commons/commons-util/src/main/java/com/bytechef/commons/util/ValueTagUtils.java
+++ b/server/libs/core/commons/commons-util/src/main/java/com/bytechef/commons/util/ValueTagUtils.java
@@ -37,12 +37,19 @@ import org.jspecify.annotations.Nullable;
  * reconstructs. Temporal values are normalized via {@link TemporalValueUtils#normalize(Object)} before being tagged;
  * numeric values are tagged as-is.
  *
+ * <p>
+ * Payload data can itself be a map of exactly that shape -- an API response whose body happens to use those two field
+ * names. Such a map is escaped on write by wrapping it in a {@code MAP} tag, so {@link #untag(Object)} can tell an
+ * encoder-written tag from user data that merely looks like one and neither is mistaken for the other.
+ *
  * @author Ivica Cardic
  */
 public final class ValueTagUtils {
 
     private static final String TYPE_KEY = "@bytechefType";
     private static final String VALUE_KEY = "@bytechefValue";
+
+    private static final String MAP_TYPE = "MAP";
 
     private static final Map<String, Function<String, Object>> PARSERS = Map.ofEntries(
         Map.entry("ZONED_DATE_TIME", ZonedDateTime::parse),
@@ -103,7 +110,7 @@ public final class ValueTagUtils {
                     taggedMap.put(String.valueOf(entry.getKey()), tagNormalized(entry.getValue()));
                 }
 
-                yield taggedMap;
+                yield isReconstructable(taggedMap) ? tagOf(MAP_TYPE, taggedMap) : taggedMap;
             }
             case List<?> list -> {
                 List<@Nullable Object> taggedList = new ArrayList<>(list.size());
@@ -118,7 +125,7 @@ public final class ValueTagUtils {
         };
     }
 
-    private static Map<String, Object> tagOf(String type, String value) {
+    private static Map<String, Object> tagOf(String type, Object value) {
         Map<String, Object> tag = new LinkedHashMap<>();
 
         tag.put(TYPE_KEY, type);
@@ -128,12 +135,20 @@ public final class ValueTagUtils {
     }
 
     private static Object untagMap(Map<?, ?> map) {
+        if (isTagShaped(map) && MAP_TYPE.equals(map.get(TYPE_KEY)) && map.get(VALUE_KEY) instanceof Map<?, ?> escaped) {
+            return untagEntries(escaped);
+        }
+
         Object reconstructed = reconstruct(map);
 
         if (reconstructed != null) {
             return reconstructed;
         }
 
+        return untagEntries(map);
+    }
+
+    private static Map<String, @Nullable Object> untagEntries(Map<?, ?> map) {
         Map<String, @Nullable Object> untaggedMap = new LinkedHashMap<>();
 
         for (Map.Entry<?, ?> entry : map.entrySet()) {
@@ -143,8 +158,27 @@ public final class ValueTagUtils {
         return untaggedMap;
     }
 
+    private static boolean isTagShaped(Map<?, ?> map) {
+        return map.size() == 2 && map.containsKey(TYPE_KEY) && map.containsKey(VALUE_KEY);
+    }
+
+    /**
+     * Whether {@link #untagMap(Map)} would read this map back as something other than a plain map, which is exactly
+     * when a map carrying user data of the same shape has to be escaped on write.
+     */
+    private static boolean isReconstructable(Map<?, ?> map) {
+        if (!isTagShaped(map) || !(map.get(TYPE_KEY) instanceof String type)) {
+            return false;
+        }
+
+        Object value = map.get(VALUE_KEY);
+
+        return (PARSERS.containsKey(type) && value instanceof String) ||
+            (MAP_TYPE.equals(type) && value instanceof Map);
+    }
+
     private static @Nullable Object reconstruct(Map<?, ?> map) {
-        if (map.size() != 2 || !map.containsKey(TYPE_KEY) || !map.containsKey(VALUE_KEY)) {
+        if (!isTagShaped(map)) {
             return null;
         }
 

--- a/server/libs/core/commons/commons-util/src/test/java/com/bytechef/commons/util/TemporalValueUtilsTest.java
+++ b/server/libs/core/commons/commons-util/src/test/java/com/bytechef/commons/util/TemporalValueUtilsTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2025 ByteChef
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.bytechef.commons.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class TemporalValueUtilsTest {
+
+    private static final ZonedDateTime EXPECTED = ZonedDateTime.parse("2026-08-26T00:00:00Z");
+
+    @Test
+    public void testNormalizeInstantBearingTypesToUtcZonedDateTime() {
+        assertEquals(EXPECTED, TemporalValueUtils.normalize(Timestamp.from(Instant.parse("2026-08-26T00:00:00Z"))));
+        assertEquals(EXPECTED, TemporalValueUtils.normalize(Instant.parse("2026-08-26T00:00:00Z")));
+        assertEquals(EXPECTED,
+            TemporalValueUtils.normalize(java.util.Date.from(Instant.parse("2026-08-26T00:00:00Z"))));
+        assertEquals(EXPECTED, TemporalValueUtils.normalize(OffsetDateTime.parse("2026-08-26T02:00:00+02:00")));
+        assertEquals(EXPECTED, TemporalValueUtils.normalize(ZonedDateTime.parse("2026-08-26T02:00:00+02:00")));
+    }
+
+    @Test
+    public void testNormalizeLeavesValuesThatFixNoInstant() {
+        assertEquals(LocalDate.of(2026, 8, 26), TemporalValueUtils.normalize(LocalDate.of(2026, 8, 26)));
+        assertEquals(
+            LocalDateTime.of(2026, 8, 26, 0, 0), TemporalValueUtils.normalize(LocalDateTime.of(2026, 8, 26, 0, 0)));
+        assertEquals(LocalTime.of(10, 30), TemporalValueUtils.normalize(LocalTime.of(10, 30)));
+    }
+
+    @Test
+    public void testNormalizeMapsSqlDateAndTimeToTheirOwnTypes() {
+        assertEquals(LocalDate.of(2026, 8, 26), TemporalValueUtils.normalize(java.sql.Date.valueOf("2026-08-26")));
+        assertEquals(LocalTime.of(10, 30), TemporalValueUtils.normalize(java.sql.Time.valueOf("10:30:00")));
+    }
+
+    @Test
+    public void testNormalizeRecursesIntoListsAndMaps() {
+        Object normalized = TemporalValueUtils.normalize(
+            List.of(Map.of("APPLYDATE", Timestamp.from(Instant.parse("2026-08-26T00:00:00Z")))));
+
+        assertEquals(List.of(Map.of("APPLYDATE", EXPECTED)), normalized);
+    }
+
+    @Test
+    public void testNormalizeLeavesNonTemporalValuesUntouched() {
+        assertEquals("2026-08-26T00:00:00.000Z", TemporalValueUtils.normalize("2026-08-26T00:00:00.000Z"));
+        assertEquals(42, TemporalValueUtils.normalize(42));
+        assertNull(TemporalValueUtils.normalize(null));
+    }
+
+    @Test
+    public void testNormalizeIsIdempotent() {
+        Object once = TemporalValueUtils.normalize(Timestamp.from(Instant.parse("2026-08-26T00:00:00Z")));
+
+        assertEquals(once, TemporalValueUtils.normalize(once));
+    }
+
+    @Test
+    public void testNormalizePreservesTheInstantWhenChangingZone() {
+        ZonedDateTime normalized = (ZonedDateTime) TemporalValueUtils.normalize(
+            ZonedDateTime.parse("2026-08-26T02:00:00+02:00"));
+
+        assertEquals(ZoneOffset.UTC, normalized.getZone());
+        assertEquals(Instant.parse("2026-08-26T00:00:00Z"), normalized.toInstant());
+    }
+}

--- a/server/libs/core/commons/commons-util/src/test/java/com/bytechef/commons/util/ValueTagUtilsTest.java
+++ b/server/libs/core/commons/commons-util/src/test/java/com/bytechef/commons/util/ValueTagUtilsTest.java
@@ -17,6 +17,7 @@
 package com.bytechef.commons.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -31,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
+@SuppressWarnings("unchecked")
 public class ValueTagUtilsTest {
 
     @Test
@@ -175,5 +177,31 @@ public class ValueTagUtilsTest {
             "real", 5L);
 
         assertEquals(value, ValueTagUtils.untag(ValueTagUtils.tag(value)));
+    }
+
+    @Test
+    public void testUntagMapKeepsAnUnescapedLookalikeAsAMap() {
+        Map<String, Object> legacy = Map.of("@bytechefType", "LONG", "@bytechefValue", "5");
+
+        assertEquals(legacy, ValueTagUtils.untagMap(legacy));
+    }
+
+    @Test
+    public void testUntagMapUnwrapsAnEscapedMap() {
+        Map<String, Object> lookalike = Map.of("@bytechefType", "LONG", "@bytechefValue", "5");
+
+        Object tagged = ValueTagUtils.tag(lookalike);
+
+        assertInstanceOf(Map.class, tagged);
+        assertEquals(lookalike, ValueTagUtils.untagMap((Map<String, ?>) tagged));
+    }
+
+    @Test
+    public void testUntagMapStillReconstructsValuesInsideTheMap() {
+        Map<String, Object> tagged = Map.of(
+            "when", Map.of("@bytechefType", "ZONED_DATE_TIME", "@bytechefValue", "2026-08-26T00:00:00Z"));
+
+        assertEquals(
+            Map.of("when", java.time.ZonedDateTime.parse("2026-08-26T00:00:00Z")), ValueTagUtils.untagMap(tagged));
     }
 }

--- a/server/libs/core/commons/commons-util/src/test/java/com/bytechef/commons/util/ValueTagUtilsTest.java
+++ b/server/libs/core/commons/commons-util/src/test/java/com/bytechef/commons/util/ValueTagUtilsTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2025 ByteChef
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.bytechef.commons.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class ValueTagUtilsTest {
+
+    @Test
+    public void testTagRoundTripsEveryReconstructedType() {
+        List<Object> values = List.of(
+            java.time.ZonedDateTime.parse("2026-08-26T00:00:00Z"), LocalDate.of(2026, 8, 26),
+            LocalDateTime.of(2026, 8, 26, 0, 0), LocalTime.of(10, 30),
+            java.time.OffsetTime.parse("10:30:00+02:00"));
+
+        for (Object value : values) {
+            assertEquals(value, ValueTagUtils.untag(ValueTagUtils.tag(value)), String.valueOf(value));
+        }
+    }
+
+    @Test
+    public void testTagNormalizesBeforeTagging() {
+        Object tagged = ValueTagUtils.tag(Timestamp.from(Instant.parse("2026-08-26T00:00:00Z")));
+
+        assertEquals(
+            Map.of("@bytechefType", "ZONED_DATE_TIME", "@bytechefValue", "2026-08-26T00:00:00Z"), tagged);
+        assertEquals(java.time.ZonedDateTime.parse("2026-08-26T00:00:00Z"), ValueTagUtils.untag(tagged));
+    }
+
+    @Test
+    public void testTagRecursesIntoListsAndMaps() {
+        Object tagged = ValueTagUtils.tag(
+            List.of(Map.of("APPLYDATE", Timestamp.from(Instant.parse("2026-08-26T00:00:00Z")))));
+
+        assertEquals(
+            List.of(Map.of("APPLYDATE", java.time.ZonedDateTime.parse("2026-08-26T00:00:00Z"))),
+            ValueTagUtils.untag(tagged));
+    }
+
+    @Test
+    public void testUntagLeavesUntaggedDataUnchanged() {
+        Object legacy = List.of(Map.of("APPLYDATE", "2026-08-26T00:00:00.000Z"));
+
+        assertEquals(legacy, ValueTagUtils.untag(legacy));
+    }
+
+    @Test
+    public void testUntagTreatsLookalikeMapsAsPlainData() {
+        Map<String, Object> unknownType = Map.of("@bytechefType", "NOT_A_TYPE", "@bytechefValue", "x");
+        Map<String, Object> extraKey = Map.of(
+            "@bytechefType", "ZONED_DATE_TIME", "@bytechefValue", "2026-08-26T00:00:00Z", "extra", 1);
+        Map<String, Object> unparseableValue = Map.of(
+            "@bytechefType", "ZONED_DATE_TIME", "@bytechefValue", "not-a-date");
+
+        assertEquals(unknownType, ValueTagUtils.untag(unknownType));
+        assertEquals(extraKey, ValueTagUtils.untag(extraKey));
+        assertEquals(unparseableValue, ValueTagUtils.untag(unparseableValue));
+    }
+
+    @Test
+    public void testTagRoundTripsEveryNumericType() {
+        List<Object> values = List.of(
+            new BigDecimal("7.5345"), new BigInteger("123456789012345678901234567890"), Long.valueOf(42L),
+            Float.valueOf(9.5f), Short.valueOf((short) 7), Byte.valueOf((byte) 5));
+
+        for (Object value : values) {
+            assertEquals(value, ValueTagUtils.untag(ValueTagUtils.tag(value)), String.valueOf(value));
+        }
+    }
+
+    @Test
+    public void testTagPreservesBigDecimalScale() {
+        BigDecimal withTrailingZero = new BigDecimal("1.10");
+        BigDecimal withoutTrailingZero = new BigDecimal("1.1");
+
+        assertNotEquals(withTrailingZero, withoutTrailingZero);
+
+        Object untaggedWithTrailingZero = ValueTagUtils.untag(ValueTagUtils.tag(withTrailingZero));
+        Object untaggedWithoutTrailingZero = ValueTagUtils.untag(ValueTagUtils.tag(withoutTrailingZero));
+
+        assertEquals(withTrailingZero, untaggedWithTrailingZero);
+        assertEquals(withoutTrailingZero, untaggedWithoutTrailingZero);
+        assertNotEquals(untaggedWithTrailingZero, untaggedWithoutTrailingZero);
+    }
+
+    @Test
+    public void testTagWritesBigDecimalAsPlainString() {
+        Object tagged = ValueTagUtils.tag(new BigDecimal("0.0000001"));
+
+        assertEquals(Map.of("@bytechefType", "BIG_DECIMAL", "@bytechefValue", "0.0000001"), tagged);
+    }
+
+    @Test
+    public void testTagLeavesIntegerDoubleBooleanAndStringUntagged() {
+        assertEquals(42, ValueTagUtils.tag(42));
+        assertEquals(9.5, ValueTagUtils.tag(9.5));
+        assertEquals(true, ValueTagUtils.tag(true));
+        assertEquals("hello", ValueTagUtils.tag("hello"));
+    }
+
+    @Test
+    public void testTagRecursesIntoListsAndMapsForNumericValues() {
+        Object tagged = ValueTagUtils.tag(List.of(Map.of("AMOUNT", new BigDecimal("7.5345"))));
+
+        assertEquals(
+            List.of(Map.of("AMOUNT", new BigDecimal("7.5345"))),
+            ValueTagUtils.untag(tagged));
+    }
+
+    @Test
+    public void testUntagReturnsPlainDataForUnparseableNumericValue() {
+        Map<String, Object> unparseableValue = Map.of("@bytechefType", "LONG", "@bytechefValue", "not-a-number");
+
+        assertEquals(unparseableValue, ValueTagUtils.untag(unparseableValue));
+    }
+
+    @Test
+    public void testUntagReturnsNullForNull() {
+        assertNull(ValueTagUtils.untag(null));
+    }
+}

--- a/server/libs/core/commons/commons-util/src/test/java/com/bytechef/commons/util/ValueTagUtilsTest.java
+++ b/server/libs/core/commons/commons-util/src/test/java/com/bytechef/commons/util/ValueTagUtilsTest.java
@@ -145,4 +145,35 @@ public class ValueTagUtilsTest {
     public void testUntagReturnsNullForNull() {
         assertNull(ValueTagUtils.untag(null));
     }
+
+    @Test
+    public void testTagEscapesAMapThatWouldBeReadBackAsATag() {
+        Map<String, Object> lookalike = Map.of("@bytechefType", "LONG", "@bytechefValue", "5");
+
+        assertEquals(lookalike, ValueTagUtils.untag(ValueTagUtils.tag(lookalike)));
+    }
+
+    @Test
+    public void testTagEscapesALookalikeMapNestedInsideAList() {
+        Object value = List.of(
+            Map.of("row", Map.of("@bytechefType", "ZONED_DATE_TIME", "@bytechefValue", "2026-08-26T00:00:00Z")));
+
+        assertEquals(value, ValueTagUtils.untag(ValueTagUtils.tag(value)));
+    }
+
+    @Test
+    public void testTagEscapesAMapShapedLikeTheEscapeItself() {
+        Map<String, Object> lookalike = Map.of("@bytechefType", "MAP", "@bytechefValue", Map.of("a", 1));
+
+        assertEquals(lookalike, ValueTagUtils.untag(ValueTagUtils.tag(lookalike)));
+    }
+
+    @Test
+    public void testTagKeepsARealTagAndALookalikeApartInTheSameMap() {
+        Map<String, Object> value = Map.of(
+            "lookalike", Map.of("@bytechefType", "LONG", "@bytechefValue", "5"),
+            "real", 5L);
+
+        assertEquals(value, ValueTagUtils.untag(ValueTagUtils.tag(value)));
+    }
 }

--- a/server/libs/core/evaluator/evaluator-api/src/main/java/com/bytechef/evaluator/Evaluator.java
+++ b/server/libs/core/evaluator/evaluator-api/src/main/java/com/bytechef/evaluator/Evaluator.java
@@ -40,8 +40,10 @@ public interface Evaluator {
      *
      * @param map     The {@link java.util.Map} instance to evaluate
      * @param context The context to evaluate the task against
-     * @param lenient When {@code true} (editor preview), invalid formula expressions return the original value. When
-     *                {@code false} (workflow execution), invalid formula expressions throw an exception.
+     * @param lenient When {@code true} (editor preview), a formula expression that is invalid or fails to evaluate
+     *                returns the original value. When {@code false} (workflow execution), it throws an exception. Plain
+     *                {@code ${...}} accessors always return the original value when they cannot be resolved, in either
+     *                mode.
      * @return the evaluate {@link java.util.Map}.
      */
     default Map<String, @Nullable Object> evaluate(Map<String, ?> map, Map<String, ?> context, boolean lenient) {

--- a/server/libs/core/evaluator/evaluator-impl/build.gradle.kts
+++ b/server/libs/core/evaluator/evaluator-impl/build.gradle.kts
@@ -1,6 +1,7 @@
 dependencies {
     api(project(":server:libs:core:evaluator:evaluator-api"))
 
+    implementation(project(":server:libs:core:commons:commons-util"))
     implementation("org.slf4j:slf4j-api")
     implementation("org.springframework:spring-context")
     implementation("org.springframework:spring-expression")

--- a/server/libs/core/evaluator/evaluator-impl/src/main/java/com/bytechef/evaluator/Parse.java
+++ b/server/libs/core/evaluator/evaluator-impl/src/main/java/com/bytechef/evaluator/Parse.java
@@ -16,8 +16,10 @@
 
 package com.bytechef.evaluator;
 
+import com.bytechef.commons.util.TemporalValueUtils;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import org.springframework.expression.AccessException;
@@ -43,20 +45,51 @@ class Parse implements MethodExecutor {
 
     @Override
     public TypedValue execute(EvaluationContext context, Object target, Object... arguments) throws AccessException {
+        Object argument = TemporalValueUtils.normalize(arguments[0]);
+
+        if (argument instanceof ZonedDateTime zonedDateTime) {
+            return new TypedValue(type == Type.DATE ? zonedDateTime : zonedDateTime.toLocalDateTime());
+        }
+
+        if (argument instanceof LocalDateTime localDateTime) {
+            return new TypedValue(type == Type.DATE ? localDateTime.atZone(ZoneOffset.UTC) : localDateTime);
+        }
+
+        if (argument instanceof LocalDate localDate) {
+            return new TypedValue(type == Type.DATE ? localDate : localDate.atStartOfDay());
+        }
+
+        if (!(argument instanceof String text)) {
+            String receivedTypeName;
+            if (argument == null) {
+                receivedTypeName = "null";
+            } else {
+                Class<?> argumentClass = argument.getClass();
+
+                receivedTypeName = argumentClass.getName();
+            }
+
+            throw new IllegalArgumentException(
+                "%s expects a string or a temporal value but received %s: %s".formatted(
+                    functionName(), receivedTypeName, argument));
+        }
+
         if (type == Type.DATE) {
             if (arguments.length == 2) {
-                return new TypedValue(
-                    ZonedDateTime.parse((String) arguments[0], DateTimeFormatter.ofPattern((String) arguments[1])));
-            } else {
-                return new TypedValue(LocalDate.parse((String) arguments[0]));
+                return new TypedValue(ZonedDateTime.parse(text, DateTimeFormatter.ofPattern((String) arguments[1])));
             }
-        } else {
-            if (arguments.length == 2) {
-                return new TypedValue(
-                    LocalDateTime.parse((String) arguments[0], DateTimeFormatter.ofPattern((String) arguments[1])));
-            } else {
-                return new TypedValue(LocalDateTime.parse((String) arguments[0]));
-            }
+
+            return new TypedValue(LocalDate.parse(text));
         }
+
+        if (arguments.length == 2) {
+            return new TypedValue(LocalDateTime.parse(text, DateTimeFormatter.ofPattern((String) arguments[1])));
+        }
+
+        return new TypedValue(LocalDateTime.parse(text));
+    }
+
+    private String functionName() {
+        return type == Type.DATE ? "parseDate" : "parseDateTime";
     }
 }

--- a/server/libs/core/evaluator/evaluator-impl/src/main/java/com/bytechef/evaluator/Parse.java
+++ b/server/libs/core/evaluator/evaluator-impl/src/main/java/com/bytechef/evaluator/Parse.java
@@ -47,6 +47,23 @@ class Parse implements MethodExecutor {
 
     @Override
     public TypedValue execute(EvaluationContext context, Object target, Object... arguments) throws AccessException {
+        if (arguments.length == 0 || arguments.length > 2) {
+            throw new AccessException(
+                "%s expects one or two arguments but received %d".formatted(functionName(), arguments.length));
+        }
+
+        String format = null;
+
+        if (arguments.length == 2) {
+            if (!(arguments[1] instanceof String formatArgument)) {
+                throw new AccessException(
+                    "%s expects a string format but received %s: %s".formatted(
+                        functionName(), typeNameOf(arguments[1]), arguments[1]));
+            }
+
+            format = formatArgument;
+        }
+
         Object argument = TemporalValueUtils.normalize(arguments[0]);
 
         if (argument instanceof ZonedDateTime zonedDateTime) {
@@ -68,24 +85,24 @@ class Parse implements MethodExecutor {
         }
 
         try {
-            return new TypedValue(parseText(text, arguments));
+            return new TypedValue(parseText(text, format));
         } catch (DateTimeException | IllegalArgumentException exception) {
             throw new AccessException(
                 "%s cannot parse %s: %s".formatted(functionName(), text, exception.getMessage()), exception);
         }
     }
 
-    private Object parseText(String text, Object[] arguments) {
+    private Object parseText(String text, @Nullable String format) {
         if (type == Type.DATE) {
-            if (arguments.length == 2) {
-                return ZonedDateTime.parse(text, DateTimeFormatter.ofPattern((String) arguments[1]));
+            if (format != null) {
+                return ZonedDateTime.parse(text, DateTimeFormatter.ofPattern(format));
             }
 
             return LocalDate.parse(text);
         }
 
-        if (arguments.length == 2) {
-            return LocalDateTime.parse(text, DateTimeFormatter.ofPattern((String) arguments[1]));
+        if (format != null) {
+            return LocalDateTime.parse(text, DateTimeFormatter.ofPattern(format));
         }
 
         return LocalDateTime.parse(text);

--- a/server/libs/core/evaluator/evaluator-impl/src/main/java/com/bytechef/evaluator/Parse.java
+++ b/server/libs/core/evaluator/evaluator-impl/src/main/java/com/bytechef/evaluator/Parse.java
@@ -17,11 +17,13 @@
 package com.bytechef.evaluator;
 
 import com.bytechef.commons.util.TemporalValueUtils;
+import java.time.DateTimeException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import org.jspecify.annotations.Nullable;
 import org.springframework.expression.AccessException;
 import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.MethodExecutor;
@@ -60,33 +62,43 @@ class Parse implements MethodExecutor {
         }
 
         if (!(argument instanceof String text)) {
-            String receivedTypeName;
-            if (argument == null) {
-                receivedTypeName = "null";
-            } else {
-                Class<?> argumentClass = argument.getClass();
-
-                receivedTypeName = argumentClass.getName();
-            }
-
-            throw new IllegalArgumentException(
+            throw new AccessException(
                 "%s expects a string or a temporal value but received %s: %s".formatted(
-                    functionName(), receivedTypeName, argument));
+                    functionName(), typeNameOf(argument), argument));
         }
 
+        try {
+            return new TypedValue(parseText(text, arguments));
+        } catch (DateTimeException | IllegalArgumentException exception) {
+            throw new AccessException(
+                "%s cannot parse %s: %s".formatted(functionName(), text, exception.getMessage()), exception);
+        }
+    }
+
+    private Object parseText(String text, Object[] arguments) {
         if (type == Type.DATE) {
             if (arguments.length == 2) {
-                return new TypedValue(ZonedDateTime.parse(text, DateTimeFormatter.ofPattern((String) arguments[1])));
+                return ZonedDateTime.parse(text, DateTimeFormatter.ofPattern((String) arguments[1]));
             }
 
-            return new TypedValue(LocalDate.parse(text));
+            return LocalDate.parse(text);
         }
 
         if (arguments.length == 2) {
-            return new TypedValue(LocalDateTime.parse(text, DateTimeFormatter.ofPattern((String) arguments[1])));
+            return LocalDateTime.parse(text, DateTimeFormatter.ofPattern((String) arguments[1]));
         }
 
-        return new TypedValue(LocalDateTime.parse(text));
+        return LocalDateTime.parse(text);
+    }
+
+    private static String typeNameOf(@Nullable Object argument) {
+        if (argument == null) {
+            return "null";
+        }
+
+        Class<?> argumentClass = argument.getClass();
+
+        return argumentClass.getName();
     }
 
     private String functionName() {

--- a/server/libs/core/evaluator/evaluator-impl/src/main/java/com/bytechef/evaluator/SpelEvaluator.java
+++ b/server/libs/core/evaluator/evaluator-impl/src/main/java/com/bytechef/evaluator/SpelEvaluator.java
@@ -281,7 +281,7 @@ public class SpelEvaluator implements Evaluator {
                             return value;
                         }
 
-                        if (lenient) {
+                        if (lenient || !formulaExpression) {
                             if (log.isDebugEnabled()) {
                                 log.debug("Unevaluatable expression: {}", value, spelEvaluationException);
                             }

--- a/server/libs/core/evaluator/evaluator-impl/src/main/java/com/bytechef/evaluator/SpelEvaluator.java
+++ b/server/libs/core/evaluator/evaluator-impl/src/main/java/com/bytechef/evaluator/SpelEvaluator.java
@@ -277,11 +277,21 @@ public class SpelEvaluator implements Evaluator {
                     try {
                         return expression.getValue(createEvaluationContext(context, formulaExpression));
                     } catch (SpelEvaluationException spelEvaluationException) {
-                        if (log.isTraceEnabled()) {
-                            log.debug(spelEvaluationException.getMessage());
+                        if (isUnresolvedReference(spelEvaluationException)) {
+                            return value;
                         }
 
-                        return value;
+                        if (lenient) {
+                            if (log.isDebugEnabled()) {
+                                log.debug("Unevaluatable expression: {}", value, spelEvaluationException);
+                            }
+
+                            return value;
+                        }
+
+                        throw new IllegalArgumentException(
+                            "Unevaluatable expression: " + value + " - " + spelEvaluationException.getMessage(),
+                            spelEvaluationException);
                     }
                 }
             }
@@ -324,6 +334,13 @@ public class SpelEvaluator implements Evaluator {
 
             return executor;
         };
+    }
+
+    private static boolean isUnresolvedReference(SpelEvaluationException spelEvaluationException) {
+        SpelMessage messageCode = spelEvaluationException.getMessageCode();
+
+        return messageCode == SpelMessage.PROPERTY_OR_FIELD_NOT_READABLE ||
+            messageCode == SpelMessage.PROPERTY_OR_FIELD_NOT_READABLE_ON_NULL;
     }
 
     private static boolean validateTextExpression(String expression) {

--- a/server/libs/core/evaluator/evaluator-impl/src/test/java/com/bytechef/evaluator/SpelEvaluatorTest.java
+++ b/server/libs/core/evaluator/evaluator-impl/src/test/java/com/bytechef/evaluator/SpelEvaluatorTest.java
@@ -847,4 +847,46 @@ public class SpelEvaluatorTest {
                     Map.of("value", "=parseDate(${a})"), Map.of("a", LocalDateTime.of(2026, 8, 26, 0, 0))),
                 "value"));
     }
+
+    @Test
+    public void testParseDateWithNoArgumentsReturnsOriginalValueInLenientMode() {
+        Map<String, Object> map = EVALUATOR.evaluate(
+            Map.of("value", "=parseDate()"), Collections.emptyMap(), true);
+
+        assertEquals("=parseDate()", MapUtils.get(map, "value"));
+    }
+
+    @Test
+    public void testParseDateTimeWithNoArgumentsReturnsOriginalValueInLenientMode() {
+        Map<String, Object> map = EVALUATOR.evaluate(
+            Map.of("value", "=parseDateTime()"), Collections.emptyMap(), true);
+
+        assertEquals("=parseDateTime()", MapUtils.get(map, "value"));
+    }
+
+    @Test
+    public void testParseDateWithNoArgumentsThrowsInStrictMode() {
+        IllegalArgumentException illegalArgumentException = assertThrowsExactly(
+            IllegalArgumentException.class,
+            () -> EVALUATOR.evaluate(Map.of("value", "=parseDate()"), Collections.emptyMap()));
+
+        assertTrue(illegalArgumentException.getMessage()
+            .contains("parseDate"), illegalArgumentException.getMessage());
+    }
+
+    @Test
+    public void testParseDateWithTooManyArgumentsThrowsInStrictMode() {
+        assertThrowsExactly(
+            IllegalArgumentException.class,
+            () -> EVALUATOR.evaluate(
+                Map.of("value", "=parseDate('2026-08-26', 'yyyy-MM-dd', 'extra')"), Collections.emptyMap()));
+    }
+
+    @Test
+    public void testParseDateWithNonStringFormatReturnsOriginalValueInLenientMode() {
+        Map<String, Object> map = EVALUATOR.evaluate(
+            Map.of("value", "=parseDate('2026-08-26', 5)"), Collections.emptyMap(), true);
+
+        assertEquals("=parseDate('2026-08-26', 5)", MapUtils.get(map, "value"));
+    }
 }

--- a/server/libs/core/evaluator/evaluator-impl/src/test/java/com/bytechef/evaluator/SpelEvaluatorTest.java
+++ b/server/libs/core/evaluator/evaluator-impl/src/test/java/com/bytechef/evaluator/SpelEvaluatorTest.java
@@ -21,6 +21,7 @@ package com.bytechef.evaluator;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -28,6 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.bytechef.commons.util.MapUtils;
 import com.bytechef.test.extension.ObjectMapperSetupExtension;
 import java.text.SimpleDateFormat;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Collections;
@@ -776,5 +778,73 @@ public class SpelEvaluatorTest {
         assertThrowsExactly(
             IllegalArgumentException.class,
             () -> EVALUATOR.evaluate(Map.of("value", "=parseDate(${dbValue})"), context));
+    }
+
+    @Test
+    public void testAccessorEvaluationFailureReturnsOriginalExpression() {
+        Map<String, Object> map = EVALUATOR.evaluate(
+            Map.of("value", "${items[5]}"), Map.of("items", List.of(1, 2, 3)));
+
+        assertEquals("${items[5]}", MapUtils.get(map, "value"));
+    }
+
+    @Test
+    public void testFormulaEvaluationFailureStillThrowsForTheSameFailure() {
+        assertThrowsExactly(
+            IllegalArgumentException.class,
+            () -> EVALUATOR.evaluate(Map.of("value", "=${items[5]} > 1"), Map.of("items", List.of(1, 2, 3))));
+    }
+
+    @Test
+    public void testParseDateRejectionReturnsOriginalValueInLenientMode() {
+        Map<String, Object> context = Map.of("dbTime", java.time.LocalTime.of(10, 15, 30));
+
+        Map<String, Object> map = EVALUATOR.evaluate(
+            Map.of("value", "=parseDate(${dbTime})"), context, true);
+
+        assertEquals("=parseDate(${dbTime})", MapUtils.get(map, "value"));
+    }
+
+    @Test
+    public void testParseDateUnparseableTextReturnsOriginalValueInLenientMode() {
+        Map<String, Object> map = EVALUATOR.evaluate(
+            Map.of("value", "=parseDate('not-a-date')"), Collections.emptyMap(), true);
+
+        assertEquals("=parseDate('not-a-date')", MapUtils.get(map, "value"));
+    }
+
+    @Test
+    public void testParseDateUnparseableTextThrowsInStrictMode() {
+        IllegalArgumentException illegalArgumentException = assertThrowsExactly(
+            IllegalArgumentException.class,
+            () -> EVALUATOR.evaluate(Map.of("value", "=parseDate('not-a-date')"), Collections.emptyMap()));
+
+        assertTrue(illegalArgumentException.getMessage()
+            .contains("parseDate"), illegalArgumentException.getMessage());
+    }
+
+    @Test
+    public void testParseDateReturnTypeFollowsTheArgumentPrecision() {
+        assertInstanceOf(
+            LocalDate.class,
+            MapUtils.get(EVALUATOR.evaluate(Map.of("value", "=parseDate(${a})"), Map.of("a", "2026-08-26")), "value"));
+        assertInstanceOf(
+            LocalDate.class,
+            MapUtils.get(
+                EVALUATOR.evaluate(Map.of("value", "=parseDate(${a})"), Map.of("a", LocalDate.of(2026, 8, 26))),
+                "value"));
+        assertInstanceOf(
+            java.time.ZonedDateTime.class,
+            MapUtils.get(
+                EVALUATOR.evaluate(
+                    Map.of("value", "=parseDate(${a})"),
+                    Map.of("a", java.time.ZonedDateTime.parse("2026-08-26T00:00:00Z"))),
+                "value"));
+        assertInstanceOf(
+            java.time.ZonedDateTime.class,
+            MapUtils.get(
+                EVALUATOR.evaluate(
+                    Map.of("value", "=parseDate(${a})"), Map.of("a", LocalDateTime.of(2026, 8, 26, 0, 0))),
+                "value"));
     }
 }

--- a/server/libs/core/evaluator/evaluator-impl/src/test/java/com/bytechef/evaluator/SpelEvaluatorTest.java
+++ b/server/libs/core/evaluator/evaluator-impl/src/test/java/com/bytechef/evaluator/SpelEvaluatorTest.java
@@ -571,11 +571,10 @@ public class SpelEvaluatorTest {
     }
 
     @Test
-    void testBeanReferenceIsSilentlyRejectedAtRuntime() {
-        Map<String, Object> map = EVALUATOR.evaluate(
-            Map.of("value", "=@dangerousService"), Collections.emptyMap());
-
-        assertEquals("=@dangerousService", MapUtils.get(map, "value"));
+    void testBeanReferenceIsRejectedAtRuntime() {
+        assertThrowsExactly(
+            IllegalArgumentException.class,
+            () -> EVALUATOR.evaluate(Map.of("value", "=@dangerousService"), Collections.emptyMap()));
     }
 
     @Test
@@ -690,5 +689,92 @@ public class SpelEvaluatorTest {
             IllegalArgumentException.class,
             () -> EVALUATOR.evaluate(Map.of("key", "${" + accessor + "}"), Collections.emptyMap()),
             accessor);
+    }
+
+    @Test
+    public void testEvaluationFailureThrowsInStrictMode() {
+        String formula = "=${startDate} > parseDate('2026-08-24T22:00:00Z', \"yyyy-MM-dd'T'HH:mm:ssX\")";
+
+        IllegalArgumentException illegalArgumentException = assertThrowsExactly(
+            IllegalArgumentException.class,
+            () -> EVALUATOR.evaluate(Map.of("value", formula), Map.of("startDate", "2026-08-26T00:00:00.000Z")));
+
+        assertTrue(illegalArgumentException.getMessage()
+            .contains("Cannot compare instances of class java.lang.String and class java.time.ZonedDateTime"));
+        assertNotNull(illegalArgumentException.getCause());
+    }
+
+    @Test
+    public void testEvaluationFailureReturnsOriginalValueInLenientMode() {
+        String formula = "=${startDate} > parseDate('2026-08-24T22:00:00Z', \"yyyy-MM-dd'T'HH:mm:ssX\")";
+
+        Map<String, Object> map = EVALUATOR.evaluate(
+            Map.of("value", formula), Map.of("startDate", "2026-08-26T00:00:00.000Z"), true);
+
+        assertEquals(formula, MapUtils.get(map, "value"));
+    }
+
+    @Test
+    public void testParseDateAcceptsAnAlreadyTemporalArgument() {
+        Map<String, Object> context = Map.of("dbDate", java.time.ZonedDateTime.parse("2026-08-26T00:00:00Z"));
+
+        Map<String, Object> map = EVALUATOR.evaluate(
+            Map.of("value", "=parseDate(${dbDate}, \"yyyy-MM-dd'T'HH:mm:ss.SSSX\")"), context);
+
+        assertEquals(java.time.ZonedDateTime.parse("2026-08-26T00:00:00Z"), MapUtils.get(map, "value"));
+    }
+
+    @Test
+    public void testParseDateStillAcceptsAString() {
+        Map<String, Object> context = Map.of("dbDate", "2026-08-26T00:00:00.000Z");
+
+        Map<String, Object> map = EVALUATOR.evaluate(
+            Map.of("value", "=parseDate(${dbDate}, \"yyyy-MM-dd'T'HH:mm:ss.SSSX\")"), context);
+
+        assertEquals(java.time.ZonedDateTime.parse("2026-08-26T00:00:00Z"), MapUtils.get(map, "value"));
+    }
+
+    @Test
+    public void testParseDateTimeAcceptsAnAlreadyTemporalArgument() {
+        Map<String, Object> context = Map.of("dbDate", java.time.ZonedDateTime.parse("2026-08-26T00:00:00Z"));
+
+        Map<String, Object> map = EVALUATOR.evaluate(Map.of("value", "=parseDateTime(${dbDate})"), context);
+
+        assertEquals(LocalDateTime.of(2026, 8, 26, 0, 0), MapUtils.get(map, "value"));
+    }
+
+    @Test
+    public void testParseDateRejectsALocalTimeArgument() {
+        Map<String, Object> context = Map.of("dbTime", java.time.LocalTime.of(10, 15, 30));
+
+        IllegalArgumentException illegalArgumentException = assertThrowsExactly(
+            IllegalArgumentException.class,
+            () -> EVALUATOR.evaluate(Map.of("value", "=parseDate(${dbTime})"), context));
+
+        assertTrue(illegalArgumentException.getMessage()
+            .contains("parseDate"));
+        assertTrue(illegalArgumentException.getMessage()
+            .contains("10:15:30"));
+    }
+
+    @Test
+    public void testParseDateTimeRejectsALocalTimeArgument() {
+        Map<String, Object> context = Map.of("dbTime", java.time.LocalTime.of(10, 15, 30));
+
+        IllegalArgumentException illegalArgumentException = assertThrowsExactly(
+            IllegalArgumentException.class,
+            () -> EVALUATOR.evaluate(Map.of("value", "=parseDateTime(${dbTime})"), context));
+
+        assertTrue(illegalArgumentException.getMessage()
+            .contains("parseDateTime"));
+    }
+
+    @Test
+    public void testParseDateRejectsANonTemporalNonStringArgument() {
+        Map<String, Object> context = Map.of("dbValue", 123);
+
+        assertThrowsExactly(
+            IllegalArgumentException.class,
+            () -> EVALUATOR.evaluate(Map.of("value", "=parseDate(${dbValue})"), context));
     }
 }

--- a/server/libs/modules/task-dispatchers/condition/src/main/java/com/bytechef/task/dispatcher/condition/util/ConditionTaskUtils.java
+++ b/server/libs/modules/task-dispatchers/condition/src/main/java/com/bytechef/task/dispatcher/condition/util/ConditionTaskUtils.java
@@ -24,7 +24,6 @@ import com.bytechef.commons.util.EncodingUtils;
 import com.bytechef.commons.util.MapUtils;
 import com.bytechef.task.dispatcher.condition.constant.ConditionTaskDispatcherConstants;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -160,25 +159,31 @@ public class ConditionTaskUtils {
                 .get(operandType)
                 .get(MapUtils.getRequiredString(condition, ConditionTaskDispatcherConstants.OPERATION));
 
-            String value1 = MapUtils.getString(condition, ConditionTaskDispatcherConstants.VALUE_1, "");
-            String value2 = MapUtils.getString(condition, ConditionTaskDispatcherConstants.VALUE_2, "");
-
             String replacement1;
             String replacement2;
 
             if (operandType.equals(ConditionTaskDispatcherConstants.DATE_TIME)) {
+                Object value1 = MapUtils.get(condition, ConditionTaskDispatcherConstants.VALUE_1);
+                Object value2 = MapUtils.get(condition, ConditionTaskDispatcherConstants.VALUE_2);
+
                 String variableName1 = "dt" + variables.size();
                 String variableName2 = "dt" + (variables.size() + 1);
 
-                variables.put(variableName1, LocalDateTime.parse(value1));
-                variables.put(variableName2, LocalDateTime.parse(value2));
+                variables.put(variableName1, DateTimeOperandParser.parse(value1, "value1"));
+                variables.put(variableName2, DateTimeOperandParser.parse(value2, "value2"));
 
                 replacement1 = "#" + variableName1;
                 replacement2 = "#" + variableName2;
             } else if (operandType.equals(ConditionTaskDispatcherConstants.STRING)) {
+                String value1 = MapUtils.getString(condition, ConditionTaskDispatcherConstants.VALUE_1, "");
+                String value2 = MapUtils.getString(condition, ConditionTaskDispatcherConstants.VALUE_2, "");
+
                 replacement1 = EncodingUtils.urlEncode(value1);
                 replacement2 = EncodingUtils.urlEncode(value2);
             } else {
+                String value1 = MapUtils.getString(condition, ConditionTaskDispatcherConstants.VALUE_1, "");
+                String value2 = MapUtils.getString(condition, ConditionTaskDispatcherConstants.VALUE_2, "");
+
                 replacement1 = value1;
                 replacement2 = value2;
             }

--- a/server/libs/modules/task-dispatchers/condition/src/main/java/com/bytechef/task/dispatcher/condition/util/DateTimeOperandParser.java
+++ b/server/libs/modules/task-dispatchers/condition/src/main/java/com/bytechef/task/dispatcher/condition/util/DateTimeOperandParser.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2025 ByteChef
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.bytechef.task.dispatcher.condition.util;
+
+import com.bytechef.commons.util.TemporalValueUtils;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeParseException;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Parses a {@code dateTime} condition operand into a {@link ZonedDateTime} at UTC. Operands reach this class either as
+ * a reconstructed temporal value or as text from an API response or the editor's date picker.
+ *
+ * @author Ivica Cardic
+ */
+final class DateTimeOperandParser {
+
+    private DateTimeOperandParser() {
+    }
+
+    static ZonedDateTime parse(@Nullable Object operand, String operandName) {
+        Object normalized = TemporalValueUtils.normalize(operand);
+
+        if (normalized instanceof ZonedDateTime zonedDateTime) {
+            return zonedDateTime;
+        }
+
+        if (normalized instanceof LocalDateTime localDateTime) {
+            return localDateTime.atZone(ZoneOffset.UTC);
+        }
+
+        if (normalized instanceof LocalDate localDate) {
+            return localDate.atStartOfDay(ZoneOffset.UTC);
+        }
+
+        if (normalized instanceof String text && !text.isBlank()) {
+            return parseText(text, operandName);
+        }
+
+        throw new IllegalArgumentException(
+            "Condition operand " + operandName + " is not a date: " + normalized);
+    }
+
+    private static ZonedDateTime parseText(String text, String operandName) {
+        try {
+            return ZonedDateTime.parse(text)
+                .withZoneSameInstant(ZoneOffset.UTC);
+        } catch (DateTimeParseException zonedException) {
+            try {
+                return LocalDateTime.parse(text)
+                    .atZone(ZoneOffset.UTC);
+            } catch (DateTimeParseException localDateTimeException) {
+                try {
+                    return LocalDate.parse(text)
+                        .atStartOfDay(ZoneOffset.UTC);
+                } catch (DateTimeParseException localDateException) {
+                    throw new IllegalArgumentException(
+                        "Condition operand " + operandName + " is not a date: " + text, localDateException);
+                }
+            }
+        }
+    }
+}

--- a/server/libs/modules/task-dispatchers/condition/src/test/java/com/bytechef/task/dispatcher/condition/ConditionTaskDispatcherIntTest.java
+++ b/server/libs/modules/task-dispatchers/condition/src/test/java/com/bytechef/task/dispatcher/condition/ConditionTaskDispatcherIntTest.java
@@ -18,6 +18,7 @@ package com.bytechef.task.dispatcher.condition;
 
 import com.bytechef.atlas.coordinator.task.completion.TaskCompletionHandlerFactory;
 import com.bytechef.atlas.coordinator.task.dispatcher.TaskDispatcherResolverFactory;
+import com.bytechef.atlas.execution.domain.TaskExecution;
 import com.bytechef.atlas.execution.service.ContextService;
 import com.bytechef.atlas.execution.service.CounterService;
 import com.bytechef.atlas.execution.service.TaskExecutionService;
@@ -26,13 +27,18 @@ import com.bytechef.atlas.worker.task.handler.TaskHandler;
 import com.bytechef.commons.util.EncodingUtils;
 import com.bytechef.evaluator.Evaluator;
 import com.bytechef.evaluator.SpelEvaluator;
+import com.bytechef.exception.ExecutionException;
 import com.bytechef.platform.workflow.task.dispatcher.test.annotation.TaskDispatcherIntTest;
+import com.bytechef.platform.workflow.task.dispatcher.test.task.handler.TestTemporalTaskHandler;
 import com.bytechef.platform.workflow.task.dispatcher.test.task.handler.TestVarTaskHandler;
 import com.bytechef.platform.workflow.task.dispatcher.test.workflow.TaskDispatcherJobTestExecutor;
+import com.bytechef.platform.workflow.task.dispatcher.test.workflow.TaskDispatcherJobTestExecutor.TaskDispatcherJobExecution;
 import com.bytechef.task.dispatcher.condition.completion.ConditionTaskCompletionHandler;
 import java.nio.charset.StandardCharsets;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -157,6 +163,126 @@ public class ConditionTaskDispatcherIntTest {
         Assertions.assertEquals("true branch", testVarTaskHandler.get("equalsResult"));
     }
 
+    @Test
+    public void testDispatchRawExpressionDateComparison() {
+        taskDispatcherJobTestExecutor.execute(
+            EncodingUtils.base64EncodeToString(
+                "condition_v1-rawExpression-dateComparison".getBytes(StandardCharsets.UTF_8)),
+            Map.of("restDate", "2026-08-24T22:00:00Z"),
+            this::getTaskCompletionHandlerFactories,
+            this::getTaskDispatcherResolverFactories,
+            this::getTaskHandlerMap);
+
+        Assertions.assertEquals("true branch", testVarTaskHandler.get("comparisonResult"));
+
+        taskDispatcherJobTestExecutor.execute(
+            EncodingUtils.base64EncodeToString(
+                "condition_v1-rawExpression-dateComparison".getBytes(StandardCharsets.UTF_8)),
+            Map.of("restDate", "2026-08-27T22:00:00Z"),
+            this::getTaskCompletionHandlerFactories,
+            this::getTaskDispatcherResolverFactories,
+            this::getTaskHandlerMap);
+
+        Assertions.assertEquals("false branch", testVarTaskHandler.get("comparisonResult"));
+    }
+
+    @Test
+    public void testDispatchRawExpressionUncomparableOperandsFailsWithEvaluationError() {
+        ExecutionException executionException = Assertions.assertThrows(
+            ExecutionException.class,
+            () -> taskDispatcherJobTestExecutor.execute(
+                EncodingUtils.base64EncodeToString(
+                    "condition_v1-rawExpression-uncomparableOperands".getBytes(StandardCharsets.UTF_8)),
+                Map.of("restDate", "2026-08-24T22:00:00Z"),
+                this::getTaskCompletionHandlerFactories,
+                this::getTaskDispatcherResolverFactories,
+                this::getTaskHandlerMap));
+
+        Assertions.assertTrue(
+            executionException.getMessage()
+                .contains("Cannot compare instances of class java.lang.String and class java.time.ZonedDateTime"),
+            executionException.getMessage());
+    }
+
+    @Test
+    public void testDispatchTemporalOutputComparesWithoutParseDate() {
+        TaskDispatcherJobExecution jobExecution = taskDispatcherJobTestExecutor.execute(
+            EncodingUtils.base64EncodeToString(
+                "condition_v1-temporalOutput-noParseDate".getBytes(StandardCharsets.UTF_8)),
+            Map.of("dbDate", "2026-08-26T00:00:00Z", "restDate", "2026-08-24T22:00:00Z"),
+            this::getTaskCompletionHandlerFactories,
+            this::getTaskDispatcherResolverFactories,
+            this::getTaskHandlerMap);
+
+        Assertions.assertEquals("true branch", testVarTaskHandler.get("comparisonResult"));
+
+        TaskExecution dbDateTaskExecution = jobExecution.taskExecutions()
+            .stream()
+            .filter(taskExecution -> "dbDate".equals(taskExecution.getName()))
+            .findFirst()
+            .orElseThrow();
+
+        Assertions.assertInstanceOf(
+            ZonedDateTime.class,
+            taskFileStorage.readTaskExecutionOutput(Objects.requireNonNull(dbDateTaskExecution.getOutput())));
+
+        taskDispatcherJobTestExecutor.execute(
+            EncodingUtils.base64EncodeToString(
+                "condition_v1-temporalOutput-noParseDate".getBytes(StandardCharsets.UTF_8)),
+            Map.of("dbDate", "2026-08-23T00:00:00Z", "restDate", "2026-08-24T22:00:00Z"),
+            this::getTaskCompletionHandlerFactories,
+            this::getTaskDispatcherResolverFactories,
+            this::getTaskHandlerMap);
+
+        Assertions.assertEquals("false branch", testVarTaskHandler.get("comparisonResult"));
+    }
+
+    @Test
+    public void testDispatchStringOutputStaysAString() {
+        TaskDispatcherJobExecution jobExecution = taskDispatcherJobTestExecutor.execute(
+            EncodingUtils.base64EncodeToString(
+                "condition_v1-temporalOutput-stringStaysString".getBytes(StandardCharsets.UTF_8)),
+            Map.of("restDate", "2026-08-26T00:00:00Z"),
+            this::getTaskCompletionHandlerFactories,
+            this::getTaskDispatcherResolverFactories,
+            this::getTaskHandlerMap);
+
+        Assertions.assertEquals("true branch", testVarTaskHandler.get("stringResult"));
+
+        TaskExecution restDateTaskExecution = jobExecution.taskExecutions()
+            .stream()
+            .filter(taskExecution -> "restDate".equals(taskExecution.getName()))
+            .findFirst()
+            .orElseThrow();
+
+        Assertions.assertInstanceOf(
+            String.class,
+            taskFileStorage.readTaskExecutionOutput(Objects.requireNonNull(restDateTaskExecution.getOutput())));
+    }
+
+    @Test
+    public void testDispatchDateTimeConditionOverTaskOutputs() {
+        taskDispatcherJobTestExecutor.execute(
+            EncodingUtils.base64EncodeToString(
+                "condition_v1-dateTime-temporalOutput".getBytes(StandardCharsets.UTF_8)),
+            Map.of("dbDate", "2026-08-26T00:00:00Z", "restDate", "2026-08-24T22:00:00Z"),
+            this::getTaskCompletionHandlerFactories,
+            this::getTaskDispatcherResolverFactories,
+            this::getTaskHandlerMap);
+
+        Assertions.assertEquals("true branch", testVarTaskHandler.get("dateTimeResult"));
+
+        taskDispatcherJobTestExecutor.execute(
+            EncodingUtils.base64EncodeToString(
+                "condition_v1-dateTime-temporalOutput".getBytes(StandardCharsets.UTF_8)),
+            Map.of("dbDate", "2026-08-23T00:00:00Z", "restDate", "2026-08-24T22:00:00Z"),
+            this::getTaskCompletionHandlerFactories,
+            this::getTaskDispatcherResolverFactories,
+            this::getTaskHandlerMap);
+
+        Assertions.assertEquals("false branch", testVarTaskHandler.get("dateTimeResult"));
+    }
+
     @SuppressWarnings("PMD")
     private List<TaskCompletionHandlerFactory> getTaskCompletionHandlerFactories(
         ContextService contextService, CounterService counterService, TaskExecutionService taskExecutionService) {
@@ -179,6 +305,6 @@ public class ConditionTaskDispatcherIntTest {
     }
 
     private Map<String, TaskHandler<?>> getTaskHandlerMap() {
-        return Map.of("var/v1/set", testVarTaskHandler);
+        return Map.of("var/v1/set", testVarTaskHandler, "temporal/v1/set", new TestTemporalTaskHandler());
     }
 }

--- a/server/libs/modules/task-dispatchers/condition/src/test/java/com/bytechef/task/dispatcher/condition/util/ConditionTaskUtilsTest.java
+++ b/server/libs/modules/task-dispatchers/condition/src/test/java/com/bytechef/task/dispatcher/condition/util/ConditionTaskUtilsTest.java
@@ -24,6 +24,7 @@ import com.bytechef.atlas.configuration.constant.WorkflowConstants;
 import com.bytechef.atlas.configuration.domain.WorkflowTask;
 import com.bytechef.atlas.execution.domain.TaskExecution;
 import com.bytechef.test.extension.ObjectMapperSetupExtension;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -185,6 +186,36 @@ public class ConditionTaskUtilsTest {
                 List.of(Map.of("type", "number", "value1", "5", "value2", "10", "operation", "LESS"))));
 
         assertTrue(ConditionTaskUtils.resolveCase(taskExecution));
+    }
+
+    @Test
+    public void testResolveCaseWithOffsetBearingDateTimeOperands() {
+        assertTrue(
+            resolveDateTimeCase("AFTER", "2026-08-26T00:00:00.000Z", "2026-08-24T22:00:00Z"));
+        assertFalse(
+            resolveDateTimeCase("AFTER", "2026-08-23T00:00:00.000Z", "2026-08-24T22:00:00Z"));
+    }
+
+    @Test
+    public void testResolveCaseWithAlreadyTemporalDateTimeOperands() {
+        assertTrue(
+            resolveDateTimeCase(
+                "AFTER", ZonedDateTime.parse("2026-08-26T00:00:00Z"), ZonedDateTime.parse("2026-08-24T22:00:00Z")));
+    }
+
+    @Test
+    public void testResolveCaseWithZoneLessDateTimeOperandsIsUnchanged() {
+        assertTrue(resolveDateTimeCase("AFTER", "2026-08-26T00:00:00", "2026-08-24T22:00:00"));
+        assertTrue(resolveDateTimeCase("BEFORE", "2026-08-24T22:00:00", "2026-08-26T00:00:00"));
+    }
+
+    private static boolean resolveDateTimeCase(String operation, Object value1, Object value2) {
+        return ConditionTaskUtils.resolveCase(
+            buildConditionsTask(
+                List.of(
+                    List.of(
+                        Map.of(
+                            "type", "dateTime", "operation", operation, "value1", value1, "value2", value2)))));
     }
 
     private static TaskExecution buildRawExpressionTask(String expression) {

--- a/server/libs/modules/task-dispatchers/condition/src/test/java/com/bytechef/task/dispatcher/condition/util/DateTimeOperandParserTest.java
+++ b/server/libs/modules/task-dispatchers/condition/src/test/java/com/bytechef/task/dispatcher/condition/util/DateTimeOperandParserTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2025 ByteChef
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.bytechef.task.dispatcher.condition.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.ZonedDateTime;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Ivica Cardic
+ */
+public class DateTimeOperandParserTest {
+
+    private static final ZonedDateTime EXPECTED = ZonedDateTime.parse("2026-08-26T00:00:00Z");
+
+    @Test
+    public void testParseOffsetBearingStrings() {
+        assertEquals(EXPECTED, DateTimeOperandParser.parse("2026-08-26T00:00:00Z", "value1"));
+        assertEquals(EXPECTED, DateTimeOperandParser.parse("2026-08-26T00:00:00.000Z", "value1"));
+        assertEquals(EXPECTED, DateTimeOperandParser.parse("2026-08-26T02:00:00+02:00", "value1"));
+    }
+
+    @Test
+    public void testParseZoneLessValuesAsUtc() {
+        assertEquals(EXPECTED, DateTimeOperandParser.parse("2026-08-26T00:00:00", "value1"));
+        assertEquals(EXPECTED, DateTimeOperandParser.parse("2026-08-26", "value1"));
+    }
+
+    @Test
+    public void testParseAlreadyTemporalOperands() {
+        assertEquals(EXPECTED, DateTimeOperandParser.parse(EXPECTED, "value1"));
+        assertEquals(
+            EXPECTED, DateTimeOperandParser.parse(Timestamp.from(Instant.parse("2026-08-26T00:00:00Z")), "value1"));
+    }
+
+    @Test
+    public void testParseFailsNamingTheOperandAndValue() {
+        IllegalArgumentException emptyException = assertThrows(
+            IllegalArgumentException.class, () -> DateTimeOperandParser.parse("", "value1"));
+        IllegalArgumentException unparseableException = assertThrows(
+            IllegalArgumentException.class, () -> DateTimeOperandParser.parse("not-a-date", "value2"));
+        IllegalArgumentException nullException = assertThrows(
+            IllegalArgumentException.class, () -> DateTimeOperandParser.parse(null, "value1"));
+
+        assertTrue(emptyException.getMessage()
+            .contains("value1"));
+        assertTrue(unparseableException.getMessage()
+            .contains("value2"));
+        assertTrue(unparseableException.getMessage()
+            .contains("not-a-date"));
+        assertTrue(nullException.getMessage()
+            .contains("value1"));
+    }
+}

--- a/server/libs/modules/task-dispatchers/condition/src/test/resources/workflows/condition_v1-dateTime-temporalOutput.yaml
+++ b/server/libs/modules/task-dispatchers/condition/src/test/resources/workflows/condition_v1-dateTime-temporalOutput.yaml
@@ -1,0 +1,36 @@
+---
+label: "If Task Date Time Condition Over Task Outputs"
+inputs:
+- name: "dbDate"
+  type: "string"
+  required: true
+- name: "restDate"
+  type: "string"
+  required: true
+tasks:
+- name: "dbDate"
+  type: "temporal/v1/set"
+  parameters:
+    value: "${dbDate}"
+- name: "restDate"
+  type: "var/v1/set"
+  parameters:
+    value: "${restDate}"
+- name: "condition_1"
+  type: "condition/v1"
+  parameters:
+    conditions:
+    - - type: "dateTime"
+        value1: "${dbDate}"
+        operation: "AFTER"
+        value2: "${restDate}"
+    caseTrue:
+    - name: "dateTimeResult"
+      type: "var/v1/set"
+      parameters:
+        value: "true branch"
+    caseFalse:
+    - name: "dateTimeResult"
+      type: "var/v1/set"
+      parameters:
+        value: "false branch"

--- a/server/libs/modules/task-dispatchers/condition/src/test/resources/workflows/condition_v1-rawExpression-dateComparison.yaml
+++ b/server/libs/modules/task-dispatchers/condition/src/test/resources/workflows/condition_v1-rawExpression-dateComparison.yaml
@@ -1,0 +1,27 @@
+---
+label: "If Task Raw Expression Date Comparison"
+inputs:
+- name: "restDate"
+  type: "string"
+  required: true
+tasks:
+- name: "dbDate"
+  type: "var/v1/set"
+  parameters:
+    value: "2026-08-26T00:00:00.000Z"
+- name: "condition_1"
+  type: "condition/v1"
+  parameters:
+    rawExpression: true
+    expression: "=parseDate(${dbDate}, \"yyyy-MM-dd'T'HH:mm:ss.SSSX\") > parseDate(${restDate},\
+      \ \"yyyy-MM-dd'T'HH:mm:ssX\")"
+    caseTrue:
+    - name: "comparisonResult"
+      type: "var/v1/set"
+      parameters:
+        value: "true branch"
+    caseFalse:
+    - name: "comparisonResult"
+      type: "var/v1/set"
+      parameters:
+        value: "false branch"

--- a/server/libs/modules/task-dispatchers/condition/src/test/resources/workflows/condition_v1-rawExpression-uncomparableOperands.yaml
+++ b/server/libs/modules/task-dispatchers/condition/src/test/resources/workflows/condition_v1-rawExpression-uncomparableOperands.yaml
@@ -1,0 +1,26 @@
+---
+label: "If Task Raw Expression Uncomparable Operands"
+inputs:
+- name: "restDate"
+  type: "string"
+  required: true
+tasks:
+- name: "dbDate"
+  type: "var/v1/set"
+  parameters:
+    value: "2026-08-26T00:00:00.000Z"
+- name: "condition_1"
+  type: "condition/v1"
+  parameters:
+    rawExpression: true
+    expression: "=${dbDate} > parseDate(${restDate}, \"yyyy-MM-dd'T'HH:mm:ssX\")"
+    caseTrue:
+    - name: "comparisonResult"
+      type: "var/v1/set"
+      parameters:
+        value: "true branch"
+    caseFalse:
+    - name: "comparisonResult"
+      type: "var/v1/set"
+      parameters:
+        value: "false branch"

--- a/server/libs/modules/task-dispatchers/condition/src/test/resources/workflows/condition_v1-temporalOutput-noParseDate.yaml
+++ b/server/libs/modules/task-dispatchers/condition/src/test/resources/workflows/condition_v1-temporalOutput-noParseDate.yaml
@@ -1,0 +1,29 @@
+---
+label: "If Task Temporal Output Without parseDate"
+inputs:
+- name: "dbDate"
+  type: "string"
+  required: true
+- name: "restDate"
+  type: "string"
+  required: true
+tasks:
+- name: "dbDate"
+  type: "temporal/v1/set"
+  parameters:
+    value: "${dbDate}"
+- name: "condition_1"
+  type: "condition/v1"
+  parameters:
+    rawExpression: true
+    expression: "=${dbDate} > parseDate(${restDate}, \"yyyy-MM-dd'T'HH:mm:ssX\")"
+    caseTrue:
+    - name: "comparisonResult"
+      type: "var/v1/set"
+      parameters:
+        value: "true branch"
+    caseFalse:
+    - name: "comparisonResult"
+      type: "var/v1/set"
+      parameters:
+        value: "false branch"

--- a/server/libs/modules/task-dispatchers/condition/src/test/resources/workflows/condition_v1-temporalOutput-stringStaysString.yaml
+++ b/server/libs/modules/task-dispatchers/condition/src/test/resources/workflows/condition_v1-temporalOutput-stringStaysString.yaml
@@ -1,0 +1,27 @@
+---
+label: "If Task String Output Stays A String"
+inputs:
+- name: "restDate"
+  type: "string"
+  required: true
+tasks:
+- name: "restDate"
+  type: "var/v1/set"
+  parameters:
+    value: "${restDate}"
+- name: "condition_1"
+  type: "condition/v1"
+  parameters:
+    rawExpression: true
+    expression: "=parseDate(${restDate}, \"yyyy-MM-dd'T'HH:mm:ssX\") > parseDate('2026-08-24T22:00:00Z',\
+      \ \"yyyy-MM-dd'T'HH:mm:ssX\")"
+    caseTrue:
+    - name: "stringResult"
+      type: "var/v1/set"
+      parameters:
+        value: "true branch"
+    caseFalse:
+    - name: "stringResult"
+      type: "var/v1/set"
+      parameters:
+        value: "false branch"

--- a/server/libs/platform/platform-file-storage/platform-file-storage-impl/build.gradle.kts
+++ b/server/libs/platform/platform-file-storage/platform-file-storage-impl/build.gradle.kts
@@ -6,4 +6,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-autoconfigure")
     implementation(project(":server:libs:config:app-config"))
     implementation(project(":server:libs:core:commons:commons-util"))
+
+    testImplementation(project(":server:libs:core:file-storage:file-storage-base64-service"))
+    testImplementation(project(":server:libs:test:test-support"))
 }

--- a/server/libs/platform/platform-file-storage/platform-file-storage-impl/src/main/java/com/bytechef/platform/file/storage/TriggerFileStorageImpl.java
+++ b/server/libs/platform/platform-file-storage/platform-file-storage-impl/src/main/java/com/bytechef/platform/file/storage/TriggerFileStorageImpl.java
@@ -18,6 +18,7 @@ package com.bytechef.platform.file.storage;
 
 import com.bytechef.commons.util.CompressionUtils;
 import com.bytechef.commons.util.JsonUtils;
+import com.bytechef.commons.util.ValueTagUtils;
 import com.bytechef.file.storage.domain.FileEntry;
 import com.bytechef.file.storage.service.FileStorageService;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -38,16 +39,18 @@ public class TriggerFileStorageImpl implements TriggerFileStorage {
 
     @Override
     public Object readTriggerExecutionOutput(FileEntry fileEntry) {
-        return JsonUtils.read(
+        Object value = JsonUtils.read(
             CompressionUtils.decompressToString(
                 fileStorageService.readFileToBytes(TRIGGER_EXECUTION_FILES_DIR, fileEntry)),
             Object.class);
+
+        return ValueTagUtils.untag(value);
     }
 
     @Override
     public FileEntry storeTriggerExecutionOutput(long triggerExecutionId, Object output) {
         return fileStorageService.storeFileContent(
             TRIGGER_EXECUTION_FILES_DIR, triggerExecutionId + ".json",
-            CompressionUtils.compress(JsonUtils.write(output)));
+            CompressionUtils.compress(JsonUtils.write(ValueTagUtils.tag(output))));
     }
 }

--- a/server/libs/platform/platform-file-storage/platform-file-storage-impl/src/test/java/com/bytechef/platform/file/storage/TriggerFileStorageTest.java
+++ b/server/libs/platform/platform-file-storage/platform-file-storage-impl/src/test/java/com/bytechef/platform/file/storage/TriggerFileStorageTest.java
@@ -16,16 +16,69 @@
 
 package com.bytechef.platform.file.storage;
 
-import org.junit.jupiter.api.Disabled;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.bytechef.commons.util.CompressionUtils;
+import com.bytechef.commons.util.JsonUtils;
+import com.bytechef.file.storage.base64.service.Base64FileStorageService;
+import com.bytechef.file.storage.domain.FileEntry;
+import com.bytechef.file.storage.service.FileStorageService;
+import com.bytechef.test.extension.ObjectMapperSetupExtension;
+import java.math.BigDecimal;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * @author Ivica Cardic
  */
+@ExtendWith(ObjectMapperSetupExtension.class)
 public class TriggerFileStorageTest {
 
-    @Disabled
+    private final FileStorageService fileStorageService = new Base64FileStorageService();
+    private final TriggerFileStorage triggerFileStorage = new TriggerFileStorageImpl(fileStorageService);
+
     @Test
-    public void test() {
+    public void testTriggerExecutionOutputPreservesTemporalValues() {
+        Object output = Map.of("createdDate", Timestamp.from(Instant.parse("2026-08-26T00:00:00Z")));
+
+        FileEntry fileEntry = triggerFileStorage.storeTriggerExecutionOutput(1L, output);
+
+        assertEquals(
+            Map.of("createdDate", ZonedDateTime.parse("2026-08-26T00:00:00Z")),
+            triggerFileStorage.readTriggerExecutionOutput(fileEntry));
+    }
+
+    @Test
+    public void testTriggerExecutionOutputPreservesBigDecimal() {
+        Object output = Map.of("amount", new BigDecimal("1234.56"));
+
+        FileEntry fileEntry = triggerFileStorage.storeTriggerExecutionOutput(2L, output);
+
+        assertEquals(
+            Map.of("amount", new BigDecimal("1234.56")), triggerFileStorage.readTriggerExecutionOutput(fileEntry));
+    }
+
+    @Test
+    public void testTriggerExecutionOutputLeavesStringsAsStrings() {
+        Object output = Map.of("modifiedDate", "2026-08-24T22:00:00Z");
+
+        FileEntry fileEntry = triggerFileStorage.storeTriggerExecutionOutput(3L, output);
+
+        assertEquals(output, triggerFileStorage.readTriggerExecutionOutput(fileEntry));
+    }
+
+    @Test
+    public void testTriggerExecutionOutputReadsLegacyUntaggedJson() {
+        Map<String, ?> legacyOutput = Map.of("name", "Acme", "count", 5);
+
+        FileEntry fileEntry = fileStorageService.storeFileContent(
+            "outputs/workflow_trigger_executions", "legacy.json",
+            CompressionUtils.compress(JsonUtils.write(legacyOutput)));
+
+        assertEquals(legacyOutput, triggerFileStorage.readTriggerExecutionOutput(fileEntry));
     }
 }

--- a/server/libs/platform/platform-job-sync/build.gradle.kts
+++ b/server/libs/platform/platform-job-sync/build.gradle.kts
@@ -19,4 +19,8 @@ dependencies {
     implementation(project(":server:libs:platform:platform-notification:platform-notification-api"))
     implementation(project(":server:libs:platform:platform-webhook:platform-webhook-api"))
     implementation(project(":server:libs:platform:platform-worker"))
+
+    testImplementation(project(":server:libs:atlas:atlas-file-storage:atlas-file-storage-impl"))
+    testImplementation(project(":server:libs:core:file-storage:file-storage-base64-service"))
+    testImplementation(project(":server:libs:test:test-support"))
 }

--- a/server/libs/platform/platform-job-sync/src/main/java/com/bytechef/platform/job/sync/file/storage/InMemoryTaskFileStorage.java
+++ b/server/libs/platform/platform-job-sync/src/main/java/com/bytechef/platform/job/sync/file/storage/InMemoryTaskFileStorage.java
@@ -18,6 +18,7 @@ package com.bytechef.platform.job.sync.file.storage;
 
 import com.bytechef.atlas.execution.domain.Context;
 import com.bytechef.atlas.file.storage.TaskFileStorage;
+import com.bytechef.commons.util.TemporalValueUtils;
 import com.bytechef.file.storage.domain.FileEntry;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
@@ -71,9 +72,9 @@ public class InMemoryTaskFileStorage implements TaskFileStorage {
 
         Map<String, ?> value = durableTaskFileStorage.readContextValue(fileEntry);
 
-        cache(fileEntry, value);
+        Object normalizedValue = cache(fileEntry, value);
 
-        return value;
+        return (Map<String, ?>) normalizedValue;
     }
 
     @Override
@@ -87,9 +88,9 @@ public class InMemoryTaskFileStorage implements TaskFileStorage {
 
         Map<String, ?> value = durableTaskFileStorage.readJobOutputs(fileEntry);
 
-        cache(fileEntry, value);
+        Object normalizedValue = cache(fileEntry, value);
 
-        return value;
+        return (Map<String, ?>) normalizedValue;
     }
 
     @Override
@@ -102,9 +103,7 @@ public class InMemoryTaskFileStorage implements TaskFileStorage {
 
         Object value = durableTaskFileStorage.readTaskExecutionOutput(fileEntry);
 
-        cache(fileEntry, value);
-
-        return value;
+        return cache(fileEntry, value);
     }
 
     @Override
@@ -145,11 +144,18 @@ public class InMemoryTaskFileStorage implements TaskFileStorage {
         return fileEntry;
     }
 
-    private void cache(FileEntry fileEntry, @Nullable Object value) {
+    @Nullable
+    private Object cache(FileEntry fileEntry, @Nullable Object value) {
         if (value == null) {
-            return;
+            return null;
         }
 
-        jobDataStorage.put(fileEntry.getUrl(), value);
+        Object normalizedValue = TemporalValueUtils.normalize(value);
+
+        if (normalizedValue != null) {
+            jobDataStorage.put(fileEntry.getUrl(), normalizedValue);
+        }
+
+        return normalizedValue;
     }
 }

--- a/server/libs/platform/platform-job-sync/src/test/java/com/bytechef/platform/job/sync/file/storage/InMemoryTaskFileStorageTest.java
+++ b/server/libs/platform/platform-job-sync/src/test/java/com/bytechef/platform/job/sync/file/storage/InMemoryTaskFileStorageTest.java
@@ -21,14 +21,23 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 
 import com.bytechef.atlas.execution.domain.Context;
 import com.bytechef.atlas.file.storage.TaskFileStorage;
+import com.bytechef.atlas.file.storage.TaskFileStorageImpl;
+import com.bytechef.file.storage.base64.service.Base64FileStorageService;
 import com.bytechef.file.storage.domain.FileEntry;
+import com.bytechef.test.extension.ObjectMapperSetupExtension;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * @author Ivica Cardic
  */
+@ExtendWith(ObjectMapperSetupExtension.class)
 class InMemoryTaskFileStorageTest {
 
     private static final long jobId = 123L;
@@ -62,8 +71,8 @@ class InMemoryTaskFileStorageTest {
         Map<String, ?> readOnce = storage.readJobOutputs(durableFileEntry);
         Map<String, ?> readTwice = storage.readJobOutputs(durableFileEntry);
 
-        assertSame(outputs, readOnce);
-        assertSame(outputs, readTwice);
+        assertEquals(outputs, readOnce);
+        assertSame(readOnce, readTwice);
         assertEquals(0, durable.readJobOutputsCalls.get());
     }
 
@@ -99,7 +108,7 @@ class InMemoryTaskFileStorageTest {
 
         Map<String, ?> read = storage.readContextValue(durableFileEntry);
 
-        assertSame(contextValue, read);
+        assertEquals(contextValue, read);
         assertEquals(1, durable.storeContextCalls.get());
         assertEquals(0, durable.readContextCalls.get());
     }
@@ -120,6 +129,20 @@ class InMemoryTaskFileStorageTest {
         assertSame(output, read);
         assertEquals(1, durable.storeTaskExecutionCalls.get());
         assertEquals(0, durable.readTaskExecutionCalls.get());
+    }
+
+    @Test
+    void testCachedReadReturnsTheSameTypeAsTheDurableRead() {
+        Object output = List.of(Map.of("APPLYDATE", Timestamp.from(Instant.parse("2026-08-26T00:00:00Z"))));
+
+        TaskFileStorage taskFileStorage = new InMemoryTaskFileStorage(
+            new TaskFileStorageImpl(new Base64FileStorageService()));
+
+        FileEntry fileEntry = taskFileStorage.storeTaskExecutionOutput(1L, 1L, output);
+
+        assertEquals(
+            List.of(Map.of("APPLYDATE", ZonedDateTime.parse("2026-08-26T00:00:00Z"))),
+            taskFileStorage.readTaskExecutionOutput(fileEntry));
     }
 
     private static final class RecordingTaskFileStorage implements TaskFileStorage {

--- a/server/libs/platform/platform-workflow/platform-workflow-task-dispatcher/platform-workflow-task-dispatcher-test-int-support/src/main/java/com/bytechef/platform/workflow/task/dispatcher/test/task/handler/TestTemporalTaskHandler.java
+++ b/server/libs/platform/platform-workflow/platform-workflow-task-dispatcher/platform-workflow-task-dispatcher-test-int-support/src/main/java/com/bytechef/platform/workflow/task/dispatcher/test/task/handler/TestTemporalTaskHandler.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2025 ByteChef
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.bytechef.platform.workflow.task.dispatcher.test.task.handler;
+
+import com.bytechef.atlas.execution.domain.TaskExecution;
+import com.bytechef.atlas.worker.task.handler.TaskHandler;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.Map;
+
+/**
+ * Returns a {@link Timestamp} so integration tests can exercise a task whose output is genuinely temporal, the way a
+ * JDBC query action's {@code rs.getObject} result is.
+ *
+ * @author Ivica Cardic
+ */
+public class TestTemporalTaskHandler implements TaskHandler<Object> {
+
+    @Override
+    public Object handle(TaskExecution taskExecution) {
+        Map<String, ?> parameters = taskExecution.getParameters();
+
+        return Timestamp.from(Instant.parse((String) parameters.get("value")));
+    }
+}


### PR DESCRIPTION
Closes #5575.

Task outputs and job contexts are persisted as untyped JSON, which erases `java.time` and `java.sql` temporal types to strings. A workflow that compared a date coming out of a task against a parsed literal therefore compared a `String` to a `ZonedDateTime`, and the resulting SpEL failure was swallowed and handed back as the unevaluated expression — surfacing later as a misleading parse error rather than the type mismatch it was.

## What's here

A codec in `commons-util` tags values on write and reconstructs them on read, normalising every instant-bearing temporal to `ZonedDateTime` at UTC — the type `parseDate` already returns, and therefore the one that makes comparisons evaluate. The same normalisation is applied to the synchronous in-memory cache so sync and async runs agree. The structured `dateTime` condition operand is fixed in the same change because it re-flattened the reconstructed value through `MapUtils.getString`.

| Commit | |
|---|---|
| `80d86b6` | `TemporalValueUtils` + `ValueTagUtils` — the value tag codec |
| `22559e2` | `SpelEvaluator` reports evaluation failures; `parseDate`/`parseDateTime` accept already-temporal arguments |
| `40f11b0` | Task-output, trigger-output and context storage write through the codec |
| `ce50ae7` | `dateTime` condition operands accept offset-bearing and temporal values |
| `a679ff3` | Follow-up: match the evaluator's failure handling to its lenient/strict contract |
| `21abf91` | Follow-up: escape payload maps shaped like the value tag |

The last two came out of reviewing the first four and are worth calling out, since both are behaviour the first four got wrong:

- **Accessors no longer fail the job.** Surfacing evaluation failures was meant for formula (`=`) expressions, but the catch also covered plain `${...}` accessors — so `${items[5]}` over a three-element list started failing the whole job where it previously passed through unchanged. The strict throw is now gated on `formulaExpression`, the flag already computed one line above.
- **`Parse` failures go through SpEL's error handling.** It signalled a rejected argument with an unchecked `IllegalArgumentException`; `MethodReference` only converts `AccessException`, so it escaped the lenient/strict branch entirely — an editor preview threw instead of returning the original value. It now throws `AccessException`, and the `DateTimeParseException` from a malformed date string (which escaped the same way before this series) is wrapped alongside it.
- **The codec can tell its own tags from lookalike data.** `untag()` read any two-entry map carrying both tag keys as an encoded value, and payload data can have that shape on its own — an API response whose body happens to use those field names came back as a scalar, and the unchecked cast in `readContextValue`/`readJobOutputs` turned that into a `ClassCastException`. Such maps are now escaped on write.

## Compatibility

Data written before this change reads back unchanged — `untag` is a no-op on untagged JSON. Every input that `parseDate` accepted before still returns the same type; only non-`String` arguments changed behaviour, and those previously threw `ClassCastException`.

`parseDate`'s return type tracks the precision of its argument (`LocalDate` for a date-only value, `ZonedDateTime` for an instant). That is pre-existing and deliberately left alone — pinning it to `ZonedDateTime` would break a DB `DATE` column, which normalises to `LocalDate` and compares fine against `parseDate('2026-08-26')` today. `testParseDateReturnTypeFollowsTheArgumentPrecision` pins the matrix so it can't drift silently.

## Testing

`compileJava compileTestJava spotlessCheck --continue` clean, and 431 tests across the seven affected modules (`test` + `testIntegration`) with 0 failures. 13 tests are new; 10 of them were confirmed to fail against the unfixed code, so they're regression guards rather than tautologies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
