### PR TITLE
5612 client - Remove the TanStack Query devtools launcher

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -48,7 +48,6 @@
                 "@radix-ui/react-visually-hidden": "^1.2.6",
                 "@rolldown/plugin-babel": "^0.2.3",
                 "@tanstack/react-query": "^5.101.0",
-                "@tanstack/react-query-devtools": "^5.101.0",
                 "@tanstack/react-table": "^8.21.3",
                 "@testing-library/dom": "^10.4.1",
                 "@testing-library/user-event": "^14.6.1",
@@ -180,7 +179,7 @@
         },
         "../sdks/frontend/embedded/library": {
             "name": "@bytechef/embedded",
-            "version": "0.1.0",
+            "version": "0.2.0",
             "license": "MIT",
             "devDependencies": {
                 "@chromatic-com/storybook": "5.2.1",
@@ -7674,16 +7673,6 @@
                 "url": "https://github.com/sponsors/tannerlinsley"
             }
         },
-        "node_modules/@tanstack/query-devtools": {
-            "version": "5.101.2",
-            "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.101.2.tgz",
-            "integrity": "sha512-o+wHcqgN7Pp0s8v1i0UGq/ZrrEKrxdIiMQmKRdYb2w7NPtylYSJ4+wg/tIn71m9DLstwUwdEGAvROdly6HXP6w==",
-            "license": "MIT",
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/tannerlinsley"
-            }
-        },
         "node_modules/@tanstack/react-query": {
             "version": "5.101.2",
             "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.2.tgz",
@@ -7697,23 +7686,6 @@
                 "url": "https://github.com/sponsors/tannerlinsley"
             },
             "peerDependencies": {
-                "react": "^18 || ^19"
-            }
-        },
-        "node_modules/@tanstack/react-query-devtools": {
-            "version": "5.101.2",
-            "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.101.2.tgz",
-            "integrity": "sha512-eU7HctdA9gDjqoERoEdzLbw9DiqnBDfh5+Hu0u26gjqoHJezOpQAuiesDL2VvkU+2cPV76zgv0tMZsOrI4LjnQ==",
-            "license": "MIT",
-            "dependencies": {
-                "@tanstack/query-devtools": "5.101.2"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/tannerlinsley"
-            },
-            "peerDependencies": {
-                "@tanstack/react-query": "^5.101.2",
                 "react": "^18 || ^19"
             }
         },

--- a/client/package.json
+++ b/client/package.json
@@ -85,7 +85,6 @@
         "@radix-ui/react-visually-hidden": "^1.2.6",
         "@rolldown/plugin-babel": "^0.2.3",
         "@tanstack/react-query": "^5.101.0",
-        "@tanstack/react-query-devtools": "^5.101.0",
         "@tanstack/react-table": "^8.21.3",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/user-event": "^14.6.1",

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -10,7 +10,6 @@ import {ThemeProvider} from '@/shared/providers/theme-provider';
 import {applicationInfoStore} from '@/shared/stores/useApplicationInfoStore';
 import {authenticationStore} from '@/shared/stores/useAuthenticationStore';
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
-import {ReactQueryDevtools} from '@tanstack/react-query-devtools';
 import {StrictMode} from 'react';
 import {RouterProvider} from 'react-router-dom';
 
@@ -84,8 +83,6 @@ async function renderApp() {
                                 <RouterProvider router={router} />
                             </TooltipProvider>
                         </ConditionalPostHogProvider>
-
-                        <ReactQueryDevtools buttonPosition="bottom-right" initialIsOpen={false} />
                     </QueryClientProvider>
                 </ThemeProvider>
             </I18n>


### PR DESCRIPTION
Closes #5612

## Problem

`ReactQueryDevtools` was mounted unconditionally in `client/src/main.tsx:88`, so its floating launcher
sat in the bottom-right corner of every page in development, overlapping page content - most visibly the
bottom of the Projects list.

The devtools package is excluded from production builds automatically, so this only ever affected
development. Nothing else in the codebase referenced it.

## Change

Removes the mount, the import, and the `@tanstack/react-query-devtools` dependency (lockfile updated).
`@tanstack/react-query` itself is untouched.

## Testing

- `npm run check` passes - prettier, eslint, tsc, 370 test files / 3942 tests.
- `npm run build` succeeds, confirming nothing referenced the removed dependency.

If you would rather keep the devtools for debugging, the alternative is to gate the mount behind an env
flag so it is opt-in rather than always on - say the word and I will do that instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)