### PR TITLE
5610 Assert the filesystem write byte count as the long it actually is

### DIFF
--- a/server/libs/modules/components/filesystem/src/test/java/com/bytechef/component/filesystem/FilesystemComponentHandlerIntTest.java
+++ b/server/libs/modules/components/filesystem/src/test/java/com/bytechef/component/filesystem/FilesystemComponentHandlerIntTest.java
@@ -89,7 +89,7 @@ public class FilesystemComponentHandlerIntTest {
 
         Map<String, ?> outputs = taskFileStorage.readJobOutputs(job.getOutputs());
 
-        assertThat((Map<?, ?>) outputs.get("writeLocalFile")).hasFieldOrPropertyWithValue("bytes", 5);
+        assertThat((Map<?, ?>) outputs.get("writeLocalFile")).hasFieldOrPropertyWithValue("bytes", 5L);
     }
 
     private File getFile() {


### PR DESCRIPTION
Closes #5610

## Problem

The `server` job fails on every push to `master`:

```
FilesystemComponentHandlerIntTest > testWrite() FAILED
    Expecting {"bytes"=5L} to have a property or a field named "bytes" with value 5
    but value was: 5L
```

`FilesystemWriteFileAction` returns `Files.copy(InputStream, Path, CopyOption...)`, whose return type is
`long`, so the value arrives as a `Long`. The test asserted the `int` literal `5`.

The failure is pre-existing and independent of what is being pushed — the run that surfaced it was
triggered by a docs-only commit.

## Change

One line: assert `5L`.

The runtime value is the correct one and the literal was wrong. A byte count has to be a `long`, since a
written file can exceed 2^31 bytes; narrowing the action to `int` to match the assertion would silently
truncate large writes.

## Testing

`:server:libs:modules:components:filesystem:testIntegration` passes on master with this change — 2 tests,
2 successes, 0 failures. The red side is already evidenced by the CI run linked in #5610.

🤖 Generated with [Claude Code](https://claude.com/claude-code)