### PR TITLE
5600 client - Drop the tooltip from the environment selector

### DIFF
--- a/client/src/shared/components/EnvironmentSelect.tsx
+++ b/client/src/shared/components/EnvironmentSelect.tsx
@@ -7,7 +7,6 @@ import {
     DropdownMenuRadioItem,
     DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import {Tooltip, TooltipContent, TooltipTrigger} from '@/components/ui/tooltip';
 import {ENVIRONMENT_CONFIGS, type EnvironmentConfigI} from '@/shared/constants/environmentConfigs';
 import {useEnvironmentsQuery} from '@/shared/middleware/graphql';
 import {useApplicationInfoStore} from '@/shared/stores/useApplicationInfoStore';
@@ -75,41 +74,33 @@ const EnvironmentSelect = ({onChange, variant = 'default'}: EnvironmentSelectPro
 
     return (
         <DropdownMenu>
-            <Tooltip>
-                <TooltipTrigger asChild>
-                    <DropdownMenuTrigger asChild>
-                        <Button
-                            aria-label={isIcon ? currentConfig.label : undefined}
-                            className={twMerge('h-auto gap-1 p-2', isCompact && 'px-1', isIcon && 'p-1')}
-                            variant="ghost"
-                        >
-                            {isIcon ? (
-                                <Badge
-                                    aria-label={currentConfig.label}
-                                    icon={<CurrentIcon className="size-3" />}
-                                    styleType={currentConfig.styleType}
-                                    weight="semibold"
-                                />
-                            ) : (
-                                <Badge
-                                    icon={<CurrentIcon className="size-3" />}
-                                    label={isCompact ? currentConfig.shortLabel : currentConfig.label}
-                                    styleType={currentConfig.styleType}
-                                    weight="semibold"
-                                />
-                            )}
+            <DropdownMenuTrigger asChild>
+                <Button
+                    aria-label={isIcon ? currentConfig.label : undefined}
+                    className={twMerge('h-auto gap-1 p-2', isCompact && 'px-1', isIcon && 'p-1')}
+                    variant="ghost"
+                >
+                    {isIcon ? (
+                        <Badge
+                            aria-label={currentConfig.label}
+                            icon={<CurrentIcon className="size-3" />}
+                            styleType={currentConfig.styleType}
+                            weight="semibold"
+                        />
+                    ) : (
+                        <Badge
+                            icon={<CurrentIcon className="size-3" />}
+                            label={isCompact ? currentConfig.shortLabel : currentConfig.label}
+                            styleType={currentConfig.styleType}
+                            weight="semibold"
+                        />
+                    )}
 
-                            {!isIcon && (
-                                <ChevronDownIcon
-                                    className={twMerge('size-4 text-muted-foreground', isCompact && 'size-3')}
-                                />
-                            )}
-                        </Button>
-                    </DropdownMenuTrigger>
-                </TooltipTrigger>
-
-                <TooltipContent>{currentConfig.description}</TooltipContent>
-            </Tooltip>
+                    {!isIcon && (
+                        <ChevronDownIcon className={twMerge('size-4 text-muted-foreground', isCompact && 'size-3')} />
+                    )}
+                </Button>
+            </DropdownMenuTrigger>
 
             <DropdownMenuContent align={isCompact || isIcon ? 'start' : 'end'} className="w-72">
                 <DropdownMenuRadioGroup

--- a/client/src/shared/components/tests/EnvironmentSelect.test.tsx
+++ b/client/src/shared/components/tests/EnvironmentSelect.test.tsx
@@ -1,4 +1,3 @@
-import {TooltipProvider} from '@/components/ui/tooltip';
 import EnvironmentSelect from '@/shared/components/EnvironmentSelect';
 import {mockScrollIntoView, render, screen, userEvent} from '@/shared/util/test-utils';
 import {MemoryRouter} from 'react-router-dom';
@@ -41,9 +40,7 @@ vi.mock('@/shared/middleware/graphql', () => ({
 const renderEnvironmentSelect = (variant?: 'compact' | 'default' | 'icon') =>
     render(
         <MemoryRouter>
-            <TooltipProvider>
-                <EnvironmentSelect variant={variant} />
-            </TooltipProvider>
+            <EnvironmentSelect variant={variant} />
         </MemoryRouter>
     );
 


### PR DESCRIPTION
Follow-up to #5602, found while checking the merged change against a running instance.

## Problem

After switching environments, the tooltip stays open over the sidebar, covering the first navigation item
until something else takes focus.

Radix returns focus to the trigger when the dropdown closes, and `Tooltip` opens on focus. Confirmed against
a live instance rather than inferred: parking the pointer elsewhere for two seconds left the tooltip up, and
clicking anywhere dismissed it — focus-driven, not a hover artifact.

The `Tooltip`-wrapping-`DropdownMenuTrigger` nesting predates #5602, but its consequence did not. In a page
header the stuck tooltip covered page content; the selector now sits directly above the navigation.

## Change

Remove the tooltip. It earns nothing in its new home:

- expanded, the trigger already shows a visible `DEV` / `STG` / `PRD` label;
- collapsed, it keeps its `aria-label`, so screen readers are unaffected;
- every environment's full name *and* description are in the dropdown, one click away.

The alternative — controlling the tooltip's open state against Radix's focus restoration — is more machinery
than a redundant tooltip justifies.

## Testing

`npm run check` passes: prettier, eslint, tsc, 370 test files / 3942 tests. The `EnvironmentSelect` tests no
longer need a `TooltipProvider` wrapper, so that comes out too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)