### PR TITLE
5624 client - Hide the existing-deployments note when a project has none

### DIFF
--- a/client/src/pages/automation/project-deployments/components/project-deployment-dialog/ProjectDeploymentDialogBasicStep.tsx
+++ b/client/src/pages/automation/project-deployments/components/project-deployment-dialog/ProjectDeploymentDialogBasicStep.tsx
@@ -130,7 +130,13 @@ const ProjectDeploymentDialogBasicStep = ({
         setCurrentProjectVersion(undefined);
     };
 
-    const hasDeployments = (projectDeployments?.length ?? 0) > 0;
+    const deploymentCount = projectDeployments?.length ?? 0;
+    const hasDeployments = deploymentCount > 0;
+
+    const existingDeploymentsNote =
+        deploymentCount === 1
+            ? 'A deployment already exists for this project. This will start an additional deployment instance.'
+            : 'Deployments already exist for this project. This will start an additional deployment instance.';
 
     const newDeploymentForm = (
         <>
@@ -313,12 +319,8 @@ const ProjectDeploymentDialogBasicStep = ({
                 </TabsTrigger>
             </TabsList>
 
-            <TabsContent className="m-0 flex flex-col gap-4" value="new-deployment">
-                <Note
-                    className="mt-4"
-                    content="Deployments already exists. This will start an additional deployment instance."
-                    icon={<InfoIcon />}
-                />
+            <TabsContent className="m-0 flex flex-col gap-4 pt-4" value="new-deployment">
+                {hasDeployments && <Note content={existingDeploymentsNote} icon={<InfoIcon />} />}
 
                 {newDeploymentForm}
             </TabsContent>


### PR DESCRIPTION
Fixes #5624

## What

The "New" tab of the project deployment dialog rendered its info note unconditionally, so a project with **no** deployments was told *"Deployments already exists. This will start an additional deployment instance."* — while the "Change Version" tab of the same dialog correctly showed *"No deployments for this project yet"*.

The note is now gated on the `hasDeployments` flag the sibling tab already uses, and worded by count ("A deployment already exists…" / "Deployments already exist…"; the old string was wrong on grammar either way).

## Note on the spacing change

The note was carrying the panel's top margin (`mt-4`). Gating it away would have left the project ComboBox butted against the tab bar, so the spacing moves onto the always-rendered `TabsContent` as `pt-4`. Rendered output is unchanged when the note *is* shown.

## Verification

- `npx prettier --check` — clean
- `npx eslint` on the changed file — clean
- `npm run typecheck` — exit 0

No tests exist under `project-deployment-dialog/`, so nothing directly covered this path.

## Follow-up, not addressed here

The dialog's project ComboBox lets you switch projects mid-dialog, but `projectDeployments` is fetched by the caller for the originally-clicked project (`ProjectListItem.tsx`) and never refetched. After switching projects, both this note and the "Change Version" tab still describe the project you started from.
