### PR TITLE
5616 client - Refresh the project list after creating a workflow

### DIFF
--- a/client/src/pages/automation/projects/components/project-list/ProjectListItem.tsx
+++ b/client/src/pages/automation/projects/components/project-list/ProjectListItem.tsx
@@ -126,6 +126,8 @@ const ProjectListItem = ({project, projectGitConfiguration, remainingTags}: Proj
         onSuccess: (response) => {
             captureProjectWorkflowCreated();
 
+            queryClient.invalidateQueries({queryKey: ProjectKeys.projects});
+
             navigate(`/automation/projects/${project.id}/project-workflows/${response.projectWorkflowId}`);
         },
     });

--- a/client/src/pages/automation/projects/components/project-workflow-list/ProjectWorkflowList.tsx
+++ b/client/src/pages/automation/projects/components/project-workflow-list/ProjectWorkflowList.tsx
@@ -67,6 +67,8 @@ const ProjectWorkflowList = ({
         onSuccess: (response) => {
             captureProjectWorkflowCreated();
 
+            queryClient.invalidateQueries({queryKey: ProjectKeys.projects});
+
             navigate(`/automation/projects/${project.id}/project-workflows/${response.projectWorkflowId}`);
         },
     });


### PR DESCRIPTION
Closes #5616

## Problem

Creating a workflow from a project card leaves the card showing its old count ("0 workflows") until the page
is reloaded. The workflow is created correctly - only the cached list is stale.

## Cause

`createProjectWorkflowMutation.onSuccess` in `ProjectListItem.tsx` and `ProjectWorkflowList.tsx` captures
analytics and navigates, but invalidates nothing.

The inconsistency is local and visible: the `importProjectWorkflowMutation` handlers a few lines below **in
the same two files** already invalidate `ProjectKeys.projects`, and the create handler in
`useProjectsLeftSidebar.ts` invalidates `ProjectKeys.filteredProjects`. These two create paths were the only
ones that skipped it.

## Change

Add `queryClient.invalidateQueries({queryKey: ProjectKeys.projects})` to both.

That key alone is sufficient - `filteredProjects` is `[...projects, id, filters]` and `project(id)` is
`[...projects, id]`, so a prefix invalidation covers both. `queryClient` and `ProjectKeys` were already in
scope in both files.

## Testing

`npm run check` passes - prettier, eslint, tsc, 370 test files / 3942 tests.

Found while driving the UI to build screenshot data: the stale count made an automated click sequence target
the wrong control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)