### PR TITLE
5623 client - Fix AI Providers accordion flicker on open/close

### DIFF
--- a/client/src/ee/pages/settings/platform/ai-providers/components/AiProviderList.test.tsx
+++ b/client/src/ee/pages/settings/platform/ai-providers/components/AiProviderList.test.tsx
@@ -130,4 +130,20 @@ describe('AiProviderList', () => {
 
         expect(screen.queryByText('Embeddings')).not.toBeInTheDocument();
     });
+
+    it('keeps other providers collapsed when a provider switch is toggled', async () => {
+        renderWithProviders(<AiProviderList aiProviders={providers} environment={1} />);
+
+        fireEvent.click(screen.getByText('Open AI'));
+
+        expect(await screen.findByText('sk-openai')).toBeInTheDocument();
+
+        fireEvent.click(screen.getByText('Open AI'));
+
+        expect(screen.queryByText('sk-openai')).not.toBeInTheDocument();
+
+        fireEvent.click(screen.getAllByRole('switch')[1]);
+
+        expect(screen.queryByText('sk-openai')).not.toBeInTheDocument();
+    });
 });

--- a/client/src/ee/pages/settings/platform/ai-providers/components/AiProviderList.tsx
+++ b/client/src/ee/pages/settings/platform/ai-providers/components/AiProviderList.tsx
@@ -20,7 +20,7 @@ const isConfigured = (aiProvider: AiProvider) => isOllamaProvider(aiProvider) ||
 
 const AiProviderList = ({aiProviders, environment}: {aiProviders: AiProvider[]; environment: number}) => {
     const [enabledItems, setEnabledItems] = useState<{[key: number]: boolean}>({});
-    const [openItem, setOpenItem] = useState<string>();
+    const [openItem, setOpenItem] = useState('');
     const [showForm, setShowForm] = useState<{[key: number]: boolean}>({});
 
     const queryClient = useQueryClient();
@@ -42,7 +42,7 @@ const AiProviderList = ({aiProviders, environment}: {aiProviders: AiProvider[]; 
             [aiProvider.id!]: value,
         }));
 
-        setOpenItem(undefined);
+        setOpenItem('');
 
         const configured = isConfigured(aiProvider);
 

--- a/client/src/styles/index.css
+++ b/client/src/styles/index.css
@@ -5,14 +5,20 @@
 @config '../../tailwind.config.js';
 
 /* tw-animate-css defaults animation-fill-mode to `none`, which makes Radix-driven
-   exit animations (dialogs, sheets, dropdowns, popovers, etc.) snap back to their
-   resting state for a frame before unmount, causing a visible flicker on close.
-   Match v3 tailwindcss-animate's behavior by forcing `forwards`. */
+   exit animations (dialogs, sheets, dropdowns, popovers, accordions, etc.) snap back
+   to their resting state for a frame before unmount, causing a visible flicker on
+   close. Match v3 tailwindcss-animate's behavior by forcing `forwards`. */
 @theme {
     --animate-in: enter var(--tw-animation-duration, var(--tw-duration, 0.15s)) var(--tw-ease, ease)
         var(--tw-animation-delay, 0s) var(--tw-animation-iteration-count, 1) var(--tw-animation-direction, normal)
         forwards;
     --animate-out: exit var(--tw-animation-duration, var(--tw-duration, 0.15s)) var(--tw-ease, ease)
+        var(--tw-animation-delay, 0s) var(--tw-animation-iteration-count, 1) var(--tw-animation-direction, normal)
+        forwards;
+    --animate-accordion-down: accordion-down var(--tw-animation-duration, var(--tw-duration, 0.2s))
+        var(--tw-ease, ease-out) var(--tw-animation-delay, 0s) var(--tw-animation-iteration-count, 1)
+        var(--tw-animation-direction, normal) forwards;
+    --animate-accordion-up: accordion-up var(--tw-animation-duration, var(--tw-duration, 0.2s)) var(--tw-ease, ease-out)
         var(--tw-animation-delay, 0s) var(--tw-animation-iteration-count, 1) var(--tw-animation-direction, normal)
         forwards;
 }


### PR DESCRIPTION
Fixes #5623

Two independent defects made rows other than the one you clicked flicker on the **Settings → AI Providers** page. Both reproduce on `master`.

## 1. The accordion flipped between controlled and uncontrolled

Radix's `useControllableState` recomputes `isControlled` from `prop !== undefined` **on every render**:

```js
const isControlled = prop !== void 0;
const value = isControlled ? prop : uncontrolledProp;
```

`AiProviderList` drove it with `useState<string>()` — initial `undefined` — so the accordion mounted uncontrolled, became controlled on the first click, and dropped back to uncontrolled every time `handleOnCheckedChange` ran `setOpenItem(undefined)`.

While controlled, Radix's `setValue` takes the `onChange` branch and never writes `uncontrolledProp`, so that internal value stays frozen at whichever item was opened *first* after mount. On the flip back, Radix falls back to it and reopens a provider the user already closed — toggling one provider's switch resurrected another provider's panel. Radix logs its own warning for this: `Accordion is changing from uncontrolled to controlled`.

Fixed by using `''`, the value Radix's own `onItemClose` dispatches for `type="single"`, so the value is never `undefined` and the mode never flips.

## 2. Exit animations ran with `animation-fill-mode: none`

`tw-animate-css` ends every animation shorthand with `var(--tw-animation-fill-mode, none)`. With `none`, the moment the exit animation finishes the animated `height: 0` is released, so the panel reverts to its natural full height for one frame before Radix's `Presence` unmounts it on `animationend`. That frame shoves every row below the closing one down and back.

`index.css` already fixes exactly this for `--animate-in`/`--animate-out` and the comment there names the symptom — the accordion pair was simply never added to that block.

Worth noting for reviewers: `tailwind.config.js` declares `accordion-down 300ms ease-out forwards`, which reads as though `forwards` were already handled. It isn't — `tw-animate-css`'s `@theme` wins, and the live computed values were `0.2s` / `none`. That stale config is a good part of why this was hard to spot.

## Testing

- Reproduced defect 1 in the running app: opened a provider, closed it, clicked a *different* row's switch, and the first provider expanded on its own.
- Added a regression test, `keeps other providers collapsed when a provider switch is toggled`. Verified it goes **red** on the unfixed code (`expected document not to contain element, found <span>sk-openai</span>`) and green after.
- `vitest` 6/6, `eslint --max-warnings=0`, and `prettier --check` all pass on this branch.
- Defect 2 is verified at the CSS level — computed `animationFillMode` goes `none` → `forwards` in the live page. The end-to-end visual was **not** confirmed by me: the browser surface I was driving does not composite, so `requestAnimationFrame` and `animationend` never fire there and CSS animations are frozen. Worth a manual look on review.

## Follow-up, deliberately not included

`--animate-collapsible-down`/`-up` carry the identical `fill-mode: none` defect and affect Radix Collapsible. Left out to keep this PR scoped, and because work is currently in flight against those components.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

