### PR TITLE
5615 Scope project categories and knowledge base document tags to their owner

### DIFF
--- a/client/codegen.ts
+++ b/client/codegen.ts
@@ -78,6 +78,7 @@ const config: CodegenConfig = {
         '../server/libs/platform/platform-security/platform-security-graphql/src/main/resources/graphql/*.graphqls',
         '../server/libs/platform/platform-component/platform-component-log/platform-component-log-graphql/src/main/resources/graphql/*.graphqls',
         '../server/libs/ai/ai-mcp/ai-mcp-server-configuration/ai-mcp-server-configuration-graphql/src/main/resources/graphql/*.graphqls',
+        '../server/libs/platform/platform-user/platform-user-graphql/src/main/resources/graphql/*.graphqls',
         '../server/ee/libs/platform/platform-user/platform-user-graphql/src/main/resources/graphql/*.graphqls',
         '../server/ee/libs/platform/platform-api-connector/platform-api-connector-configuration/platform-api-connector-configuration-graphql/src/main/resources/graphql/*.graphqls',
         '../server/ee/libs/platform/platform-custom-component/platform-custom-component-configuration/platform-custom-component-configuration-graphql/src/main/resources/graphql/*.graphqls',

--- a/client/src/components/EmptyFilterResult.tsx
+++ b/client/src/components/EmptyFilterResult.tsx
@@ -3,13 +3,14 @@ import {FilterXIcon} from 'lucide-react';
 
 interface EmptyFilterResultProps {
     entityName: string;
+    entityTitle: string;
 }
 
-const EmptyFilterResult = ({entityName}: EmptyFilterResultProps) => (
+const EmptyFilterResult = ({entityName, entityTitle}: EmptyFilterResultProps) => (
     <EmptyList
         icon={<FilterXIcon className="size-24 text-stroke-neutral-tertiary" />}
-        message={`No ${entityName} match the current filter. Clear it to see the rest.`}
-        title="No matches"
+        message={`No ${entityName} match the current filter.`}
+        title={`No Matching ${entityTitle}`}
     />
 );
 

--- a/client/src/components/EmptyFilterResult.tsx
+++ b/client/src/components/EmptyFilterResult.tsx
@@ -1,0 +1,16 @@
+import EmptyList from '@/components/EmptyList';
+import {FilterXIcon} from 'lucide-react';
+
+interface EmptyFilterResultProps {
+    entityName: string;
+}
+
+const EmptyFilterResult = ({entityName}: EmptyFilterResultProps) => (
+    <EmptyList
+        icon={<FilterXIcon className="size-24 text-stroke-neutral-tertiary" />}
+        message={`No ${entityName} match the current filter. Clear it to see the rest.`}
+        title="No matches"
+    />
+);
+
+export default EmptyFilterResult;

--- a/client/src/components/tests/EmptyFilterResult.test.tsx
+++ b/client/src/components/tests/EmptyFilterResult.test.tsx
@@ -1,0 +1,20 @@
+import EmptyFilterResult from '@/components/EmptyFilterResult';
+import {render, screen} from '@testing-library/react';
+import {expect, it} from 'vitest';
+
+// The point of the component: a filtered list that comes back empty used to render the first-run empty state,
+// which told the reader the workspace was empty and offered to create the thing they already had.
+it('names what was filtered rather than offering to create one', () => {
+    render(<EmptyFilterResult entityName="project deployments" entityTitle="Project Deployments" />);
+
+    expect(screen.getByText('No Matching Project Deployments')).toBeInTheDocument();
+    expect(screen.getByText('No project deployments match the current filter.')).toBeInTheDocument();
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+});
+
+it('carries the caller\'s casing into the title and the message separately', () => {
+    render(<EmptyFilterResult entityName="API collections" entityTitle="API Collections" />);
+
+    expect(screen.getByText('No Matching API Collections')).toBeInTheDocument();
+    expect(screen.getByText('No API collections match the current filter.')).toBeInTheDocument();
+});

--- a/client/src/components/tests/EmptyFilterResult.test.tsx
+++ b/client/src/components/tests/EmptyFilterResult.test.tsx
@@ -12,7 +12,7 @@ it('names what was filtered rather than offering to create one', () => {
     expect(screen.queryByRole('button')).not.toBeInTheDocument();
 });
 
-it('carries the caller\'s casing into the title and the message separately', () => {
+it("carries the caller's casing into the title and the message separately", () => {
     render(<EmptyFilterResult entityName="API collections" entityTitle="API Collections" />);
 
     expect(screen.getByText('No Matching API Collections')).toBeInTheDocument();

--- a/client/src/ee/pages/automation/api-platform/api-collections/ApiCollections.tsx
+++ b/client/src/ee/pages/automation/api-platform/api-collections/ApiCollections.tsx
@@ -121,7 +121,7 @@ const ApiCollections = () => {
                         </WorkflowReadOnlyProvider>
                     </div>
                 ) : isFiltered ? (
-                    <EmptyFilterResult entityName="API collections" />
+                    <EmptyFilterResult entityName="API collections" entityTitle="API Collections" />
                 ) : (
                     <EmptyList
                         button={<ApiCollectionDialog triggerNode={<Button label="New API Collection" />} />}

--- a/client/src/ee/pages/automation/api-platform/api-collections/ApiCollections.tsx
+++ b/client/src/ee/pages/automation/api-platform/api-collections/ApiCollections.tsx
@@ -1,4 +1,5 @@
 import Button from '@/components/Button/Button';
+import EmptyFilterResult from '@/components/EmptyFilterResult';
 import EmptyList from '@/components/EmptyList';
 import PageLoader from '@/components/PageLoader';
 import ApiPlatformLeftSidebarNav from '@/ee/pages/automation/api-platform/ApiPlatformLeftSidebarNav';
@@ -45,6 +46,8 @@ const ApiCollections = () => {
             }
           : {type: Type.Project};
 
+    const isFiltered = 'id' in filterData && filterData.id !== undefined;
+
     const {
         data: projects,
         error: projectsError,
@@ -82,7 +85,7 @@ const ApiCollections = () => {
                         )
                     }
                     title={
-                        apiCollections && apiCollections.length > 0 ? (
+                        (apiCollections && apiCollections.length > 0) || isFiltered ? (
                             <ApiCollectionsFilterTitle filterData={filterData} projects={projects} tags={tags} />
                         ) : (
                             ''
@@ -117,6 +120,8 @@ const ApiCollections = () => {
                             <ReadOnlyWorkflowSheet />
                         </WorkflowReadOnlyProvider>
                     </div>
+                ) : isFiltered ? (
+                    <EmptyFilterResult entityName="API collections" />
                 ) : (
                     <EmptyList
                         button={<ApiCollectionDialog triggerNode={<Button label="New API Collection" />} />}

--- a/client/src/graphql/automation/knowledge-base/knowledgeBaseDocumentTags.graphql
+++ b/client/src/graphql/automation/knowledge-base/knowledgeBaseDocumentTags.graphql
@@ -1,3 +1,3 @@
-query knowledgeBaseDocumentTags {
-    knowledgeBaseDocumentTags
+query knowledgeBaseDocumentTags($knowledgeBaseId: ID!) {
+    knowledgeBaseDocumentTags(knowledgeBaseId: $knowledgeBaseId)
 }

--- a/client/src/graphql/automation/knowledge-base/knowledgeBaseDocumentTagsByDocument.graphql
+++ b/client/src/graphql/automation/knowledge-base/knowledgeBaseDocumentTagsByDocument.graphql
@@ -1,5 +1,5 @@
-query knowledgeBaseDocumentTagsByDocument {
-    knowledgeBaseDocumentTagsByDocument {
+query knowledgeBaseDocumentTagsByDocument($knowledgeBaseId: ID!) {
+    knowledgeBaseDocumentTagsByDocument(knowledgeBaseId: $knowledgeBaseId) {
         knowledgeBaseDocumentId
         tags
     }

--- a/client/src/pages/automation/connections/Connections.tsx
+++ b/client/src/pages/automation/connections/Connections.tsx
@@ -1,4 +1,5 @@
 import Button from '@/components/Button/Button';
+import EmptyFilterResult from '@/components/EmptyFilterResult';
 import EmptyList from '@/components/EmptyList';
 import PageLoader from '@/components/PageLoader';
 import ConnectionsFilterTitle from '@/pages/automation/connections/components/ConnectionsFilterTitle';
@@ -112,7 +113,7 @@ export const Connections = () => {
                         )
                     }
                     title={
-                        connections && connections.length > 0 && componentDefinitions ? (
+                        ((connections && connections.length > 0) || hasActiveFilter) && componentDefinitions ? (
                             <ConnectionsFilterTitle
                                 componentDefinitions={componentDefinitions}
                                 filterData={filterData}
@@ -199,6 +200,8 @@ export const Connections = () => {
                             tags={tags}
                         />
                     )
+                ) : hasActiveFilter ? (
+                    <EmptyFilterResult entityName="connections" />
                 ) : (
                     <EmptyList
                         button={

--- a/client/src/pages/automation/connections/Connections.tsx
+++ b/client/src/pages/automation/connections/Connections.tsx
@@ -201,7 +201,7 @@ export const Connections = () => {
                         />
                     )
                 ) : hasActiveFilter ? (
-                    <EmptyFilterResult entityName="connections" />
+                    <EmptyFilterResult entityName="connections" entityTitle="Connections" />
                 ) : (
                     <EmptyList
                         button={

--- a/client/src/pages/automation/knowledge-base/components/knowledge-base-document-list/KnowledgeBaseDocumentList.tsx
+++ b/client/src/pages/automation/knowledge-base/components/knowledge-base-document-list/KnowledgeBaseDocumentList.tsx
@@ -11,7 +11,7 @@ interface KnowledgeBaseDocumentListProps {
 }
 
 const KnowledgeBaseDocumentList = ({documents, knowledgeBaseId}: KnowledgeBaseDocumentListProps) => {
-    const {getRemainingTagsForDocument, getTagsForDocument} = useKnowledgeBaseDocumentList();
+    const {getRemainingTagsForDocument, getTagsForDocument} = useKnowledgeBaseDocumentList({knowledgeBaseId});
 
     const {
         handleClose: handleDeleteDialogClose,

--- a/client/src/pages/automation/knowledge-base/components/knowledge-base-document-list/hooks/tests/useKnowledgeBaseDocumentList.test.ts
+++ b/client/src/pages/automation/knowledge-base/components/knowledge-base-document-list/hooks/tests/useKnowledgeBaseDocumentList.test.ts
@@ -1,3 +1,7 @@
+import {
+    useKnowledgeBaseDocumentTagsByDocumentQuery,
+    useKnowledgeBaseDocumentTagsQuery,
+} from '@/shared/middleware/graphql';
 import {renderHook} from '@testing-library/react';
 import {beforeEach, describe, expect, it, vi} from 'vitest';
 
@@ -35,7 +39,7 @@ describe('useKnowledgeBaseDocumentList', () => {
 
     describe('getTagsForDocument', () => {
         it('returns empty array when no tags for document', () => {
-            const {result} = renderHook(() => useKnowledgeBaseDocumentList());
+            const {result} = renderHook(() => useKnowledgeBaseDocumentList({knowledgeBaseId: 'kb-1'}));
 
             expect(result.current.getTagsForDocument('doc-1')).toEqual([]);
         });
@@ -50,7 +54,7 @@ describe('useKnowledgeBaseDocumentList', () => {
                 ],
             };
 
-            const {result} = renderHook(() => useKnowledgeBaseDocumentList());
+            const {result} = renderHook(() => useKnowledgeBaseDocumentList({knowledgeBaseId: 'kb-1'}));
 
             const tags = result.current.getTagsForDocument('doc-1');
 
@@ -69,7 +73,7 @@ describe('useKnowledgeBaseDocumentList', () => {
                 ],
             };
 
-            const {result} = renderHook(() => useKnowledgeBaseDocumentList());
+            const {result} = renderHook(() => useKnowledgeBaseDocumentList({knowledgeBaseId: 'kb-1'}));
 
             expect(result.current.getTagsForDocument('doc-2')).toEqual([]);
         });
@@ -81,7 +85,7 @@ describe('useKnowledgeBaseDocumentList', () => {
                 knowledgeBaseDocumentTags: ['Tag 1', 'Tag 2', 'Tag 3'],
             };
 
-            const {result} = renderHook(() => useKnowledgeBaseDocumentList());
+            const {result} = renderHook(() => useKnowledgeBaseDocumentList({knowledgeBaseId: 'kb-1'}));
 
             const remainingTags = result.current.getRemainingTagsForDocument('doc-1');
 
@@ -102,7 +106,7 @@ describe('useKnowledgeBaseDocumentList', () => {
                 ],
             };
 
-            const {result} = renderHook(() => useKnowledgeBaseDocumentList());
+            const {result} = renderHook(() => useKnowledgeBaseDocumentList({knowledgeBaseId: 'kb-1'}));
 
             const remainingTags = result.current.getRemainingTagsForDocument('doc-1');
 
@@ -126,7 +130,7 @@ describe('useKnowledgeBaseDocumentList', () => {
                 ],
             };
 
-            const {result} = renderHook(() => useKnowledgeBaseDocumentList());
+            const {result} = renderHook(() => useKnowledgeBaseDocumentList({knowledgeBaseId: 'kb-1'}));
 
             const remainingTags = result.current.getRemainingTagsForDocument('doc-1');
 
@@ -136,10 +140,21 @@ describe('useKnowledgeBaseDocumentList', () => {
 
     describe('return values', () => {
         it('returns all expected functions', () => {
-            const {result} = renderHook(() => useKnowledgeBaseDocumentList());
+            const {result} = renderHook(() => useKnowledgeBaseDocumentList({knowledgeBaseId: 'kb-1'}));
 
             expect(typeof result.current.getTagsForDocument).toBe('function');
             expect(typeof result.current.getRemainingTagsForDocument).toBe('function');
+        });
+    });
+
+    describe('scoping', () => {
+        // Both queries were unscoped, so the tag suggestions offered on one knowledge base's documents were
+        // aggregated from every document in the instance.
+        it('asks both tag queries for the knowledge base being viewed', () => {
+            renderHook(() => useKnowledgeBaseDocumentList({knowledgeBaseId: 'kb-7'}));
+
+            expect(useKnowledgeBaseDocumentTagsQuery).toHaveBeenCalledWith({knowledgeBaseId: 'kb-7'});
+            expect(useKnowledgeBaseDocumentTagsByDocumentQuery).toHaveBeenCalledWith({knowledgeBaseId: 'kb-7'});
         });
     });
 });

--- a/client/src/pages/automation/knowledge-base/components/knowledge-base-document-list/hooks/useKnowledgeBaseDocumentList.ts
+++ b/client/src/pages/automation/knowledge-base/components/knowledge-base-document-list/hooks/useKnowledgeBaseDocumentList.ts
@@ -4,9 +4,9 @@ import {
 } from '@/shared/middleware/graphql';
 import {useMemo} from 'react';
 
-export default function useKnowledgeBaseDocumentList() {
-    const {data: tagsByDocumentData} = useKnowledgeBaseDocumentTagsByDocumentQuery();
-    const {data: allTagsData} = useKnowledgeBaseDocumentTagsQuery();
+export default function useKnowledgeBaseDocumentList({knowledgeBaseId}: {knowledgeBaseId: string}) {
+    const {data: tagsByDocumentData} = useKnowledgeBaseDocumentTagsByDocumentQuery({knowledgeBaseId});
+    const {data: allTagsData} = useKnowledgeBaseDocumentTagsQuery({knowledgeBaseId});
 
     const tagsByDocument = useMemo(
         () => tagsByDocumentData?.knowledgeBaseDocumentTagsByDocument ?? [],

--- a/client/src/pages/automation/mcp-servers/McpServers.tsx
+++ b/client/src/pages/automation/mcp-servers/McpServers.tsx
@@ -80,7 +80,7 @@ const McpServers = () => {
                 {filteredMcpServers.length > 0 ? (
                     <McpServerList mcpServers={filteredMcpServers as McpServer[]} tags={tags} />
                 ) : validMcpServers.length > 0 ? (
-                    <EmptyFilterResult entityName="MCP servers" />
+                    <EmptyFilterResult entityName="MCP servers" entityTitle="MCP Servers" />
                 ) : (
                     <EmptyList
                         button={

--- a/client/src/pages/automation/mcp-servers/McpServers.tsx
+++ b/client/src/pages/automation/mcp-servers/McpServers.tsx
@@ -1,4 +1,5 @@
 import Button from '@/components/Button/Button';
+import EmptyFilterResult from '@/components/EmptyFilterResult';
 import EmptyList from '@/components/EmptyList';
 import PageLoader from '@/components/PageLoader';
 import Header from '@/shared/layout/Header';
@@ -78,6 +79,8 @@ const McpServers = () => {
             <PageLoader errors={[mcpServersError, tagsError]} loading={mcpServersIsLoading || tagsIsLoading}>
                 {filteredMcpServers.length > 0 ? (
                     <McpServerList mcpServers={filteredMcpServers as McpServer[]} tags={tags} />
+                ) : validMcpServers.length > 0 ? (
+                    <EmptyFilterResult entityName="MCP servers" />
                 ) : (
                     <EmptyList
                         button={

--- a/client/src/pages/automation/project-deployments/ProjectDeployments.tsx
+++ b/client/src/pages/automation/project-deployments/ProjectDeployments.tsx
@@ -1,4 +1,5 @@
 import Button from '@/components/Button/Button';
+import EmptyFilterResult from '@/components/EmptyFilterResult';
 import EmptyList from '@/components/EmptyList';
 import PageLoader from '@/components/PageLoader';
 import {Skeleton} from '@/components/ui/skeleton';
@@ -65,6 +66,8 @@ const ProjectDeployments = () => {
         id: projectId ? parseInt(projectId) : tagId ? parseInt(tagId) : undefined,
         type: tagId ? Type.Tag : Type.Project,
     };
+
+    const isFiltered = filterData.id !== undefined;
 
     const {
         data: projects,
@@ -139,7 +142,7 @@ const ProjectDeployments = () => {
                         )
                     }
                     title={
-                        projectDeployments && projectDeployments.length > 0 ? (
+                        (projectDeployments && projectDeployments.length > 0) || isFiltered ? (
                             <ProjectDeploymentFilterTitle filterData={filterData} projects={projects} tags={tags} />
                         ) : (
                             ''
@@ -244,6 +247,8 @@ const ProjectDeployments = () => {
                             <ReadOnlyWorkflowSheet />
                         </WorkflowReadOnlyProvider>
                     </div>
+                ) : isFiltered ? (
+                    <EmptyFilterResult entityName="project deployments" />
                 ) : (
                     <EmptyList
                         button={

--- a/client/src/pages/automation/project-deployments/ProjectDeployments.tsx
+++ b/client/src/pages/automation/project-deployments/ProjectDeployments.tsx
@@ -248,7 +248,7 @@ const ProjectDeployments = () => {
                         </WorkflowReadOnlyProvider>
                     </div>
                 ) : isFiltered ? (
-                    <EmptyFilterResult entityName="project deployments" />
+                    <EmptyFilterResult entityName="project deployments" entityTitle="Project Deployments" />
                 ) : (
                     <EmptyList
                         button={

--- a/client/src/pages/automation/project/components/project-header/components/settings-menu/hooks/useSettingsMenu.ts
+++ b/client/src/pages/automation/project/components/project-header/components/settings-menu/hooks/useSettingsMenu.ts
@@ -43,7 +43,7 @@ export const useSettingsMenu = ({project, workflow}: {project: Project; workflow
 
             queryClient.invalidateQueries({queryKey: ProjectKeys.projects});
             queryClient.invalidateQueries({
-                queryKey: ProjectCategoryKeys.projectCategories,
+                queryKey: ProjectCategoryKeys.projectCategories(project.workspaceId!),
             });
             queryClient.invalidateQueries({
                 queryKey: ProjectTagKeys.projectTags,

--- a/client/src/pages/automation/project/hooks/useProject.ts
+++ b/client/src/pages/automation/project/hooks/useProject.ts
@@ -108,7 +108,7 @@ export const useProject = () => {
         );
     };
 
-    const {data: categories} = useGetProjectCategoriesQuery();
+    const {data: categories} = useGetProjectCategoriesQuery(currentWorkspaceId!);
 
     const {data: tags} = useGetProjectTagsQuery();
 

--- a/client/src/pages/automation/projects/Projects.test.tsx
+++ b/client/src/pages/automation/projects/Projects.test.tsx
@@ -101,9 +101,9 @@ afterEach(() => {
     queryClient.clear();
 });
 
-const renderProjects = () => {
+const renderProjects = (initialEntries: string[] = ['/']) => {
     render(
-        <MemoryRouter>
+        <MemoryRouter initialEntries={initialEntries}>
             <QueryClientProvider client={queryClient}>
                 <TooltipProvider>
                     <Projects />
@@ -170,5 +170,23 @@ describe('Projects Import Functionality', () => {
                 workspaceId: 1,
             });
         });
+    });
+});
+
+describe('Projects empty states', () => {
+    it('offers to create a project when the workspace has none', () => {
+        renderProjects();
+
+        expect(screen.getByText('No Projects')).toBeInTheDocument();
+        expect(screen.getByText('Get started by creating a new project.')).toBeInTheDocument();
+    });
+
+    // The filtered list and the unfiltered one were the same array, so a filter that matched nothing rendered
+    // the first-run state and told the reader the workspace was empty.
+    it('reports a filter miss rather than an empty workspace', () => {
+        renderProjects(['/?tagId=1']);
+
+        expect(screen.getByText('No Matching Projects')).toBeInTheDocument();
+        expect(screen.queryByText('Get started by creating a new project.')).not.toBeInTheDocument();
     });
 });

--- a/client/src/pages/automation/projects/Projects.tsx
+++ b/client/src/pages/automation/projects/Projects.tsx
@@ -1,4 +1,5 @@
 import Button from '@/components/Button/Button';
+import EmptyFilterResult from '@/components/EmptyFilterResult';
 import EmptyList from '@/components/EmptyList';
 import PageLoader from '@/components/PageLoader';
 import {ButtonGroup} from '@/components/ui/button-group';
@@ -62,12 +63,18 @@ const Projects = () => {
         type: tagId ? Type.Tag : Type.Category,
     };
 
+    const isFiltered = filterData.id !== undefined;
+
     const {data: componentDefinitions} = useGetComponentDefinitionsQuery({
         actionDefinitions: true,
         triggerDefinitions: true,
     });
 
-    const {data: categories, error: categoriesError, isLoading: categoriesIsLoading} = useGetProjectCategoriesQuery(currentWorkspaceId!);
+    const {
+        data: categories,
+        error: categoriesError,
+        isLoading: categoriesIsLoading,
+    } = useGetProjectCategoriesQuery(currentWorkspaceId!);
 
     const {
         data: projectGitConfigurations,
@@ -165,6 +172,8 @@ const Projects = () => {
                         tags={tags}
                         taskDispatcherDefinitions={taskDispatcherDefinitions}
                     />
+                ) : isFiltered ? (
+                    <EmptyFilterResult entityName="projects" />
                 ) : (
                     <EmptyList
                         button={

--- a/client/src/pages/automation/projects/Projects.tsx
+++ b/client/src/pages/automation/projects/Projects.tsx
@@ -173,7 +173,7 @@ const Projects = () => {
                         taskDispatcherDefinitions={taskDispatcherDefinitions}
                     />
                 ) : isFiltered ? (
-                    <EmptyFilterResult entityName="projects" />
+                    <EmptyFilterResult entityName="projects" entityTitle="Projects" />
                 ) : (
                     <EmptyList
                         button={

--- a/client/src/pages/automation/projects/Projects.tsx
+++ b/client/src/pages/automation/projects/Projects.tsx
@@ -67,7 +67,7 @@ const Projects = () => {
         triggerDefinitions: true,
     });
 
-    const {data: categories, error: categoriesError, isLoading: categoriesIsLoading} = useGetProjectCategoriesQuery();
+    const {data: categories, error: categoriesError, isLoading: categoriesIsLoading} = useGetProjectCategoriesQuery(currentWorkspaceId!);
 
     const {
         data: projectGitConfigurations,

--- a/client/src/pages/automation/projects/components/ProjectDialog.tsx
+++ b/client/src/pages/automation/projects/components/ProjectDialog.tsx
@@ -60,7 +60,11 @@ const ProjectDialog = ({onClose, onSuccess, project, triggerNode}: ProjectDialog
 
     const {control, getValues, handleSubmit, reset, setValue} = form;
 
-    const {data: categories, error: categoriesError, isLoading: categoriesLoading} = useGetProjectCategoriesQuery();
+    const {
+        data: categories,
+        error: categoriesError,
+        isLoading: categoriesLoading,
+    } = useGetProjectCategoriesQuery(currentWorkspaceId!);
 
     const {data: tags, error: tagsError, isLoading: tagsLoading} = useGetProjectTagsQuery();
 
@@ -80,7 +84,7 @@ const ProjectDialog = ({onClose, onSuccess, project, triggerNode}: ProjectDialog
         }
 
         queryClient.invalidateQueries({
-            queryKey: ProjectCategoryKeys.projectCategories,
+            queryKey: ProjectCategoryKeys.projectCategories(currentWorkspaceId!),
         });
         queryClient.invalidateQueries({queryKey: ProjectKeys.projects});
         queryClient.invalidateQueries({

--- a/client/src/pages/automation/projects/components/project-list/ProjectListItem.tsx
+++ b/client/src/pages/automation/projects/components/project-list/ProjectListItem.tsx
@@ -139,7 +139,7 @@ const ProjectListItem = ({project, projectGitConfiguration, remainingTags}: Proj
 
             queryClient.invalidateQueries({queryKey: ProjectKeys.projects});
             queryClient.invalidateQueries({
-                queryKey: ProjectCategoryKeys.projectCategories,
+                queryKey: ProjectCategoryKeys.projectCategories(currentWorkspaceId!),
             });
             queryClient.invalidateQueries({
                 queryKey: ProjectTagKeys.projectTags,

--- a/client/src/shared/middleware/automation/configuration/apis/CategoryApi.ts
+++ b/client/src/shared/middleware/automation/configuration/apis/CategoryApi.ts
@@ -19,6 +19,10 @@ import {
     CategoryToJSON,
 } from '../models/Category';
 
+export interface GetProjectCategoriesRequest {
+    id: number;
+}
+
 /**
  * 
  */
@@ -27,13 +31,21 @@ export class CategoryApi extends runtime.BaseAPI {
     /**
      * Creates request options for getProjectCategories without sending the request
      */
-    async getProjectCategoriesRequestOpts(): Promise<runtime.RequestOpts> {
+    async getProjectCategoriesRequestOpts(requestParameters: GetProjectCategoriesRequest): Promise<runtime.RequestOpts> {
+        if (requestParameters['id'] == null) {
+            throw new runtime.RequiredError(
+                'id',
+                'Required parameter "id" was null or undefined when calling getProjectCategories().'
+            );
+        }
+
         const queryParameters: any = {};
 
         const headerParameters: runtime.HTTPHeaders = {};
 
 
-        let urlPath = `/projects/categories`;
+        let urlPath = `/workspaces/{id}/project-categories`;
+        urlPath = urlPath.replace('{id}', encodeURIComponent(String(requestParameters['id'])));
 
         return {
             path: urlPath,
@@ -44,22 +56,22 @@ export class CategoryApi extends runtime.BaseAPI {
     }
 
     /**
-     * Get categories.
-     * Get categories
+     * Get project categories for a workspace.
+     * Get project categories
      */
-    async getProjectCategoriesRaw(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Array<Category>>> {
-        const requestOptions = await this.getProjectCategoriesRequestOpts();
+    async getProjectCategoriesRaw(requestParameters: GetProjectCategoriesRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Array<Category>>> {
+        const requestOptions = await this.getProjectCategoriesRequestOpts(requestParameters);
         const response = await this.request(requestOptions, initOverrides);
 
         return new runtime.JSONApiResponse(response, (jsonValue) => jsonValue.map(CategoryFromJSON));
     }
 
     /**
-     * Get categories.
-     * Get categories
+     * Get project categories for a workspace.
+     * Get project categories
      */
-    async getProjectCategories(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<Array<Category>> {
-        const response = await this.getProjectCategoriesRaw(initOverrides);
+    async getProjectCategories(requestParameters: GetProjectCategoriesRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<Array<Category>> {
+        const response = await this.getProjectCategoriesRaw(requestParameters, initOverrides);
         return await response.value();
     }
 

--- a/client/src/shared/middleware/automation/configuration/docs/CategoryApi.md
+++ b/client/src/shared/middleware/automation/configuration/docs/CategoryApi.md
@@ -4,17 +4,17 @@ All URIs are relative to */api/automation/internal*
 
 | Method | HTTP request | Description |
 |------------- | ------------- | -------------|
-| [**getProjectCategories**](CategoryApi.md#getprojectcategories) | **GET** /projects/categories | Get categories |
+| [**getProjectCategories**](CategoryApi.md#getprojectcategories) | **GET** /workspaces/{id}/project-categories | Get project categories |
 
 
 
 ## getProjectCategories
 
-> Array&lt;Category&gt; getProjectCategories()
+> Array&lt;Category&gt; getProjectCategories(requestParameters: GetProjectCategoriesRequest)
 
-Get categories
+Get project categories
 
-Get categories.
+Get project categories for a workspace.
 
 ### Example
 
@@ -29,8 +29,13 @@ async function example() {
   console.log("🚀 Testing  SDK...");
   const api = new CategoryApi();
 
+  const requestParameters: GetProjectCategoriesRequest = {
+    // The id of a workspace.
+    id: 789,
+  };
+
   try {
-    const data = await api.getProjectCategories();
+    const data = await api.getProjectCategories(requestParameters);
     console.log(data);
   } catch (error) {
     console.error(error);
@@ -43,7 +48,9 @@ example().catch(console.error);
 
 ### Parameters
 
-This endpoint does not need any parameter.
+| Name | Type | Description  | Notes |
+| ------------- | ------------- | ------------- | ------------- |
+| **id** | **number** | The id of a workspace. | defaults to undefined |
 
 ### Return type
 

--- a/client/src/shared/middleware/graphql-types.ts
+++ b/client/src/shared/middleware/graphql-types.ts
@@ -3145,6 +3145,16 @@ export type QueryKnowledgeBaseDocumentStatusArgs = {
 };
 
 
+export type QueryKnowledgeBaseDocumentTagsArgs = {
+  knowledgeBaseId: Scalars['ID']['input'];
+};
+
+
+export type QueryKnowledgeBaseDocumentTagsByDocumentArgs = {
+  knowledgeBaseId: Scalars['ID']['input'];
+};
+
+
 export type QueryKnowledgeBaseEmbeddingActiveArgs = {
   environment: Scalars['Int']['input'];
 };

--- a/client/src/shared/middleware/graphql.ts
+++ b/client/src/shared/middleware/graphql.ts
@@ -791,12 +791,16 @@ export type KnowledgeBaseDocumentStatusQueryVariables = Exact<{
 
 export type KnowledgeBaseDocumentStatusQuery = { knowledgeBaseDocumentStatus: { documentId: string, status: number, timestamp: any, message: string | null } | null };
 
-export type KnowledgeBaseDocumentTagsQueryVariables = Exact<{ [key: string]: never; }>;
+export type KnowledgeBaseDocumentTagsQueryVariables = Exact<{
+  knowledgeBaseId: string | number;
+}>;
 
 
 export type KnowledgeBaseDocumentTagsQuery = { knowledgeBaseDocumentTags: Array<string> | null };
 
-export type KnowledgeBaseDocumentTagsByDocumentQueryVariables = Exact<{ [key: string]: never; }>;
+export type KnowledgeBaseDocumentTagsByDocumentQueryVariables = Exact<{
+  knowledgeBaseId: string | number;
+}>;
 
 
 export type KnowledgeBaseDocumentTagsByDocumentQuery = { knowledgeBaseDocumentTagsByDocument: Array<{ knowledgeBaseDocumentId: string, tags: Array<string> }> | null };
@@ -4598,8 +4602,8 @@ export const useKnowledgeBaseDocumentStatusQuery = <
     )};
 
 export const KnowledgeBaseDocumentTagsDocument = new TypedDocumentString(`
-    query knowledgeBaseDocumentTags {
-  knowledgeBaseDocumentTags
+    query knowledgeBaseDocumentTags($knowledgeBaseId: ID!) {
+  knowledgeBaseDocumentTags(knowledgeBaseId: $knowledgeBaseId)
 }
     `);
 
@@ -4607,21 +4611,21 @@ export const useKnowledgeBaseDocumentTagsQuery = <
       TData = KnowledgeBaseDocumentTagsQuery,
       TError = unknown
     >(
-      variables?: KnowledgeBaseDocumentTagsQueryVariables,
+      variables: KnowledgeBaseDocumentTagsQueryVariables,
       options?: Omit<UseQueryOptions<KnowledgeBaseDocumentTagsQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<KnowledgeBaseDocumentTagsQuery, TError, TData>['queryKey'] }
     ) => {
     
     return useQuery<KnowledgeBaseDocumentTagsQuery, TError, TData>(
       {
-    queryKey: variables === undefined ? ['knowledgeBaseDocumentTags'] : ['knowledgeBaseDocumentTags', variables],
+    queryKey: ['knowledgeBaseDocumentTags', variables],
     queryFn: fetcher<KnowledgeBaseDocumentTagsQuery, KnowledgeBaseDocumentTagsQueryVariables>(KnowledgeBaseDocumentTagsDocument, variables),
     ...options
   }
     )};
 
 export const KnowledgeBaseDocumentTagsByDocumentDocument = new TypedDocumentString(`
-    query knowledgeBaseDocumentTagsByDocument {
-  knowledgeBaseDocumentTagsByDocument {
+    query knowledgeBaseDocumentTagsByDocument($knowledgeBaseId: ID!) {
+  knowledgeBaseDocumentTagsByDocument(knowledgeBaseId: $knowledgeBaseId) {
     knowledgeBaseDocumentId
     tags
   }
@@ -4632,13 +4636,13 @@ export const useKnowledgeBaseDocumentTagsByDocumentQuery = <
       TData = KnowledgeBaseDocumentTagsByDocumentQuery,
       TError = unknown
     >(
-      variables?: KnowledgeBaseDocumentTagsByDocumentQueryVariables,
+      variables: KnowledgeBaseDocumentTagsByDocumentQueryVariables,
       options?: Omit<UseQueryOptions<KnowledgeBaseDocumentTagsByDocumentQuery, TError, TData>, 'queryKey'> & { queryKey?: UseQueryOptions<KnowledgeBaseDocumentTagsByDocumentQuery, TError, TData>['queryKey'] }
     ) => {
     
     return useQuery<KnowledgeBaseDocumentTagsByDocumentQuery, TError, TData>(
       {
-    queryKey: variables === undefined ? ['knowledgeBaseDocumentTagsByDocument'] : ['knowledgeBaseDocumentTagsByDocument', variables],
+    queryKey: ['knowledgeBaseDocumentTagsByDocument', variables],
     queryFn: fetcher<KnowledgeBaseDocumentTagsByDocumentQuery, KnowledgeBaseDocumentTagsByDocumentQueryVariables>(KnowledgeBaseDocumentTagsByDocumentDocument, variables),
     ...options
   }

--- a/client/src/shared/queries/automation/projectCategories.queries.ts
+++ b/client/src/shared/queries/automation/projectCategories.queries.ts
@@ -3,11 +3,11 @@ import {Category, CategoryApi} from '@/shared/middleware/automation/configuratio
 import {useQuery} from '@tanstack/react-query';
 
 export const ProjectCategoryKeys = {
-    projectCategories: ['projectCategories'] as const,
+    projectCategories: (id: number) => ['projectCategories', id] as const,
 };
 
-export const useGetProjectCategoriesQuery = () =>
+export const useGetProjectCategoriesQuery = (id: number) =>
     useQuery<Category[], Error>({
-        queryKey: ProjectCategoryKeys.projectCategories,
-        queryFn: () => new CategoryApi().getProjectCategories(),
+        queryKey: ProjectCategoryKeys.projectCategories(id),
+        queryFn: () => new CategoryApi().getProjectCategories({id}),
     });

--- a/client/src/shared/queries/automation/tests/projectCategories.queries.test.tsx
+++ b/client/src/shared/queries/automation/tests/projectCategories.queries.test.tsx
@@ -1,0 +1,38 @@
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
+import {renderHook, waitFor} from '@testing-library/react';
+import {ReactNode} from 'react';
+import {describe, expect, it, vi} from 'vitest';
+
+import {ProjectCategoryKeys, useGetProjectCategoriesQuery} from '../projectCategories.queries';
+
+const {getProjectCategoriesMock} = vi.hoisted(() => ({getProjectCategoriesMock: vi.fn()}));
+
+vi.mock('@/shared/middleware/automation/configuration', () => ({
+    CategoryApi: class {
+        getProjectCategories = getProjectCategoriesMock;
+    },
+}));
+
+const wrapper = ({children}: {children: ReactNode}) => (
+    <QueryClientProvider client={new QueryClient({defaultOptions: {queries: {retry: false}}})}>
+        {children}
+    </QueryClientProvider>
+);
+
+describe('projectCategories.queries', () => {
+    it('keys the cache by workspace, so two workspaces cannot share an entry', () => {
+        expect(ProjectCategoryKeys.projectCategories(1)).toEqual(['projectCategories', 1]);
+        expect(ProjectCategoryKeys.projectCategories(1)).not.toEqual(ProjectCategoryKeys.projectCategories(2));
+    });
+
+    it('asks for the categories of the given workspace', async () => {
+        getProjectCategoriesMock.mockResolvedValue([{id: 10, name: 'Records'}]);
+
+        const {result} = renderHook(() => useGetProjectCategoriesQuery(7), {wrapper});
+
+        await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+        expect(getProjectCategoriesMock).toHaveBeenCalledWith({id: 7});
+        expect(result.current.data).toEqual([{id: 10, name: 'Records'}]);
+    });
+});

--- a/server/libs/automation/automation-configuration/automation-configuration-api/src/main/java/com/bytechef/automation/configuration/facade/ProjectCategoryFacade.java
+++ b/server/libs/automation/automation-configuration/automation-configuration-api/src/main/java/com/bytechef/automation/configuration/facade/ProjectCategoryFacade.java
@@ -24,5 +24,5 @@ import java.util.List;
  */
 public interface ProjectCategoryFacade {
 
-    List<Category> getProjectCategories();
+    List<Category> getProjectCategories(long workspaceId);
 }

--- a/server/libs/automation/automation-configuration/automation-configuration-rest/automation-configuration-rest-api/generated/src/main/java/com/bytechef/automation/configuration/web/rest/CategoryApi.java
+++ b/server/libs/automation/automation-configuration/automation-configuration-rest/automation-configuration-rest-api/generated/src/main/java/com/bytechef/automation/configuration/web/rest/CategoryApi.java
@@ -42,17 +42,18 @@ public interface CategoryApi {
         return Optional.empty();
     }
 
-    String PATH_GET_PROJECT_CATEGORIES = "/projects/categories";
+    String PATH_GET_PROJECT_CATEGORIES = "/workspaces/{id}/project-categories";
     /**
-     * GET /projects/categories : Get categories
-     * Get categories.
+     * GET /workspaces/{id}/project-categories : Get project categories
+     * Get project categories for a workspace.
      *
+     * @param id The id of a workspace. (required)
      * @return The list of categories. (status code 200)
      */
     @Operation(
         operationId = "getProjectCategories",
-        summary = "Get categories",
-        description = "Get categories.",
+        summary = "Get project categories",
+        description = "Get project categories for a workspace.",
         tags = { "category" },
         responses = {
             @ApiResponse(responseCode = "200", description = "The list of categories.", content = {
@@ -66,7 +67,7 @@ public interface CategoryApi {
         produces = { "application/json" }
     )
     default ResponseEntity<List<CategoryModel>> getProjectCategories(
-        
+        @Parameter(name = "id", description = "The id of a workspace.", required = true, in = ParameterIn.PATH) @PathVariable("id") Long id
     ) {
         getRequest().ifPresent(request -> {
             for (MediaType mediaType: MediaType.parseMediaTypes(request.getHeader("Accept"))) {

--- a/server/libs/automation/automation-configuration/automation-configuration-rest/automation-configuration-rest-impl/openapi.yaml
+++ b/server/libs/automation/automation-configuration/automation-configuration-rest/automation-configuration-rest-impl/openapi.yaml
@@ -465,13 +465,21 @@ paths:
               schema:
                 type: integer
                 format: int64
-  /projects/categories:
+  /workspaces/{id}/project-categories:
     get:
-      description: "Get categories."
-      summary: "Get categories"
+      description: "Get project categories for a workspace."
+      summary: "Get project categories"
       tags:
       - "category"
       operationId: "getProjectCategories"
+      parameters:
+        - name: "id"
+          description: "The id of a workspace."
+          in: "path"
+          required: true
+          schema:
+            type: "integer"
+            format: "int64"
       responses:
         "200":
           description: "The list of categories."

--- a/server/libs/automation/automation-configuration/automation-configuration-rest/automation-configuration-rest-impl/src/main/java/com/bytechef/automation/configuration/web/rest/CategoryApiController.java
+++ b/server/libs/automation/automation-configuration/automation-configuration-rest/automation-configuration-rest-impl/src/main/java/com/bytechef/automation/configuration/web/rest/CategoryApiController.java
@@ -44,9 +44,9 @@ public class CategoryApiController implements CategoryApi {
     }
 
     @Override
-    public ResponseEntity<List<CategoryModel>> getProjectCategories() {
+    public ResponseEntity<List<CategoryModel>> getProjectCategories(Long id) {
         return ResponseEntity.ok(
-            projectCategoryFacade.getProjectCategories()
+            projectCategoryFacade.getProjectCategories(id)
                 .stream()
                 .map(category -> conversionService.convert(category, CategoryModel.class))
                 .toList());

--- a/server/libs/automation/automation-configuration/automation-configuration-rest/automation-configuration-rest-impl/src/test/java/com/bytechef/automation/configuration/web/rest/CategoryApiControllerIntTest.java
+++ b/server/libs/automation/automation-configuration/automation-configuration-rest/automation-configuration-rest-impl/src/test/java/com/bytechef/automation/configuration/web/rest/CategoryApiControllerIntTest.java
@@ -16,6 +16,7 @@
 
 package com.bytechef.automation.configuration.web.rest;
 
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
 
 import com.bytechef.atlas.configuration.service.WorkflowService;
@@ -94,12 +95,12 @@ public class CategoryApiControllerIntTest {
     @Test
     public void testGetProjectCategories() {
         try {
-            when(projectCategoryFacade.getProjectCategories())
+            when(projectCategoryFacade.getProjectCategories(anyLong()))
                 .thenReturn(List.of(new Category(1, "name")));
 
             this.webTestClient
                 .get()
-                .uri("/internal/projects/categories")
+                .uri("/internal/workspaces/1/project-categories")
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
                 .expectStatus()

--- a/server/libs/automation/automation-configuration/automation-configuration-service/src/main/java/com/bytechef/automation/configuration/facade/ProjectCategoryFacadeImpl.java
+++ b/server/libs/automation/automation-configuration/automation-configuration-service/src/main/java/com/bytechef/automation/configuration/facade/ProjectCategoryFacadeImpl.java
@@ -24,6 +24,7 @@ import com.bytechef.platform.category.service.CategoryService;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.List;
 import java.util.Objects;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -45,8 +46,9 @@ public class ProjectCategoryFacadeImpl implements ProjectCategoryFacade {
 
     @Override
     @Transactional(readOnly = true)
-    public List<Category> getProjectCategories() {
-        List<Project> projects = projectService.getProjects();
+    @PreAuthorize("hasPermission(#workspaceId, 'Workspace', 'WORKFLOW_VIEW')")
+    public List<Category> getProjectCategories(long workspaceId) {
+        List<Project> projects = projectService.getProjects(projectService.getWorkspaceProjectIds(workspaceId));
 
         return categoryService.getCategories(
             CollectionUtils.filter(CollectionUtils.map(projects, Project::getCategoryId), Objects::nonNull));

--- a/server/libs/automation/automation-configuration/automation-configuration-service/src/test/java/com/bytechef/automation/configuration/facade/ProjectCategoryFacadeImplTest.java
+++ b/server/libs/automation/automation-configuration/automation-configuration-service/src/test/java/com/bytechef/automation/configuration/facade/ProjectCategoryFacadeImplTest.java
@@ -55,8 +55,8 @@ class ProjectCategoryFacadeImplTest {
 
     /**
      * The facade previously read every project in the instance, so a workspace holding no projects still offered
-     * another workspace's categories. Both halves are asserted: that no category id is asked for, and that the
-     * caller is handed an empty list rather than whatever the unstubbed collaborator happened to return.
+     * another workspace's categories. Both halves are asserted: that no category id is asked for, and that the caller
+     * is handed an empty list rather than whatever the unstubbed collaborator happened to return.
      */
     @Test
     void testGetProjectCategoriesOfAWorkspaceWithoutProjectsIsEmpty() {

--- a/server/libs/automation/automation-configuration/automation-configuration-service/src/test/java/com/bytechef/automation/configuration/facade/ProjectCategoryFacadeImplTest.java
+++ b/server/libs/automation/automation-configuration/automation-configuration-service/src/test/java/com/bytechef/automation/configuration/facade/ProjectCategoryFacadeImplTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025 ByteChef
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.bytechef.automation.configuration.facade;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.bytechef.automation.configuration.domain.Project;
+import com.bytechef.automation.configuration.service.ProjectService;
+import com.bytechef.platform.category.domain.Category;
+import com.bytechef.platform.category.service.CategoryService;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ProjectCategoryFacadeImplTest {
+
+    private static final long OTHER_WORKSPACE_ID = 6L;
+    private static final long WORKSPACE_ID = 5L;
+
+    private final CategoryService categoryService = mock(CategoryService.class);
+    private final ProjectService projectService = mock(ProjectService.class);
+
+    /**
+     * The third project in the fixture is filed under no category at all, so this also pins that a null category id
+     * never reaches the lookup.
+     */
+    @Test
+    void testGetProjectCategoriesScopesToWorkspace() {
+        when(categoryService.getCategories(List.of(10L, 11L)))
+            .thenReturn(List.of(new Category(10, "a"), new Category(11, "b")));
+
+        List<Category> categories = facade().getProjectCategories(WORKSPACE_ID);
+
+        assertThat(categories).hasSize(2);
+
+        verify(projectService).getWorkspaceProjectIds(WORKSPACE_ID);
+        verify(categoryService).getCategories(List.of(10L, 11L));
+    }
+
+    /**
+     * The assertion is on the ids handed to {@code CategoryService}: the facade previously read every project in the
+     * instance, so a workspace holding no projects still offered another workspace's categories.
+     */
+    @Test
+    void testGetProjectCategoriesOfAWorkspaceWithoutProjectsIsEmpty() {
+        when(projectService.getWorkspaceProjectIds(OTHER_WORKSPACE_ID)).thenReturn(List.of());
+        when(projectService.getProjects(List.of())).thenReturn(List.of());
+
+        facade().getProjectCategories(OTHER_WORKSPACE_ID);
+
+        verify(categoryService).getCategories(List.of());
+    }
+
+    private ProjectCategoryFacadeImpl facade() {
+        when(projectService.getWorkspaceProjectIds(WORKSPACE_ID)).thenReturn(List.of(1L, 2L, 3L));
+        when(projectService.getProjects(List.of(1L, 2L, 3L)))
+            .thenReturn(List.of(project(1L, 10L), project(2L, 11L), project(3L, null)));
+
+        return new ProjectCategoryFacadeImpl(categoryService, projectService);
+    }
+
+    private static Project project(long id, Long categoryId) {
+        Project project = new Project();
+
+        project.setId(id);
+        project.setCategoryId(categoryId);
+
+        return project;
+    }
+}

--- a/server/libs/automation/automation-configuration/automation-configuration-service/src/test/java/com/bytechef/automation/configuration/facade/ProjectCategoryFacadeImplTest.java
+++ b/server/libs/automation/automation-configuration/automation-configuration-service/src/test/java/com/bytechef/automation/configuration/facade/ProjectCategoryFacadeImplTest.java
@@ -54,15 +54,19 @@ class ProjectCategoryFacadeImplTest {
     }
 
     /**
-     * The assertion is on the ids handed to {@code CategoryService}: the facade previously read every project in the
-     * instance, so a workspace holding no projects still offered another workspace's categories.
+     * The facade previously read every project in the instance, so a workspace holding no projects still offered
+     * another workspace's categories. Both halves are asserted: that no category id is asked for, and that the
+     * caller is handed an empty list rather than whatever the unstubbed collaborator happened to return.
      */
     @Test
     void testGetProjectCategoriesOfAWorkspaceWithoutProjectsIsEmpty() {
         when(projectService.getWorkspaceProjectIds(OTHER_WORKSPACE_ID)).thenReturn(List.of());
         when(projectService.getProjects(List.of())).thenReturn(List.of());
+        when(categoryService.getCategories(List.of())).thenReturn(List.of());
 
-        facade().getProjectCategories(OTHER_WORKSPACE_ID);
+        List<Category> categories = facade().getProjectCategories(OTHER_WORKSPACE_ID);
+
+        assertThat(categories).isEmpty();
 
         verify(categoryService).getCategories(List.of());
     }

--- a/server/libs/automation/automation-knowledge-base/automation-knowledge-base-graphql/src/main/java/com/bytechef/automation/knowledgebase/web/graphql/KnowledgeBaseDocumentTagGraphQlController.java
+++ b/server/libs/automation/automation-knowledge-base/automation-knowledge-base-graphql/src/main/java/com/bytechef/automation/knowledgebase/web/graphql/KnowledgeBaseDocumentTagGraphQlController.java
@@ -47,13 +47,13 @@ public class KnowledgeBaseDocumentTagGraphQlController {
     }
 
     @QueryMapping
-    public List<String> knowledgeBaseDocumentTags() {
-        return knowledgeBaseDocumentTagService.getAllTagNames();
+    public List<String> knowledgeBaseDocumentTags(@Argument Long knowledgeBaseId) {
+        return knowledgeBaseDocumentTagService.getTagNamesByKnowledgeBaseId(knowledgeBaseId);
     }
 
     @QueryMapping
-    public List<KnowledgeBaseDocumentTagsEntry> knowledgeBaseDocumentTagsByDocument() {
-        return knowledgeBaseDocumentTagService.getTagNamesByKnowledgeBaseDocumentId()
+    public List<KnowledgeBaseDocumentTagsEntry> knowledgeBaseDocumentTagsByDocument(@Argument Long knowledgeBaseId) {
+        return knowledgeBaseDocumentTagService.getTagNamesByKnowledgeBaseDocumentId(knowledgeBaseId)
             .entrySet()
             .stream()
             .map(entry -> new KnowledgeBaseDocumentTagsEntry(entry.getKey(), entry.getValue()))

--- a/server/libs/automation/automation-knowledge-base/automation-knowledge-base-graphql/src/main/resources/graphql/automation/knowledge-base/knowledge-base-document.graphqls
+++ b/server/libs/automation/automation-knowledge-base/automation-knowledge-base-graphql/src/main/resources/graphql/automation/knowledge-base/knowledge-base-document.graphqls
@@ -2,8 +2,8 @@ extend type Query {
     knowledgeBaseDocument(id: ID!): KnowledgeBaseDocument
     knowledgeBaseDocumentChunks(id: ID!): [KnowledgeBaseDocumentChunk]
     knowledgeBaseDocumentStatus(id: ID!): DocumentStatusUpdate
-    knowledgeBaseDocumentTags: [String!]
-    knowledgeBaseDocumentTagsByDocument: [KnowledgeBaseDocumentTagsEntry!]
+    knowledgeBaseDocumentTags(knowledgeBaseId: ID!): [String!]
+    knowledgeBaseDocumentTagsByDocument(knowledgeBaseId: ID!): [KnowledgeBaseDocumentTagsEntry!]
 }
 
 extend type Mutation {

--- a/server/libs/platform/platform-knowledge-base/platform-knowledge-base-api/src/main/java/com/bytechef/platform/knowledgebase/service/KnowledgeBaseDocumentTagService.java
+++ b/server/libs/platform/platform-knowledge-base/platform-knowledge-base-api/src/main/java/com/bytechef/platform/knowledgebase/service/KnowledgeBaseDocumentTagService.java
@@ -42,11 +42,13 @@ public interface KnowledgeBaseDocumentTagService {
     List<String> getTagNamesByKnowledgeBaseId(Long knowledgeBaseId);
 
     /**
-     * Retrieves a mapping from document ID to list of tag names assigned to that document.
+     * Retrieves a mapping from document ID to list of tag names assigned to that document, for the documents belonging
+     * to the given knowledge base.
      *
+     * @param knowledgeBaseId the unique identifier of the knowledge base
      * @return a map where keys are document IDs and values are lists of tag name strings
      */
-    Map<Long, List<String>> getTagNamesByKnowledgeBaseDocumentId();
+    Map<Long, List<String>> getTagNamesByKnowledgeBaseDocumentId(Long knowledgeBaseId);
 
     /**
      * Retrieves a mapping from document name to list of tag names assigned to that document.

--- a/server/libs/platform/platform-knowledge-base/platform-knowledge-base-service/src/main/java/com/bytechef/platform/knowledgebase/service/KnowledgeBaseDocumentTagServiceImpl.java
+++ b/server/libs/platform/platform-knowledge-base/platform-knowledge-base-service/src/main/java/com/bytechef/platform/knowledgebase/service/KnowledgeBaseDocumentTagServiceImpl.java
@@ -75,15 +75,12 @@ public class KnowledgeBaseDocumentTagServiceImpl implements KnowledgeBaseDocumen
     }
 
     @Override
-    public Map<Long, List<String>> getTagNamesByKnowledgeBaseDocumentId() {
+    public Map<Long, List<String>> getTagNamesByKnowledgeBaseDocumentId(Long knowledgeBaseId) {
         Map<Long, List<String>> map = new HashMap<>();
 
-        List<KnowledgeBaseDocument> documents = new ArrayList<>();
+        for (KnowledgeBaseDocument document : knowledgeBaseDocumentRepository.findAllByKnowledgeBaseId(
+            knowledgeBaseId)) {
 
-        knowledgeBaseDocumentRepository.findAll()
-            .forEach(documents::add);
-
-        for (KnowledgeBaseDocument document : documents) {
             List<String> tagNames = document.getTagNames();
 
             map.put(document.getId(), tagNames == null ? List.of() : tagNames);


### PR DESCRIPTION
Fixes the two filter panels that still list values from outside the workspace being viewed, and the
empty state that misreports a zero-match filter as an empty workspace.

Closes #5615.

## What this changes

**1. Project categories are scoped to the workspace.** `ProjectCategoryFacadeImpl.getProjectCategories()`
read `projectService.getProjects()` - every project in every workspace - with no permission check. It now
reads the workspace's own projects and carries the same
`hasPermission(#workspaceId, 'Workspace', 'WORKFLOW_VIEW')` guard that every other workspace-wide project
read in `ProjectFacadeImpl` carries. The endpoint moves to `/workspaces/{id}/project-categories`.

The filter panel is only one of the four call sites. `ProjectDialog` is the more serious one: it did not
merely list another workspace's categories, it let you assign one to your project.

**2. Knowledge base document tags are scoped to the knowledge base.** `knowledgeBaseDocumentTags` and
`knowledgeBaseDocumentTagsByDocument` took no argument and read `findAll()`, so the tag suggestions offered
on one knowledge base's documents were aggregated from every document in the instance. Both now take the
knowledge base being viewed, which the document list already had in hand.

**3. A zero-match filter no longer renders the first-run empty state.** Projects, Project Deployments,
Connections, API Collections and MCP Servers all gated the list on the *filtered* array and fell through to
"Get started by creating a new project", telling the reader the workspace was empty when only the filter had
missed. They now render a shared `EmptyFilterResult`, and where the filter title was gated on results it
stays in the header.

On MCP Servers the seam was visible before this: the header was gated on the unfiltered list and the body on
the filtered one, so the filter title and "No MCP Servers - get started by creating one" appeared together.

## What this deliberately does not change

The **tag** filters on Projects, Project Deployments, Connections, API Collections and MCP Servers are
unscoped on `master` too - that is the other half of #5615. Fixes for those are already written on a branch
in flight, which relocates each onto a `/workspaces/{id}/*` endpoint. Redoing them here would only guarantee
a conflict, so this PR leaves them alone and #5615 stays open until that lands.

`KnowledgeBaseDocumentTagService.getAllTagNames()` also stays. The knowledge base component's tag pickers
fall back to it while no knowledge base is selected yet, which is a separate design question.

## Notes for review

- **The generated `CategoryApi` sources carry the path change by hand, not by a regeneration run.** The
  committed generated sources were produced by openapi-generator **7.22.0**; the build now resolves
  **7.24.0**, which adds an unconditional `@JsonInclude(NON_NULL)` to every model. Running
  `generateOpenAPI` on this module therefore rewrites every automation REST model with a behaviour change
  (null fields dropped from responses). That bump belongs in its own PR - see the vendored
  `openapi-templates/pojo.mustache` in `platform-configuration-rest-impl`, which exists precisely to keep
  that annotation off, and which `automation-configuration-rest-impl` does not have.
- **One commit is infrastructure, not a fix.** `codegen.ts` listed only the EE `platform-user` schema, but
  `users`, `inviteUser` and `updateUser` are declared in the CE one, so any `npx graphql-codegen` run
  aborted on validation errors and `graphql.ts` could not be regenerated at all. Adding the CE path back
  produces no output changes on its own; it is what makes the knowledge base commit's regeneration possible.

## Verification

- `ProjectCategoryFacadeImplTest` (new) pins the workspace scoping and that a null category id never reaches
  the lookup; `CategoryApiControllerIntTest` updated for the new path.
- `useKnowledgeBaseDocumentList` gained a test asserting both tag queries receive the knowledge base id.
- `npx graphql-codegen` re-run on this branch produces **zero** diff against the committed `graphql.ts`.
- Server: the touched modules compile and their tests pass; `spotlessCheck` is clean.
- Client: `npm run lint` and `npm run typecheck` pass. `npm run test` fails in 9 files - the **same 9**, with
  the same 69 failures, as pristine `upstream/master` measured on the same `node_modules`. A 10th,
  `useFeatureFlagsStore.test.ts`, is the known full-run flake documented in CLAUDE.md and passes in isolation.
  None of the 10 are files this PR touches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q3qKJEeiFnfxJcFdJgRFpx
