### PR TITLE
3900 Stop social login from self-provisioning admins, and end refused SAML sessions

### DIFF
--- a/server/ee/libs/config/security-sso-config/build.gradle.kts
+++ b/server/ee/libs/config/security-sso-config/build.gradle.kts
@@ -12,4 +12,6 @@ dependencies {
     implementation(project(":server:libs:platform:platform-api"))
     implementation(project(":server:libs:platform:platform-security-web:platform-security-web-api"))
     implementation(project(":server:libs:platform:platform-user:platform-user-api"))
+
+    testImplementation("jakarta.servlet:jakarta.servlet-api")
 }

--- a/server/ee/libs/config/security-sso-config/src/main/java/com/bytechef/ee/security/sso/saml2/SsoSaml2AuthenticationSuccessHandler.java
+++ b/server/ee/libs/config/security-sso-config/src/main/java/com/bytechef/ee/security/sso/saml2/SsoSaml2AuthenticationSuccessHandler.java
@@ -21,6 +21,7 @@ import jakarta.servlet.http.HttpSession;
 import java.io.IOException;
 import java.util.List;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.saml2.provider.service.authentication.Saml2AuthenticatedPrincipal;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.security.web.authentication.RememberMeServices;
@@ -77,9 +78,15 @@ public class SsoSaml2AuthenticationSuccessHandler implements AuthenticationSucce
             defaultAuthority = identityProvider.getDefaultAuthority();
         }
 
-        userService.findOrCreateSocialUser(
-            email, firstName, lastName, null, UserConstants.AUTH_PROVIDER_SAML, principal.getName(), autoProvision,
-            defaultAuthority);
+        try {
+            userService.findOrCreateSocialUser(
+                email, firstName, lastName, null, UserConstants.AUTH_PROVIDER_SAML, principal.getName(), autoProvision,
+                defaultAuthority);
+        } catch (IllegalStateException illegalStateException) {
+            rejectUnprovisionedLogin(request, response);
+
+            return;
+        }
 
         List<String> tenantIds = tenantService.getTenantIdsByUserEmail(email);
 
@@ -90,6 +97,22 @@ public class SsoSaml2AuthenticationSuccessHandler implements AuthenticationSucce
         rememberMeServices.loginSuccess(request, response, authentication);
 
         response.sendRedirect("/oauth2/redirect");
+    }
+
+    private void rejectUnprovisionedLogin(HttpServletRequest request, HttpServletResponse response)
+        throws IOException {
+
+        rememberMeServices.loginFail(request, response);
+
+        SecurityContextHolder.clearContext();
+
+        HttpSession session = request.getSession(false);
+
+        if (session != null) {
+            session.invalidate();
+        }
+
+        response.sendRedirect("/login?error=saml");
     }
 
     private String extractEmail(Saml2AuthenticatedPrincipal principal) {

--- a/server/ee/libs/config/security-sso-config/src/test/java/com/bytechef/ee/security/sso/saml2/SsoSaml2AuthenticationSuccessHandlerTest.java
+++ b/server/ee/libs/config/security-sso-config/src/test/java/com/bytechef/ee/security/sso/saml2/SsoSaml2AuthenticationSuccessHandlerTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2025 ByteChef
+ *
+ * Licensed under the ByteChef Enterprise license (the "Enterprise License");
+ * you may not use this file except in compliance with the Enterprise License.
+ */
+
+package com.bytechef.ee.security.sso.saml2;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.bytechef.platform.user.domain.User;
+import com.bytechef.platform.user.service.IdentityProviderService;
+import com.bytechef.platform.user.service.UserService;
+import com.bytechef.tenant.constant.TenantConstants;
+import com.bytechef.tenant.service.TenantService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import java.io.IOException;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.saml2.provider.service.authentication.Saml2AuthenticatedPrincipal;
+import org.springframework.security.web.authentication.RememberMeServices;
+
+/**
+ * @version ee
+ *
+ * @author Ivica Cardic
+ */
+class SsoSaml2AuthenticationSuccessHandlerTest {
+
+    private static final String EMAIL_CLAIM = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress";
+    private static final String EMAIL = "someone@example.com";
+
+    private final IdentityProviderService identityProviderService = mock(IdentityProviderService.class);
+    private final RememberMeServices rememberMeServices = mock(RememberMeServices.class);
+    private final TenantService tenantService = mock(TenantService.class);
+    private final UserService userService = mock(UserService.class);
+
+    private final HttpServletRequest request = mock(HttpServletRequest.class);
+    private final HttpServletResponse response = mock(HttpServletResponse.class);
+    private final HttpSession session = mock(HttpSession.class);
+
+    @AfterEach
+    void afterEach() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void testRefusedProvisioningEndsTheAuthenticatedSession() throws IOException {
+        when(
+            userService.findOrCreateSocialUser(
+                anyString(), nullable(String.class), nullable(String.class), nullable(String.class), anyString(),
+                anyString(), anyBoolean(), anyString()))
+                    .thenThrow(new IllegalStateException("Auto-provisioning is disabled for this identity provider"));
+
+        when(request.getSession(false)).thenReturn(session);
+
+        Authentication authentication = authentication();
+
+        SecurityContextHolder.getContext()
+            .setAuthentication(authentication);
+
+        handler().onAuthenticationSuccess(request, response, authentication);
+
+        assertThat(SecurityContextHolder.getContext()
+            .getAuthentication())
+                .as("the session the filter already authenticated must not survive a refused provisioning")
+                .isNull();
+
+        verify(session).invalidate();
+        verify(rememberMeServices).loginFail(request, response);
+        verify(rememberMeServices, never()).loginSuccess(any(), any(), any());
+        verify(response).sendRedirect("/login?error=saml");
+        verify(response, never()).sendRedirect("/oauth2/redirect");
+    }
+
+    @Test
+    void testProvisionedUserReachesTheApplication() throws IOException {
+        when(
+            userService.findOrCreateSocialUser(
+                anyString(), nullable(String.class), nullable(String.class), nullable(String.class), anyString(),
+                anyString(), anyBoolean(), anyString()))
+                    .thenReturn(new User());
+
+        when(tenantService.getTenantIdsByUserEmail(EMAIL)).thenReturn(List.of("tenant-1"));
+        when(request.getSession()).thenReturn(session);
+
+        Authentication authentication = authentication();
+
+        handler().onAuthenticationSuccess(request, response, authentication);
+
+        verify(session).setAttribute(TenantConstants.CURRENT_TENANT_ID, "tenant-1");
+        verify(rememberMeServices).loginSuccess(request, response, authentication);
+        verify(response).sendRedirect("/oauth2/redirect");
+        verify(session, never()).invalidate();
+    }
+
+    private Authentication authentication() {
+        Saml2AuthenticatedPrincipal principal = mock(Saml2AuthenticatedPrincipal.class);
+
+        when(principal.getAttribute(EMAIL_CLAIM)).thenReturn(List.of(EMAIL));
+        when(principal.getName()).thenReturn("saml-name-id");
+        when(principal.getRelyingPartyRegistrationId()).thenReturn(null);
+
+        return new TestingAuthenticationToken(principal, "credentials");
+    }
+
+    private SsoSaml2AuthenticationSuccessHandler handler() {
+        return new SsoSaml2AuthenticationSuccessHandler(
+            identityProviderService, rememberMeServices, tenantService, userService);
+    }
+}

--- a/server/libs/config/security-config/src/main/java/com/bytechef/security/web/oauth2/CustomOAuth2UserService.java
+++ b/server/libs/config/security-config/src/main/java/com/bytechef/security/web/oauth2/CustomOAuth2UserService.java
@@ -16,7 +16,6 @@
 
 package com.bytechef.security.web.oauth2;
 
-import com.bytechef.platform.security.constant.AuthorityConstants;
 import com.bytechef.platform.user.domain.Authority;
 import com.bytechef.platform.user.domain.User;
 import com.bytechef.platform.user.service.AuthorityService;
@@ -92,8 +91,8 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
             throw new OAuth2AuthenticationException("Email not available from OAuth2 provider " + registrationId);
         }
 
-        User user = userService.findOrCreateSocialUser(
-            email, firstName, lastName, imageUrl, registrationId, providerId, true, AuthorityConstants.ADMIN);
+        User user = SocialUserResolver.resolveInvitedUser(
+            userService, email, firstName, lastName, imageUrl, registrationId, providerId);
 
         List<SimpleGrantedAuthority> grantedAuthorities = user.getAuthorityIds()
             .stream()

--- a/server/libs/config/security-config/src/main/java/com/bytechef/security/web/oauth2/CustomOidcUserService.java
+++ b/server/libs/config/security-config/src/main/java/com/bytechef/security/web/oauth2/CustomOidcUserService.java
@@ -16,7 +16,6 @@
 
 package com.bytechef.security.web.oauth2;
 
-import com.bytechef.platform.security.constant.AuthorityConstants;
 import com.bytechef.platform.user.domain.Authority;
 import com.bytechef.platform.user.domain.IdentityProvider;
 import com.bytechef.platform.user.domain.User;
@@ -38,8 +37,12 @@ import org.springframework.stereotype.Service;
 
 /**
  * Custom OIDC user service that integrates OIDC provider users (Okta, Azure AD, Google Workspace) with the internal
- * ByteChef user model. Extracts standardized OIDC claims (email, given_name, family_name, picture, sub) and
- * finds/creates the corresponding internal user.
+ * ByteChef user model. Extracts standardized OIDC claims (email, given_name, family_name, picture, sub) and resolves
+ * the corresponding internal user.
+ *
+ * <p>
+ * An {@code sso-} registration is provisioned as its {@code IdentityProvider} record says. Every other registration is
+ * plain social login, which signs an invited user in rather than provisioning a new one.
  *
  * @author Ivica Cardic
  */
@@ -85,22 +88,24 @@ public class CustomOidcUserService extends OidcUserService {
 
         String registrationId = clientRegistration.getRegistrationId();
 
-        String authProvider = registrationId.startsWith(SSO_PREFIX) ? "SSO" : registrationId.toUpperCase();
+        boolean ssoRegistration = registrationId.startsWith(SSO_PREFIX);
 
-        boolean autoProvision = true;
-        String defaultAuthority = AuthorityConstants.ADMIN;
+        String authProvider = ssoRegistration ? "SSO" : registrationId.toUpperCase();
 
-        if (registrationId.startsWith(SSO_PREFIX) && identityProviderService != null) {
+        User user;
+
+        if (ssoRegistration && identityProviderService != null) {
             long identityProviderId = Long.parseLong(registrationId.substring(SSO_PREFIX.length()));
 
             IdentityProvider identityProvider = identityProviderService.getIdentityProvider(identityProviderId);
 
-            autoProvision = identityProvider.isAutoProvision();
-            defaultAuthority = identityProvider.getDefaultAuthority();
+            user = SocialUserResolver.resolveUser(
+                userService, email, firstName, lastName, imageUrl, authProvider, providerId,
+                identityProvider.isAutoProvision(), identityProvider.getDefaultAuthority());
+        } else {
+            user = SocialUserResolver.resolveInvitedUser(
+                userService, email, firstName, lastName, imageUrl, authProvider, providerId);
         }
-
-        User user = userService.findOrCreateSocialUser(
-            email, firstName, lastName, imageUrl, authProvider, providerId, autoProvision, defaultAuthority);
 
         List<SimpleGrantedAuthority> grantedAuthorities = user.getAuthorityIds()
             .stream()

--- a/server/libs/config/security-config/src/main/java/com/bytechef/security/web/oauth2/SocialUserResolver.java
+++ b/server/libs/config/security-config/src/main/java/com/bytechef/security/web/oauth2/SocialUserResolver.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2025 ByteChef
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.bytechef.security.web.oauth2;
+
+import com.bytechef.platform.security.constant.AuthorityConstants;
+import com.bytechef.platform.user.domain.User;
+import com.bytechef.platform.user.service.UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+
+/**
+ * Resolves the ByteChef user behind an external identity, shared by every login path that maps a provider identity onto
+ * an internal user so they cannot drift apart: OIDC (Google), plain OAuth2 (GitHub), and the enterprise SSO path.
+ *
+ * <p>
+ * Its one behavioural job is to turn a refused provisioning attempt into an authentication failure. {@code UserService}
+ * signals that with an {@link IllegalStateException}, which is not an {@code AuthenticationException} — left unwrapped
+ * it escapes the filter chain, so the caller gets a 500 instead of a redirect back to the login page.
+ *
+ * @author Ivica Cardic
+ */
+public final class SocialUserResolver {
+
+    private static final String ACCOUNT_NOT_PROVISIONED_ERROR_CODE = "account_not_provisioned";
+
+    private SocialUserResolver() {
+    }
+
+    /**
+     * Resolves a social-login identity: social login signs an invited user in rather than provisioning a new one, so
+     * auto-provisioning is off and an unknown email is rejected. The two are coupled — the authority this path asks for
+     * is {@code ROLE_ADMIN}, so provisioning here would let anyone holding an account at the configured provider, on
+     * any email domain, self-escalate to instance admin. An email that already has a ByteChef account keeps the
+     * authorities it already holds.
+     */
+    static User resolveInvitedUser(
+        UserService userService, String email, String firstName, String lastName, String imageUrl, String authProvider,
+        String providerId) {
+
+        return resolveUser(
+            userService, email, firstName, lastName, imageUrl, authProvider, providerId, false,
+            AuthorityConstants.ADMIN);
+    }
+
+    /**
+     * Resolves an identity under caller-chosen provisioning settings, for the SSO path where they come from the
+     * tenant's {@code IdentityProvider} record. Both are passed through untouched — an administrator who turned
+     * auto-provisioning off gets a rejected login rather than a provisioned account.
+     */
+    public static User resolveUser(
+        UserService userService, String email, String firstName, String lastName, String imageUrl, String authProvider,
+        String providerId, boolean autoProvision, String defaultAuthority) {
+
+        try {
+            return userService.findOrCreateSocialUser(
+                email, firstName, lastName, imageUrl, authProvider, providerId, autoProvision, defaultAuthority);
+        } catch (IllegalStateException illegalStateException) {
+            throw new OAuth2AuthenticationException(
+                new OAuth2Error(ACCOUNT_NOT_PROVISIONED_ERROR_CODE, "No ByteChef account exists for " + email, null),
+                illegalStateException);
+        }
+    }
+}

--- a/server/libs/config/security-config/src/test/java/com/bytechef/security/web/oauth2/SocialUserResolverTest.java
+++ b/server/libs/config/security-config/src/test/java/com/bytechef/security/web/oauth2/SocialUserResolverTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2025 ByteChef
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.bytechef.security.web.oauth2;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.bytechef.platform.security.constant.AuthorityConstants;
+import com.bytechef.platform.user.domain.User;
+import com.bytechef.platform.user.service.UserService;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+
+/**
+ * @author Ivica Cardic
+ */
+class SocialUserResolverTest {
+
+    private static final String EMAIL = "someone@example.com";
+
+    @Test
+    void testResolveInvitedUserDisablesAutoProvisioning() {
+        UserService userService = mock(UserService.class);
+
+        when(
+            userService.findOrCreateSocialUser(
+                anyString(), anyString(), anyString(), anyString(), anyString(), anyString(), anyBoolean(),
+                anyString()))
+                    .thenReturn(new User());
+
+        SocialUserResolver.resolveInvitedUser(
+            userService, EMAIL, "Some", "One", "https://example.com/avatar.png", "GOOGLE", "provider-id");
+
+        ArgumentCaptor<Boolean> autoProvisionCaptor = ArgumentCaptor.forClass(Boolean.class);
+        ArgumentCaptor<String> defaultAuthorityCaptor = ArgumentCaptor.forClass(String.class);
+
+        verify(userService).findOrCreateSocialUser(
+            anyString(), anyString(), anyString(), anyString(), anyString(), anyString(),
+            autoProvisionCaptor.capture(), defaultAuthorityCaptor.capture());
+
+        assertThat(autoProvisionCaptor.getValue())
+            .as("auto-provisioning must stay off: this path asks for %s, so provisioning through social login would "
+                + "grant instance admin to any account at the configured provider", AuthorityConstants.ADMIN)
+            .isFalse();
+
+        assertThat(defaultAuthorityCaptor.getValue())
+            .as("unused while auto-provisioning is off, but pinned so that turning provisioning on here has to be a "
+                + "reviewed change rather than a silent grant of %s", AuthorityConstants.ADMIN)
+            .isEqualTo(AuthorityConstants.ADMIN);
+    }
+
+    @Test
+    void testResolveUserPassesProvisioningSettingsThrough() {
+        UserService userService = mock(UserService.class);
+
+        when(
+            userService.findOrCreateSocialUser(
+                anyString(), anyString(), anyString(), anyString(), anyString(), anyString(), anyBoolean(),
+                anyString()))
+                    .thenReturn(new User());
+
+        SocialUserResolver.resolveUser(
+            userService, EMAIL, "Some", "One", "https://example.com/avatar.png", "SSO", "provider-id", true,
+            AuthorityConstants.USER);
+
+        ArgumentCaptor<Boolean> autoProvisionCaptor = ArgumentCaptor.forClass(Boolean.class);
+        ArgumentCaptor<String> defaultAuthorityCaptor = ArgumentCaptor.forClass(String.class);
+
+        verify(userService).findOrCreateSocialUser(
+            anyString(), anyString(), anyString(), anyString(), anyString(), anyString(),
+            autoProvisionCaptor.capture(), defaultAuthorityCaptor.capture());
+
+        // The enterprise SSO path reads both from the tenant's IdentityProvider record; overriding either here would
+        // silently ignore what the administrator configured.
+        assertThat(autoProvisionCaptor.getValue())
+            .as("the caller's auto-provisioning setting must reach the service unchanged")
+            .isTrue();
+
+        assertThat(defaultAuthorityCaptor.getValue())
+            .as("the caller's default authority must reach the service unchanged")
+            .isEqualTo(AuthorityConstants.USER);
+    }
+
+    @Test
+    void testResolveInvitedUserRejectsUnknownEmail() {
+        UserService userService = mock(UserService.class);
+
+        IllegalStateException illegalStateException = new IllegalStateException("Auto-provisioning is disabled");
+
+        when(
+            userService.findOrCreateSocialUser(
+                anyString(), anyString(), anyString(), anyString(), anyString(), anyString(), anyBoolean(),
+                anyString()))
+                    .thenThrow(illegalStateException);
+
+        // The failure has to arrive as an AuthenticationException, or OAuth2AuthenticationFailureHandler never sees it
+        // and the unknown-account case surfaces as a 500 instead of a redirect back to the login page.
+        assertThatThrownBy(
+            () -> SocialUserResolver.resolveInvitedUser(
+                userService, EMAIL, "Some", "One", "https://example.com/avatar.png", "GOOGLE", "provider-id"))
+                    .isInstanceOf(OAuth2AuthenticationException.class)
+                    .hasCause(illegalStateException);
+    }
+}


### PR DESCRIPTION
Two related holes in the external-identity login paths, both reachable on a
default install with social login or SSO enabled.

## 1. Social login provisioned unknown emails straight into `ROLE_ADMIN`

`CustomOAuth2UserService` (GitHub) and the non-`sso-` branch of
`CustomOidcUserService` (Google) both called `findOrCreateSocialUser(…, true,
AuthorityConstants.ADMIN)`. Auto-provisioning was on and the requested
authority was instance admin, so **anyone with an account at the configured
provider — any email domain, no invitation — could sign in once and land as an
admin.**

Social login is now a sign-in path for invited users, not a sign-up path:
auto-provisioning is off and an email with no ByteChef account is rejected. An
email that already has an account keeps the authorities it already holds, so
the invite flow is unchanged, and email/password registration
(`AccountController.registerAccount`) plus the seeded admin remain the ways an
instance is bootstrapped.

Auto-provisioning and the requested authority are coupled — the authority is
only reachable when provisioning happens — so they move together into one
`SocialUserResolver` shared by every path that maps a provider identity onto an
internal user, instead of being repeated per call site where they can drift.
`sso-` registrations keep passing their `IdentityProvider` record through
untouched.

The resolver also wraps the refusal. `UserService` signals it with
`IllegalStateException`, which is not an `AuthenticationException`, so
unwrapped it escapes past `OAuth2AuthenticationFailureHandler` and the
unknown-account case surfaces as a 500 rather than a redirect back to the login
page.

## 2. A refused SAML assertion left a live authenticated session

An administrator who turns auto-provisioning off on an `IdentityProvider` is
saying an unknown assertion must not become an account.
`SsoSaml2AuthenticationSuccessHandler` never caught the refusal — and by the
time it runs, the Saml2 filter has already authenticated the request and put
the principal in the `SecurityContext`. The exception escaped as a 500 while
that context, and any remember-me token, stayed behind: **a user the
administrator refused to provision was left holding a live session.**

Refusal now ends the session it arrived on — remember-me failed, security
context cleared, HTTP session invalidated, redirect to `/login?error=saml`, the
same destination as every other rejected assertion, so a refusal is
indistinguishable from any other failed login rather than leaking whether the
email is known.

## Tests

- `SocialUserResolverTest` (3) — the invited-user path keeps auto-provisioning
  off, the SSO path passes the administrator's settings through unchanged, and
  a refusal arrives as an `OAuth2AuthenticationException`.
- `SsoSaml2AuthenticationSuccessHandlerTest` (2) — a refused assertion clears
  the context, invalidates the session and redirects to the login page; a
  provisioned user still reaches `/oauth2/redirect`.

`./gradlew :server:libs:config:security-config:check
:server:ee:libs:config:security-sso-config:check` passes (Spotless, Checkstyle,
PMD, SpotBugs, tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q3qKJEeiFnfxJcFdJgRFpx
