### PR TITLE
5632 client - Fix the workflow editor's phantom-node toast and jammed mutation guard

### DIFF
--- a/client/src/pages/automation/project/hooks/useProject.ts
+++ b/client/src/pages/automation/project/hooks/useProject.ts
@@ -298,6 +298,8 @@ export const useProject = () => {
 
         useWorkflowNodeDetailsPanelStore.getState().reset();
 
+        useWorkflowNodeDetailsPanelStore.getState().clearPendingSaveNodeNames();
+
         const restorePanelParam = searchParams.get('restoreExecutionPanel');
         const fromSubflowParam = searchParams.get('fromSubflow');
 

--- a/client/src/pages/platform/workflow-editor/WorkflowEditorLayout.tsx
+++ b/client/src/pages/platform/workflow-editor/WorkflowEditorLayout.tsx
@@ -186,6 +186,8 @@ const WorkflowEditorLayout = ({
     useEffect(() => {
         return () => {
             clearAllWorkflowMutations();
+
+            useWorkflowNodeDetailsPanelStore.getState().clearPendingSaveNodeNames();
         };
     }, []);
 

--- a/client/src/pages/platform/workflow-editor/components/WorkflowNodeDetailsPanel.awaitingFirstSave.test.tsx
+++ b/client/src/pages/platform/workflow-editor/components/WorkflowNodeDetailsPanel.awaitingFirstSave.test.tsx
@@ -1,0 +1,74 @@
+import {NodeDataType, PropertyAllType} from '@/shared/types';
+import {render, screen} from '@testing-library/react';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+
+import WorkflowNodeDetailsPanel from './WorkflowNodeDetailsPanel';
+
+const {panelState} = vi.hoisted(() => ({
+    panelState: {awaitingFirstSave: false},
+}));
+
+const LOGGER_PROPERTIES = [{name: 'text', type: 'STRING'}] as Array<PropertyAllType>;
+
+const LOGGER_NODE = {
+    componentName: 'logger',
+    name: 'logger_4',
+    operationName: 'debug',
+    workflowNodeName: 'logger_4',
+} as NodeDataType;
+
+vi.mock('./hooks/useWorkflowNodeDetailsPanel', () => ({
+    default: () => ({
+        activeTab: 'properties',
+        awaitingFirstSave: panelState.awaitingFirstSave,
+        currentNode: LOGGER_NODE,
+        currentOperationProperties: LOGGER_PROPERTIES,
+        currentWorkflowNode: {name: LOGGER_NODE.workflowNodeName},
+        currentWorkflowNodeConnections: [],
+        errors: [],
+        getNodeVersion: () => '1',
+        nodeTabs: [],
+        workflow: {id: 'workflow-1'},
+        workflowNodeDetailsPanelOpen: true,
+    }),
+}));
+
+vi.mock('@/pages/platform/workflow-editor/components/properties/Properties', () => ({
+    default: () => <div data-testid="generic-properties" />,
+}));
+
+vi.mock('@/shared/components/copilot/hooks/useCopilotLayoutShifted', () => ({default: () => false}));
+
+function renderPanel(awaitingFirstSave: boolean) {
+    panelState.awaitingFirstSave = awaitingFirstSave;
+
+    return render(
+        <WorkflowNodeDetailsPanel
+            previousComponentDefinitions={[]}
+            updateWorkflowMutation={{isPending: false, mutate: vi.fn()} as never}
+            workflowNodeOutputs={[]}
+        />
+    );
+}
+
+describe('WorkflowNodeDetailsPanel properties tab while a node awaits its first save', () => {
+    beforeEach(() => {
+        panelState.awaitingFirstSave = false;
+    });
+
+    it('renders the properties once the node is persisted', () => {
+        renderPanel(false);
+
+        expect(screen.getByTestId('generic-properties')).toBeInTheDocument();
+    });
+
+    it('holds the properties back behind the skeleton until the first save lands', () => {
+        // Every control on the properties tab talks to the server about the node by name: the
+        // display-conditions query on mount, hidden-property default saves 200ms later, and the
+        // parameter save behind each input. Before the add-node save lands they all 400 with
+        // "Workflow node with name: logger_4 does not exist".
+        renderPanel(true);
+
+        expect(screen.queryByTestId('generic-properties')).not.toBeInTheDocument();
+    });
+});

--- a/client/src/pages/platform/workflow-editor/components/WorkflowNodeDetailsPanel.tsx
+++ b/client/src/pages/platform/workflow-editor/components/WorkflowNodeDetailsPanel.tsx
@@ -50,6 +50,7 @@ const WorkflowNodeDetailsPanel = ({
     const {
         activeDisplayConditionsQuery,
         activeTab,
+        awaitingFirstSave,
         currentActionDefinition,
         currentComponentDefinition,
         currentNode,
@@ -325,7 +326,9 @@ const WorkflowNodeDetailsPanel = ({
                                         )}
 
                                     {activeTab === 'properties' &&
-                                        (!operationDataMissing && currentOperationProperties?.length ? (
+                                        (!operationDataMissing &&
+                                        currentOperationProperties?.length &&
+                                        !awaitingFirstSave ? (
                                             <Properties
                                                 customClassName="p-4"
                                                 displayConditionsQuery={activeDisplayConditionsQuery}

--- a/client/src/pages/platform/workflow-editor/components/WorkflowNodesPopoverMenuOperationList.tsx
+++ b/client/src/pages/platform/workflow-editor/components/WorkflowNodesPopoverMenuOperationList.tsx
@@ -32,7 +32,10 @@ import getFormattedName from '../utils/getFormattedName';
 import getParametersWithDefaultValues from '../utils/getParametersWithDefaultValues';
 import {getTask} from '../utils/getTask';
 import getTaskDispatcherContext from '../utils/getTaskDispatcherContext';
-import handleComponentAddedSuccess, {openNodeDetailsPanelForNewNode} from '../utils/handleComponentAddedSuccess';
+import handleComponentAddedSuccess, {
+    handleComponentAddedError,
+    openNodeDetailsPanelForNewNode,
+} from '../utils/handleComponentAddedSuccess';
 import handleTaskDispatcherSubtaskOperationClick from '../utils/handleTaskDispatcherSubtaskOperationClick';
 import processClusterElementsHierarchy from '../utils/processClusterElementsHierarchy';
 import saveWorkflowDefinition from '../utils/saveWorkflowDefinition';
@@ -160,6 +163,7 @@ const WorkflowNodesPopoverMenuOperationList = ({
             saveWorkflowDefinition({
                 nodeData,
                 nodeIndex,
+                onError: () => handleComponentAddedError({nodeData}),
                 onSuccess: () =>
                     handleComponentAddedSuccess({
                         nodeData,

--- a/client/src/pages/platform/workflow-editor/components/WorkflowOutputsSheetDialog.tsx
+++ b/client/src/pages/platform/workflow-editor/components/WorkflowOutputsSheetDialog.tsx
@@ -14,15 +14,15 @@ import {
 import {Form, FormControl, FormField, FormItem, FormLabel, FormMessage} from '@/components/ui/form';
 import PropertyMentionsInput from '@/pages/platform/workflow-editor/components/properties/components/property-mentions-input/PropertyMentionsInput';
 import {useWorkflowEditor} from '@/pages/platform/workflow-editor/providers/workflowEditorProvider';
-import {Workflow, WorkflowInput} from '@/shared/middleware/platform/configuration';
-import {WorkflowDefinitionType} from '@/shared/types';
+import {Workflow} from '@/shared/middleware/platform/configuration';
+import {WorkflowDefinitionType, WorkflowOutputType} from '@/shared/types';
 import {zodResolver} from '@hookform/resolvers/zod';
 import {Editor} from '@tiptap/react';
 import {ReactNode, useRef, useState} from 'react';
 import {useForm} from 'react-hook-form';
 import {z} from 'zod';
 
-import stringifyWorkflowDefinition from '../utils/stringifyWorkflowDefinition';
+import saveWorkflowDefinitionUpdate from '../utils/saveWorkflowDefinitionUpdate';
 
 const formSchema = z.object({
     name: z.string().min(2, {
@@ -70,31 +70,23 @@ const WorkflowOutputsSheetDialog = ({
     }
 
     function saveWorkflowOutputs(output: z.infer<typeof formSchema>) {
-        const workflowDefinition: WorkflowDefinitionType = JSON.parse(workflow.definition!);
+        saveWorkflowDefinitionUpdate({
+            onSuccess: () => closeDialog(),
+            updateDefinition: (workflowDefinition: WorkflowDefinitionType) => {
+                const outputs = [...(workflowDefinition.outputs ?? [])];
 
-        let outputs: WorkflowInput[] = workflowDefinition.outputs ?? [];
+                const workflowOutput = output as unknown as WorkflowOutputType;
 
-        if (outputIndex === -1) {
-            outputs = [...(outputs || []), output];
-        } else {
-            outputs[outputIndex] = output;
-        }
+                if (outputIndex === -1) {
+                    outputs.push(workflowOutput);
+                } else {
+                    outputs[outputIndex] = workflowOutput;
+                }
 
-        updateWorkflowMutation!.mutate(
-            {
-                id: workflow.id!,
-                workflow: {
-                    definition: stringifyWorkflowDefinition({
-                        ...workflowDefinition,
-                        outputs,
-                    }),
-                    version: workflow.version,
-                },
+                return {...workflowDefinition, outputs};
             },
-            {
-                onSuccess: () => closeDialog(),
-            }
-        );
+            updateWorkflowMutation: updateWorkflowMutation!,
+        });
     }
 
     return (

--- a/client/src/pages/platform/workflow-editor/components/WorkflowOutputsSheetTable.tsx
+++ b/client/src/pages/platform/workflow-editor/components/WorkflowOutputsSheetTable.tsx
@@ -18,7 +18,7 @@ import {CableIcon, EditIcon, Trash2Icon} from 'lucide-react';
 import {useState} from 'react';
 
 import useWorkflowDataStore from '../stores/useWorkflowDataStore';
-import stringifyWorkflowDefinition from '../utils/stringifyWorkflowDefinition';
+import saveWorkflowDefinitionUpdate from '../utils/saveWorkflowDefinitionUpdate';
 import WorkflowOutputValue from './WorkflowOutputValue';
 
 const WorkflowOutputsSheetTable = ({workflow}: {workflow: Workflow}) => {
@@ -31,23 +31,17 @@ const WorkflowOutputsSheetTable = ({workflow}: {workflow: Workflow}) => {
     const {updateWorkflowMutation} = useWorkflowEditor();
 
     function handleDelete(input: WorkflowInput) {
-        const definitionObject: WorkflowDefinitionType = JSON.parse(workflow.definition!);
+        saveWorkflowDefinitionUpdate({
+            updateDefinition: (workflowDefinition: WorkflowDefinitionType) => {
+                const outputs = workflowDefinition.outputs ?? [];
 
-        const outputs: WorkflowInput[] = definitionObject.outputs ?? [];
+                if (!outputs.some((output) => output.name === input.name)) {
+                    return undefined;
+                }
 
-        const index = outputs.findIndex((curInput) => curInput.name === input.name);
-
-        outputs.splice(index, 1);
-
-        updateWorkflowMutation!.mutate({
-            id: workflow.id!,
-            workflow: {
-                definition: stringifyWorkflowDefinition({
-                    ...definitionObject,
-                    outputs,
-                }),
-                version: workflow.version,
+                return {...workflowDefinition, outputs: outputs.filter((output) => output.name !== input.name)};
             },
+            updateWorkflowMutation: updateWorkflowMutation!,
         });
 
         setShowDeleteDialog(false);

--- a/client/src/pages/platform/workflow-editor/components/hooks/resolveDisplayConditionsQueryTarget.ts
+++ b/client/src/pages/platform/workflow-editor/components/hooks/resolveDisplayConditionsQueryTarget.ts
@@ -1,0 +1,43 @@
+export type DisplayConditionsQueryTargetType = 'cluster' | 'none' | 'regular';
+
+interface ResolveDisplayConditionsQueryTargetProps {
+    activeTab: string;
+    currentClusterElementName: string | undefined;
+    currentNodeClusterElementType: string | undefined;
+    currentNodeName: string | undefined;
+    pendingSaveNodeName: string | undefined;
+}
+
+/**
+ * Picks which display-conditions query the focused node may run ('cluster' | 'regular'), or 'none'.
+ * Both queries resolve the node by name against the server-side workflow definition, so a freshly
+ * added node still awaiting its first save must not be queried — it 400s with "Workflow node with
+ * name: <name> does not exist" — and neither may the manual trigger, which is never persisted as a
+ * node. The cluster/regular split mirrors resolveMissingRequiredPropertiesRefetch, including the
+ * cluster-editor-close race where clusterElementType clears before the name catches up.
+ */
+export function resolveDisplayConditionsQueryTarget({
+    activeTab,
+    currentClusterElementName,
+    currentNodeClusterElementType,
+    currentNodeName,
+    pendingSaveNodeName,
+}: ResolveDisplayConditionsQueryTargetProps): DisplayConditionsQueryTargetType {
+    if (activeTab !== 'properties' || !currentNodeName || currentNodeName === 'manual') {
+        return 'none';
+    }
+
+    if (currentNodeName === pendingSaveNodeName) {
+        return 'none';
+    }
+
+    if (currentNodeName === currentClusterElementName && !!currentNodeClusterElementType) {
+        return 'cluster';
+    }
+
+    if (currentNodeName !== currentClusterElementName && !currentNodeClusterElementType) {
+        return 'regular';
+    }
+
+    return 'none';
+}

--- a/client/src/pages/platform/workflow-editor/components/hooks/resolveDisplayConditionsQueryTarget.ts
+++ b/client/src/pages/platform/workflow-editor/components/hooks/resolveDisplayConditionsQueryTarget.ts
@@ -2,10 +2,10 @@ export type DisplayConditionsQueryTargetType = 'cluster' | 'none' | 'regular';
 
 interface ResolveDisplayConditionsQueryTargetProps {
     activeTab: string;
+    awaitingFirstSave: boolean;
     currentClusterElementName: string | undefined;
     currentNodeClusterElementType: string | undefined;
     currentNodeName: string | undefined;
-    pendingSaveNodeName: string | undefined;
 }
 
 /**
@@ -18,16 +18,16 @@ interface ResolveDisplayConditionsQueryTargetProps {
  */
 export function resolveDisplayConditionsQueryTarget({
     activeTab,
+    awaitingFirstSave,
     currentClusterElementName,
     currentNodeClusterElementType,
     currentNodeName,
-    pendingSaveNodeName,
 }: ResolveDisplayConditionsQueryTargetProps): DisplayConditionsQueryTargetType {
     if (activeTab !== 'properties' || !currentNodeName || currentNodeName === 'manual') {
         return 'none';
     }
 
-    if (currentNodeName === pendingSaveNodeName) {
+    if (awaitingFirstSave) {
         return 'none';
     }
 

--- a/client/src/pages/platform/workflow-editor/components/hooks/resolveMissingRequiredPropertiesRefetch.ts
+++ b/client/src/pages/platform/workflow-editor/components/hooks/resolveMissingRequiredPropertiesRefetch.ts
@@ -10,13 +10,13 @@ export function resolveMissingRequiredPropertiesRefetch(
     currentNodeName: string | undefined,
     currentClusterElementName: string | undefined,
     currentNodeClusterElementType: string | undefined,
-    pendingSaveNodeName: string | undefined
+    awaitingFirstSave: boolean
 ): MissingRequiredPropertiesRefetchTargetType {
     if (!currentNodeName || currentNodeName === 'manual') {
         return 'none';
     }
 
-    if (currentNodeName === pendingSaveNodeName) {
+    if (awaitingFirstSave) {
         return 'none';
     }
 

--- a/client/src/pages/platform/workflow-editor/components/hooks/tests/resolveDisplayConditionsQueryTarget.test.ts
+++ b/client/src/pages/platform/workflow-editor/components/hooks/tests/resolveDisplayConditionsQueryTarget.test.ts
@@ -1,0 +1,115 @@
+import {resolveDisplayConditionsQueryTarget} from '@/pages/platform/workflow-editor/components/hooks/resolveDisplayConditionsQueryTarget';
+import {describe, expect, it} from 'vitest';
+
+describe('resolveDisplayConditionsQueryTarget', () => {
+    it('fetches the regular endpoint for a plain workflow node on the properties tab', () => {
+        expect(
+            resolveDisplayConditionsQueryTarget({
+                activeTab: 'properties',
+                currentClusterElementName: undefined,
+                currentNodeClusterElementType: undefined,
+                currentNodeName: 'logger_1',
+                pendingSaveNodeName: undefined,
+            })
+        ).toBe('regular');
+    });
+
+    it('fetches the cluster endpoint for a cluster element on the properties tab', () => {
+        expect(
+            resolveDisplayConditionsQueryTarget({
+                activeTab: 'properties',
+                currentClusterElementName: 'openAi_1',
+                currentNodeClusterElementType: 'model',
+                currentNodeName: 'openAi_1',
+                pendingSaveNodeName: undefined,
+            })
+        ).toBe('cluster');
+    });
+
+    it('fetches nothing while another tab is active', () => {
+        expect(
+            resolveDisplayConditionsQueryTarget({
+                activeTab: 'description',
+                currentClusterElementName: undefined,
+                currentNodeClusterElementType: undefined,
+                currentNodeName: 'logger_1',
+                pendingSaveNodeName: undefined,
+            })
+        ).toBe('none');
+    });
+
+    it('fetches nothing while no node is focused', () => {
+        expect(
+            resolveDisplayConditionsQueryTarget({
+                activeTab: 'properties',
+                currentClusterElementName: undefined,
+                currentNodeClusterElementType: undefined,
+                currentNodeName: undefined,
+                pendingSaveNodeName: undefined,
+            })
+        ).toBe('none');
+    });
+
+    it('never fetches for the manual trigger', () => {
+        expect(
+            resolveDisplayConditionsQueryTarget({
+                activeTab: 'properties',
+                currentClusterElementName: undefined,
+                currentNodeClusterElementType: undefined,
+                currentNodeName: 'manual',
+                pendingSaveNodeName: undefined,
+            })
+        ).toBe('none');
+    });
+
+    it('fetches nothing for a freshly added node whose first save is still pending', () => {
+        // The panel opens optimistically before the server persists the node. Fetching display
+        // conditions for it 400s with "Workflow node with name: logger_4 does not exist" until the
+        // save lands, and the failed query never recovers once it does.
+        expect(
+            resolveDisplayConditionsQueryTarget({
+                activeTab: 'properties',
+                currentClusterElementName: undefined,
+                currentNodeClusterElementType: undefined,
+                currentNodeName: 'logger_4',
+                pendingSaveNodeName: 'logger_4',
+            })
+        ).toBe('none');
+    });
+
+    it('fetches nothing for a freshly added cluster element whose first save is still pending', () => {
+        expect(
+            resolveDisplayConditionsQueryTarget({
+                activeTab: 'properties',
+                currentClusterElementName: 'openAi_1',
+                currentNodeClusterElementType: 'model',
+                currentNodeName: 'openAi_1',
+                pendingSaveNodeName: 'openAi_1',
+            })
+        ).toBe('none');
+    });
+
+    it('fetches a persisted node even while a different node awaits its first save', () => {
+        expect(
+            resolveDisplayConditionsQueryTarget({
+                activeTab: 'properties',
+                currentClusterElementName: undefined,
+                currentNodeClusterElementType: undefined,
+                currentNodeName: 'logger_1',
+                pendingSaveNodeName: 'logger_4',
+            })
+        ).toBe('regular');
+    });
+
+    it('fetches nothing during the close race where clusterElementType cleared but the name still lags', () => {
+        expect(
+            resolveDisplayConditionsQueryTarget({
+                activeTab: 'properties',
+                currentClusterElementName: 'openAi_1',
+                currentNodeClusterElementType: undefined,
+                currentNodeName: 'openAi_1',
+                pendingSaveNodeName: undefined,
+            })
+        ).toBe('none');
+    });
+});

--- a/client/src/pages/platform/workflow-editor/components/hooks/tests/resolveDisplayConditionsQueryTarget.test.ts
+++ b/client/src/pages/platform/workflow-editor/components/hooks/tests/resolveDisplayConditionsQueryTarget.test.ts
@@ -6,10 +6,10 @@ describe('resolveDisplayConditionsQueryTarget', () => {
         expect(
             resolveDisplayConditionsQueryTarget({
                 activeTab: 'properties',
+                awaitingFirstSave: false,
                 currentClusterElementName: undefined,
                 currentNodeClusterElementType: undefined,
                 currentNodeName: 'logger_1',
-                pendingSaveNodeName: undefined,
             })
         ).toBe('regular');
     });
@@ -18,10 +18,10 @@ describe('resolveDisplayConditionsQueryTarget', () => {
         expect(
             resolveDisplayConditionsQueryTarget({
                 activeTab: 'properties',
+                awaitingFirstSave: false,
                 currentClusterElementName: 'openAi_1',
                 currentNodeClusterElementType: 'model',
                 currentNodeName: 'openAi_1',
-                pendingSaveNodeName: undefined,
             })
         ).toBe('cluster');
     });
@@ -30,10 +30,10 @@ describe('resolveDisplayConditionsQueryTarget', () => {
         expect(
             resolveDisplayConditionsQueryTarget({
                 activeTab: 'description',
+                awaitingFirstSave: false,
                 currentClusterElementName: undefined,
                 currentNodeClusterElementType: undefined,
                 currentNodeName: 'logger_1',
-                pendingSaveNodeName: undefined,
             })
         ).toBe('none');
     });
@@ -42,10 +42,10 @@ describe('resolveDisplayConditionsQueryTarget', () => {
         expect(
             resolveDisplayConditionsQueryTarget({
                 activeTab: 'properties',
+                awaitingFirstSave: false,
                 currentClusterElementName: undefined,
                 currentNodeClusterElementType: undefined,
                 currentNodeName: undefined,
-                pendingSaveNodeName: undefined,
             })
         ).toBe('none');
     });
@@ -54,10 +54,10 @@ describe('resolveDisplayConditionsQueryTarget', () => {
         expect(
             resolveDisplayConditionsQueryTarget({
                 activeTab: 'properties',
+                awaitingFirstSave: false,
                 currentClusterElementName: undefined,
                 currentNodeClusterElementType: undefined,
                 currentNodeName: 'manual',
-                pendingSaveNodeName: undefined,
             })
         ).toBe('none');
     });
@@ -69,10 +69,10 @@ describe('resolveDisplayConditionsQueryTarget', () => {
         expect(
             resolveDisplayConditionsQueryTarget({
                 activeTab: 'properties',
+                awaitingFirstSave: true,
                 currentClusterElementName: undefined,
                 currentNodeClusterElementType: undefined,
                 currentNodeName: 'logger_4',
-                pendingSaveNodeName: 'logger_4',
             })
         ).toBe('none');
     });
@@ -81,10 +81,10 @@ describe('resolveDisplayConditionsQueryTarget', () => {
         expect(
             resolveDisplayConditionsQueryTarget({
                 activeTab: 'properties',
+                awaitingFirstSave: true,
                 currentClusterElementName: 'openAi_1',
                 currentNodeClusterElementType: 'model',
                 currentNodeName: 'openAi_1',
-                pendingSaveNodeName: 'openAi_1',
             })
         ).toBe('none');
     });
@@ -93,10 +93,10 @@ describe('resolveDisplayConditionsQueryTarget', () => {
         expect(
             resolveDisplayConditionsQueryTarget({
                 activeTab: 'properties',
+                awaitingFirstSave: false,
                 currentClusterElementName: undefined,
                 currentNodeClusterElementType: undefined,
                 currentNodeName: 'logger_1',
-                pendingSaveNodeName: 'logger_4',
             })
         ).toBe('regular');
     });
@@ -105,10 +105,10 @@ describe('resolveDisplayConditionsQueryTarget', () => {
         expect(
             resolveDisplayConditionsQueryTarget({
                 activeTab: 'properties',
+                awaitingFirstSave: false,
                 currentClusterElementName: 'openAi_1',
                 currentNodeClusterElementType: undefined,
                 currentNodeName: 'openAi_1',
-                pendingSaveNodeName: undefined,
             })
         ).toBe('none');
     });

--- a/client/src/pages/platform/workflow-editor/components/hooks/tests/resolveMissingRequiredPropertiesRefetch.test.ts
+++ b/client/src/pages/platform/workflow-editor/components/hooks/tests/resolveMissingRequiredPropertiesRefetch.test.ts
@@ -4,34 +4,34 @@ import {describe, expect, it} from 'vitest';
 describe('resolveMissingRequiredPropertiesRefetch', () => {
     it('refetches the regular endpoint for a plain workflow node', () => {
         // Regular node: name set, no cluster element name, no clusterElementType.
-        expect(resolveMissingRequiredPropertiesRefetch('activeCampaign_1', undefined, undefined, undefined)).toBe(
+        expect(resolveMissingRequiredPropertiesRefetch('activeCampaign_1', undefined, undefined, false)).toBe(
             'regular'
         );
     });
 
     it('refetches the cluster endpoint for a cluster element', () => {
         // Cluster element: name === clusterElementName AND a clusterElementType is present.
-        expect(
-            resolveMissingRequiredPropertiesRefetch('activeCampaign_1', 'activeCampaign_1', 'tools', undefined)
-        ).toBe('cluster');
+        expect(resolveMissingRequiredPropertiesRefetch('activeCampaign_1', 'activeCampaign_1', 'tools', false)).toBe(
+            'cluster'
+        );
     });
 
     it('refetches nothing while no node is focused', () => {
-        expect(resolveMissingRequiredPropertiesRefetch(undefined, undefined, undefined, undefined)).toBe('none');
+        expect(resolveMissingRequiredPropertiesRefetch(undefined, undefined, undefined, false)).toBe('none');
     });
 
     it('never refetches for the manual trigger', () => {
-        expect(resolveMissingRequiredPropertiesRefetch('manual', undefined, undefined, undefined)).toBe('none');
+        expect(resolveMissingRequiredPropertiesRefetch('manual', undefined, undefined, false)).toBe('none');
     });
 
     it('refetches nothing for a freshly added node whose first save is still pending', () => {
         // The panel opens optimistically before the server persists the node; refetching it would 404
         // with "Workflow node with name: accelo_1 does not exist" until the save lands.
-        expect(resolveMissingRequiredPropertiesRefetch('accelo_1', undefined, undefined, 'accelo_1')).toBe('none');
+        expect(resolveMissingRequiredPropertiesRefetch('accelo_1', undefined, undefined, true)).toBe('none');
     });
 
     it('refetches a persisted node even while a different node awaits its first save', () => {
-        expect(resolveMissingRequiredPropertiesRefetch('activeCampaign_1', undefined, undefined, 'accelo_1')).toBe(
+        expect(resolveMissingRequiredPropertiesRefetch('activeCampaign_1', undefined, undefined, false)).toBe(
             'regular'
         );
     });
@@ -42,14 +42,14 @@ describe('resolveMissingRequiredPropertiesRefetch', () => {
         // currentClusterElementName are set together, so both still hold the cluster element's name. Branching
         // on clusterElementType alone would fire the plain endpoint with "activeCampaign_1" → server 404.
         // The equality guard keeps this at 'none' until the local name state reconciles.
-        expect(
-            resolveMissingRequiredPropertiesRefetch('activeCampaign_1', 'activeCampaign_1', undefined, undefined)
-        ).toBe('none');
+        expect(resolveMissingRequiredPropertiesRefetch('activeCampaign_1', 'activeCampaign_1', undefined, false)).toBe(
+            'none'
+        );
     });
 
     it('refetches nothing in the inverse transient (type present but names disagree)', () => {
         // Symmetric transient: clusterElementType present but the names haven't converged yet. Neither the
         // cluster guard (needs name === clusterElementName) nor the regular guard (needs no type) matches.
-        expect(resolveMissingRequiredPropertiesRefetch('activeCampaign_1', undefined, 'tools', undefined)).toBe('none');
+        expect(resolveMissingRequiredPropertiesRefetch('activeCampaign_1', undefined, 'tools', false)).toBe('none');
     });
 });

--- a/client/src/pages/platform/workflow-editor/components/hooks/useWorkflowNodeDetailsPanel.ts
+++ b/client/src/pages/platform/workflow-editor/components/hooks/useWorkflowNodeDetailsPanel.ts
@@ -84,6 +84,7 @@ import saveTaskDispatcherSubtaskFieldChange from '../../utils/saveTaskDispatcher
 import saveWorkflowDefinition from '../../utils/saveWorkflowDefinition';
 import {getTaskDispatcherTask} from '../../utils/taskDispatcherConfig';
 import isActionDefinitionFresh from './isActionDefinitionFresh';
+import {resolveDisplayConditionsQueryTarget} from './resolveDisplayConditionsQueryTarget';
 import {resolveMissingRequiredPropertiesRefetch} from './resolveMissingRequiredPropertiesRefetch';
 import resolveNodeConnectionFields from './resolveNodeConnectionFields';
 
@@ -358,17 +359,26 @@ export default function useWorkflowNodeDetailsPanel({
         !!currentNode && !!currentNode.taskDispatcher
     );
 
+    // The node details panel opens optimistically for a freshly added node, before the add-node save
+    // has reached the server. Until handleComponentAddedSuccess clears pendingSaveNodeName, every
+    // by-name request for that node 400s with "Workflow node with name: <name> does not exist".
+    const awaitingFirstSave = !!currentNodeName && currentNodeName === pendingSaveNodeName;
+
+    const displayConditionsQueryTarget = resolveDisplayConditionsQueryTarget({
+        activeTab,
+        currentClusterElementName,
+        currentNodeClusterElementType: currentNode?.clusterElementType,
+        currentNodeName,
+        pendingSaveNodeName,
+    });
+
     const displayConditionsQuery = useGetWorkflowNodeParameterDisplayConditionsQuery(
         {
             environmentId: currentEnvironmentId,
             id: workflow.id!,
             workflowNodeName: currentNodeName!,
         },
-        activeTab === 'properties' &&
-            !!currentNodeName &&
-            currentNodeName !== 'manual' &&
-            currentNodeName !== currentClusterElementName &&
-            !currentNode?.clusterElementType
+        displayConditionsQueryTarget === 'regular'
     );
 
     const clusterElementDisplayConditionsQuery = useGetClusterElementParameterDisplayConditionsQuery(
@@ -379,12 +389,7 @@ export default function useWorkflowNodeDetailsPanel({
             id: workflow.id!,
             workflowNodeName: rootClusterElementNodeData?.workflowNodeName as string,
         },
-        activeTab === 'properties' &&
-            !!currentNode &&
-            !!currentNodeName &&
-            currentNodeName !== 'manual' &&
-            currentNodeName === currentClusterElementName &&
-            !!currentNode.clusterElementType
+        !!currentNode && displayConditionsQueryTarget === 'cluster'
     );
 
     const {data: workflowNodeParameterDisplayConditions} = displayConditionsQuery;
@@ -1451,6 +1456,7 @@ export default function useWorkflowNodeDetailsPanel({
     return {
         activeDisplayConditionsQuery,
         activeTab,
+        awaitingFirstSave,
         currentActionDefinition,
         currentComponentDefinition,
         currentNode,

--- a/client/src/pages/platform/workflow-editor/components/hooks/useWorkflowNodeDetailsPanel.ts
+++ b/client/src/pages/platform/workflow-editor/components/hooks/useWorkflowNodeDetailsPanel.ts
@@ -141,7 +141,7 @@ export default function useWorkflowNodeDetailsPanel({
         activeTab,
         currentNode,
         operationChangeInProgress,
-        pendingSaveNodeName,
+        pendingSaveNodeNames,
         setActiveTab,
         setCurrentNode,
         setOperationChangeInProgress,
@@ -151,7 +151,7 @@ export default function useWorkflowNodeDetailsPanel({
             activeTab: state.activeTab,
             currentNode: state.currentNode,
             operationChangeInProgress: state.operationChangeInProgress,
-            pendingSaveNodeName: state.pendingSaveNodeName,
+            pendingSaveNodeNames: state.pendingSaveNodeNames,
             setActiveTab: state.setActiveTab,
             setCurrentNode: state.setCurrentNode,
             setOperationChangeInProgress: state.setOperationChangeInProgress,
@@ -359,17 +359,14 @@ export default function useWorkflowNodeDetailsPanel({
         !!currentNode && !!currentNode.taskDispatcher
     );
 
-    // The node details panel opens optimistically for a freshly added node, before the add-node save
-    // has reached the server. Until handleComponentAddedSuccess clears pendingSaveNodeName, every
-    // by-name request for that node 400s with "Workflow node with name: <name> does not exist".
-    const awaitingFirstSave = !!currentNodeName && currentNodeName === pendingSaveNodeName;
+    const awaitingFirstSave = !!currentNodeName && pendingSaveNodeNames.has(currentNodeName);
 
     const displayConditionsQueryTarget = resolveDisplayConditionsQueryTarget({
         activeTab,
+        awaitingFirstSave,
         currentClusterElementName,
         currentNodeClusterElementType: currentNode?.clusterElementType,
         currentNodeName,
-        pendingSaveNodeName,
     });
 
     const displayConditionsQuery = useGetWorkflowNodeParameterDisplayConditionsQuery(
@@ -414,7 +411,7 @@ export default function useWorkflowNodeDetailsPanel({
                 !!currentNodeName &&
                 currentNodeName !== 'manual' &&
                 currentNodeName !== currentClusterElementName &&
-                currentNodeName !== pendingSaveNodeName &&
+                !awaitingFirstSave &&
                 !currentNode?.clusterElementType,
         }
     );
@@ -437,7 +434,7 @@ export default function useWorkflowNodeDetailsPanel({
                 !!currentNodeName &&
                 currentNodeName !== 'manual' &&
                 currentNodeName === currentClusterElementName &&
-                currentNodeName !== pendingSaveNodeName &&
+                !awaitingFirstSave &&
                 !!currentNode.clusterElementType,
         }
     );
@@ -1145,7 +1142,7 @@ export default function useWorkflowNodeDetailsPanel({
             currentNodeName,
             currentClusterElementName,
             currentNode?.clusterElementType,
-            pendingSaveNodeName
+            awaitingFirstSave
         );
 
         if (refetchTarget === 'cluster') {
@@ -1159,7 +1156,7 @@ export default function useWorkflowNodeDetailsPanel({
         currentNodeName,
         currentClusterElementName,
         currentNode?.clusterElementType,
-        pendingSaveNodeName,
+        awaitingFirstSave,
     ]);
 
     // Arm the errors loading cue when an operation switch starts.

--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-code-editor/property-code-editor-dialog/hooks/tests/usePropertyCodeEditorDialogRightPanelConnections.test.ts
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-code-editor/property-code-editor-dialog/hooks/tests/usePropertyCodeEditorDialogRightPanelConnections.test.ts
@@ -1,3 +1,4 @@
+import {clearAllWorkflowMutations} from '@/pages/platform/workflow-editor/utils/workflowMutationGuard';
 import {act, renderHook} from '@testing-library/react';
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
 
@@ -13,6 +14,7 @@ const hoisted = vi.hoisted(() => {
             currentNode: {clusterElementType: undefined as string | undefined, name: 'testNode'},
             rootClusterElementNodeData: undefined as {workflowNodeName: string} | undefined,
             showConnectionNote: true,
+            workflow: undefined as {definition?: string; id?: string; version?: number} | undefined,
             workflowTestConfigurationConnections: [{connectionId: 1, workflowConnectionKey: 'slack_1'}],
         },
     };
@@ -42,11 +44,11 @@ vi.mock('@/pages/platform/workflow-editor/stores/useWorkflowEditorStore', () => 
 }));
 
 vi.mock('@/pages/platform/workflow-editor/stores/useWorkflowDataStore', () => {
-    const workflowDataState = {setWorkflow: hoisted.mockSetWorkflow};
+    const getWorkflowDataState = () => ({setWorkflow: hoisted.mockSetWorkflow, workflow: hoisted.storeState.workflow});
 
-    const useWorkflowDataStore = (selector?: (state: unknown) => unknown) => selector?.(workflowDataState);
+    const useWorkflowDataStore = (selector?: (state: unknown) => unknown) => selector?.(getWorkflowDataState());
 
-    useWorkflowDataStore.getState = () => workflowDataState;
+    useWorkflowDataStore.getState = getWorkflowDataState;
 
     return {default: useWorkflowDataStore};
 });
@@ -80,6 +82,15 @@ vi.mock('@/shared/queries/platform/workflowTestConfigurations.queries', () => ({
     }),
 }));
 
+type ConnectionsHookType =
+    typeof import('../usePropertyCodeEditorDialogRightPanelConnections').usePropertyCodeEditorDialogRightPanelConnections;
+
+function renderConnectionsHook(hook: ConnectionsHookType, props: Parameters<ConnectionsHookType>[0]) {
+    hoisted.storeState.workflow = props.workflow;
+
+    return renderHook(() => hook(props));
+}
+
 describe('usePropertyCodeEditorDialogRightPanelConnections', () => {
     const defaultProps = {
         componentConnections: [
@@ -101,6 +112,8 @@ describe('usePropertyCodeEditorDialogRightPanelConnections', () => {
     };
 
     beforeEach(async () => {
+        hoisted.storeState.workflow = defaultProps.workflow;
+
         hoisted.storeState.showConnectionNote = true;
         hoisted.storeState.currentEnvironmentId = 1;
         hoisted.storeState.componentDefinitions = [{name: 'slack', title: 'Slack', version: 1}];
@@ -112,6 +125,8 @@ describe('usePropertyCodeEditorDialogRightPanelConnections', () => {
     });
 
     afterEach(() => {
+        clearAllWorkflowMutations();
+
         vi.clearAllMocks();
     });
 
@@ -119,7 +134,7 @@ describe('usePropertyCodeEditorDialogRightPanelConnections', () => {
         it('should return showConnectionNote from store', async () => {
             const {usePropertyCodeEditorDialogRightPanelConnections} =
                 await import('../usePropertyCodeEditorDialogRightPanelConnections');
-            const {result} = renderHook(() => usePropertyCodeEditorDialogRightPanelConnections(defaultProps));
+            const {result} = renderConnectionsHook(usePropertyCodeEditorDialogRightPanelConnections, defaultProps);
 
             expect(result.current.showConnectionNote).toBe(true);
         });
@@ -127,7 +142,7 @@ describe('usePropertyCodeEditorDialogRightPanelConnections', () => {
         it('should return componentDefinitions', async () => {
             const {usePropertyCodeEditorDialogRightPanelConnections} =
                 await import('../usePropertyCodeEditorDialogRightPanelConnections');
-            const {result} = renderHook(() => usePropertyCodeEditorDialogRightPanelConnections(defaultProps));
+            const {result} = renderConnectionsHook(usePropertyCodeEditorDialogRightPanelConnections, defaultProps);
 
             expect(result.current.componentDefinitions).toEqual([{name: 'slack', title: 'Slack', version: 1}]);
         });
@@ -135,7 +150,7 @@ describe('usePropertyCodeEditorDialogRightPanelConnections', () => {
         it('should return workflowTestConfigurationConnections', async () => {
             const {usePropertyCodeEditorDialogRightPanelConnections} =
                 await import('../usePropertyCodeEditorDialogRightPanelConnections');
-            const {result} = renderHook(() => usePropertyCodeEditorDialogRightPanelConnections(defaultProps));
+            const {result} = renderConnectionsHook(usePropertyCodeEditorDialogRightPanelConnections, defaultProps);
 
             expect(result.current.workflowTestConfigurationConnections).toEqual([
                 {connectionId: 1, workflowConnectionKey: 'slack_1'},
@@ -145,7 +160,7 @@ describe('usePropertyCodeEditorDialogRightPanelConnections', () => {
         it('should return showNewConnectionDialog as false initially', async () => {
             const {usePropertyCodeEditorDialogRightPanelConnections} =
                 await import('../usePropertyCodeEditorDialogRightPanelConnections');
-            const {result} = renderHook(() => usePropertyCodeEditorDialogRightPanelConnections(defaultProps));
+            const {result} = renderConnectionsHook(usePropertyCodeEditorDialogRightPanelConnections, defaultProps);
 
             expect(result.current.showNewConnectionDialog).toBe(false);
         });
@@ -155,7 +170,7 @@ describe('usePropertyCodeEditorDialogRightPanelConnections', () => {
         it('should call setShowConnectionNote with false', async () => {
             const {usePropertyCodeEditorDialogRightPanelConnections} =
                 await import('../usePropertyCodeEditorDialogRightPanelConnections');
-            const {result} = renderHook(() => usePropertyCodeEditorDialogRightPanelConnections(defaultProps));
+            const {result} = renderConnectionsHook(usePropertyCodeEditorDialogRightPanelConnections, defaultProps);
 
             act(() => {
                 result.current.handleCloseConnectionNote();
@@ -169,7 +184,7 @@ describe('usePropertyCodeEditorDialogRightPanelConnections', () => {
         it('should update showNewConnectionDialog state', async () => {
             const {usePropertyCodeEditorDialogRightPanelConnections} =
                 await import('../usePropertyCodeEditorDialogRightPanelConnections');
-            const {result} = renderHook(() => usePropertyCodeEditorDialogRightPanelConnections(defaultProps));
+            const {result} = renderConnectionsHook(usePropertyCodeEditorDialogRightPanelConnections, defaultProps);
 
             act(() => {
                 result.current.setShowNewConnectionDialog(true);
@@ -183,7 +198,7 @@ describe('usePropertyCodeEditorDialogRightPanelConnections', () => {
         it('should call updateWorkflowMutation.mutate with updated definition', async () => {
             const {usePropertyCodeEditorDialogRightPanelConnections} =
                 await import('../usePropertyCodeEditorDialogRightPanelConnections');
-            const {result} = renderHook(() => usePropertyCodeEditorDialogRightPanelConnections(defaultProps));
+            const {result} = renderConnectionsHook(usePropertyCodeEditorDialogRightPanelConnections, defaultProps);
 
             act(() => {
                 result.current.handleOnSubmit({
@@ -210,12 +225,10 @@ describe('usePropertyCodeEditorDialogRightPanelConnections', () => {
         it('should not call mutate when workflow definition is missing', async () => {
             const {usePropertyCodeEditorDialogRightPanelConnections} =
                 await import('../usePropertyCodeEditorDialogRightPanelConnections');
-            const {result} = renderHook(() =>
-                usePropertyCodeEditorDialogRightPanelConnections({
-                    ...defaultProps,
-                    workflow: {...defaultProps.workflow, definition: undefined},
-                })
-            );
+            const {result} = renderConnectionsHook(usePropertyCodeEditorDialogRightPanelConnections, {
+                ...defaultProps,
+                workflow: {...defaultProps.workflow, definition: undefined},
+            });
 
             act(() => {
                 result.current.handleOnSubmit({
@@ -233,7 +246,7 @@ describe('usePropertyCodeEditorDialogRightPanelConnections', () => {
         it('should call updateWorkflowMutation.mutate with connection removed', async () => {
             const {usePropertyCodeEditorDialogRightPanelConnections} =
                 await import('../usePropertyCodeEditorDialogRightPanelConnections');
-            const {result} = renderHook(() => usePropertyCodeEditorDialogRightPanelConnections(defaultProps));
+            const {result} = renderConnectionsHook(usePropertyCodeEditorDialogRightPanelConnections, defaultProps);
 
             act(() => {
                 result.current.handleOnRemoveClick('slack_1');
@@ -253,12 +266,10 @@ describe('usePropertyCodeEditorDialogRightPanelConnections', () => {
         it('should not call mutate when workflow definition is missing', async () => {
             const {usePropertyCodeEditorDialogRightPanelConnections} =
                 await import('../usePropertyCodeEditorDialogRightPanelConnections');
-            const {result} = renderHook(() =>
-                usePropertyCodeEditorDialogRightPanelConnections({
-                    ...defaultProps,
-                    workflow: {...defaultProps.workflow, definition: undefined},
-                })
-            );
+            const {result} = renderConnectionsHook(usePropertyCodeEditorDialogRightPanelConnections, {
+                ...defaultProps,
+                workflow: {...defaultProps.workflow, definition: undefined},
+            });
 
             act(() => {
                 result.current.handleOnRemoveClick('slack_1');
@@ -312,8 +323,9 @@ describe('usePropertyCodeEditorDialogRightPanelConnections', () => {
             it('should add connection to cluster element', async () => {
                 const {usePropertyCodeEditorDialogRightPanelConnections} =
                     await import('../usePropertyCodeEditorDialogRightPanelConnections');
-                const {result} = renderHook(() =>
-                    usePropertyCodeEditorDialogRightPanelConnections(clusterElementProps)
+                const {result} = renderConnectionsHook(
+                    usePropertyCodeEditorDialogRightPanelConnections,
+                    clusterElementProps
                 );
 
                 act(() => {
@@ -338,8 +350,9 @@ describe('usePropertyCodeEditorDialogRightPanelConnections', () => {
             it('should not overwrite existing cluster element connections', async () => {
                 const {usePropertyCodeEditorDialogRightPanelConnections} =
                     await import('../usePropertyCodeEditorDialogRightPanelConnections');
-                const {result} = renderHook(() =>
-                    usePropertyCodeEditorDialogRightPanelConnections(clusterElementProps)
+                const {result} = renderConnectionsHook(
+                    usePropertyCodeEditorDialogRightPanelConnections,
+                    clusterElementProps
                 );
 
                 act(() => {
@@ -361,8 +374,9 @@ describe('usePropertyCodeEditorDialogRightPanelConnections', () => {
             it('should remove connection from cluster element', async () => {
                 const {usePropertyCodeEditorDialogRightPanelConnections} =
                     await import('../usePropertyCodeEditorDialogRightPanelConnections');
-                const {result} = renderHook(() =>
-                    usePropertyCodeEditorDialogRightPanelConnections(clusterElementProps)
+                const {result} = renderConnectionsHook(
+                    usePropertyCodeEditorDialogRightPanelConnections,
+                    clusterElementProps
                 );
 
                 act(() => {
@@ -413,8 +427,9 @@ describe('usePropertyCodeEditorDialogRightPanelConnections', () => {
         it('should add a connection to the matching tool cluster element', async () => {
             const {usePropertyCodeEditorDialogRightPanelConnections} =
                 await import('../usePropertyCodeEditorDialogRightPanelConnections');
-            const {result} = renderHook(() =>
-                usePropertyCodeEditorDialogRightPanelConnections(toolClusterElementProps)
+            const {result} = renderConnectionsHook(
+                usePropertyCodeEditorDialogRightPanelConnections,
+                toolClusterElementProps
             );
 
             act(() => {
@@ -439,8 +454,9 @@ describe('usePropertyCodeEditorDialogRightPanelConnections', () => {
         it('should not modify other tools in the array when adding a connection', async () => {
             const {usePropertyCodeEditorDialogRightPanelConnections} =
                 await import('../usePropertyCodeEditorDialogRightPanelConnections');
-            const {result} = renderHook(() =>
-                usePropertyCodeEditorDialogRightPanelConnections(toolClusterElementProps)
+            const {result} = renderConnectionsHook(
+                usePropertyCodeEditorDialogRightPanelConnections,
+                toolClusterElementProps
             );
 
             act(() => {
@@ -485,7 +501,10 @@ describe('usePropertyCodeEditorDialogRightPanelConnections', () => {
 
             const {usePropertyCodeEditorDialogRightPanelConnections} =
                 await import('../usePropertyCodeEditorDialogRightPanelConnections');
-            const {result} = renderHook(() => usePropertyCodeEditorDialogRightPanelConnections(propsWithConnection));
+            const {result} = renderConnectionsHook(
+                usePropertyCodeEditorDialogRightPanelConnections,
+                propsWithConnection
+            );
 
             act(() => {
                 result.current.handleOnRemoveClick('slack_1');
@@ -504,7 +523,7 @@ describe('usePropertyCodeEditorDialogRightPanelConnections', () => {
         it('should invalidate workflowNodeComponentConnections on submit success for regular nodes', async () => {
             const {usePropertyCodeEditorDialogRightPanelConnections} =
                 await import('../usePropertyCodeEditorDialogRightPanelConnections');
-            const {result} = renderHook(() => usePropertyCodeEditorDialogRightPanelConnections(defaultProps));
+            const {result} = renderConnectionsHook(usePropertyCodeEditorDialogRightPanelConnections, defaultProps);
 
             act(() => {
                 result.current.handleOnSubmit({
@@ -556,7 +575,10 @@ describe('usePropertyCodeEditorDialogRightPanelConnections', () => {
 
             const {usePropertyCodeEditorDialogRightPanelConnections} =
                 await import('../usePropertyCodeEditorDialogRightPanelConnections');
-            const {result} = renderHook(() => usePropertyCodeEditorDialogRightPanelConnections(clusterElementProps));
+            const {result} = renderConnectionsHook(
+                usePropertyCodeEditorDialogRightPanelConnections,
+                clusterElementProps
+            );
 
             act(() => {
                 result.current.handleOnSubmit({
@@ -580,7 +602,7 @@ describe('usePropertyCodeEditorDialogRightPanelConnections', () => {
         it('should invalidate workflowNodeComponentConnections on remove success for regular nodes', async () => {
             const {usePropertyCodeEditorDialogRightPanelConnections} =
                 await import('../usePropertyCodeEditorDialogRightPanelConnections');
-            const {result} = renderHook(() => usePropertyCodeEditorDialogRightPanelConnections(defaultProps));
+            const {result} = renderConnectionsHook(usePropertyCodeEditorDialogRightPanelConnections, defaultProps);
 
             act(() => {
                 result.current.handleOnRemoveClick('slack_1');
@@ -602,7 +624,7 @@ describe('usePropertyCodeEditorDialogRightPanelConnections', () => {
         it('should sync the updated workflow into useWorkflowDataStore on submit success', async () => {
             const {usePropertyCodeEditorDialogRightPanelConnections} =
                 await import('../usePropertyCodeEditorDialogRightPanelConnections');
-            const {result} = renderHook(() => usePropertyCodeEditorDialogRightPanelConnections(defaultProps));
+            const {result} = renderConnectionsHook(usePropertyCodeEditorDialogRightPanelConnections, defaultProps);
 
             act(() => {
                 result.current.handleOnSubmit({
@@ -629,7 +651,7 @@ describe('usePropertyCodeEditorDialogRightPanelConnections', () => {
         it('should sync the updated workflow into useWorkflowDataStore on remove success', async () => {
             const {usePropertyCodeEditorDialogRightPanelConnections} =
                 await import('../usePropertyCodeEditorDialogRightPanelConnections');
-            const {result} = renderHook(() => usePropertyCodeEditorDialogRightPanelConnections(defaultProps));
+            const {result} = renderConnectionsHook(usePropertyCodeEditorDialogRightPanelConnections, defaultProps);
 
             act(() => {
                 result.current.handleOnRemoveClick('slack_1');
@@ -680,7 +702,10 @@ describe('usePropertyCodeEditorDialogRightPanelConnections', () => {
 
             const {usePropertyCodeEditorDialogRightPanelConnections} =
                 await import('../usePropertyCodeEditorDialogRightPanelConnections');
-            const {result} = renderHook(() => usePropertyCodeEditorDialogRightPanelConnections(clusterElementProps));
+            const {result} = renderConnectionsHook(
+                usePropertyCodeEditorDialogRightPanelConnections,
+                clusterElementProps
+            );
 
             act(() => {
                 result.current.handleOnSubmit({

--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-code-editor/property-code-editor-dialog/hooks/tests/usePropertyCodeEditorDialogRightPanelConnections.test.ts
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-code-editor/property-code-editor-dialog/hooks/tests/usePropertyCodeEditorDialogRightPanelConnections.test.ts
@@ -240,6 +240,25 @@ describe('usePropertyCodeEditorDialogRightPanelConnections', () => {
 
             expect(hoisted.mockMutate).not.toHaveBeenCalled();
         });
+
+        it('declines the save when the task is gone from the fresh definition', async () => {
+            const {usePropertyCodeEditorDialogRightPanelConnections} =
+                await import('../usePropertyCodeEditorDialogRightPanelConnections');
+            const {result} = renderConnectionsHook(usePropertyCodeEditorDialogRightPanelConnections, {
+                ...defaultProps,
+                workflow: {...defaultProps.workflow, definition: JSON.stringify({tasks: []})},
+            });
+
+            act(() => {
+                result.current.handleOnSubmit({
+                    componentName: 'github',
+                    componentVersion: 2,
+                    name: 'github_connection',
+                });
+            });
+
+            expect(hoisted.mockMutate).not.toHaveBeenCalled();
+        });
     });
 
     describe('handleOnRemoveClick', () => {
@@ -368,6 +387,30 @@ describe('usePropertyCodeEditorDialogRightPanelConnections', () => {
 
                 expect(definition.tasks[0].clusterElements.source.connections.s3_connection).toBeDefined();
             });
+        });
+
+        it('declines the save when the cluster element is gone from the fresh definition', async () => {
+            const {usePropertyCodeEditorDialogRightPanelConnections} =
+                await import('../usePropertyCodeEditorDialogRightPanelConnections');
+            const {result} = renderConnectionsHook(usePropertyCodeEditorDialogRightPanelConnections, {
+                ...clusterElementProps,
+                workflow: {
+                    ...clusterElementProps.workflow,
+                    definition: JSON.stringify({
+                        tasks: [{clusterElements: {}, name: 'dataStream_1', type: 'dataStream/v1/sync'}],
+                    }),
+                },
+            });
+
+            act(() => {
+                result.current.handleOnSubmit({
+                    componentName: 'github',
+                    componentVersion: 2,
+                    name: 'github_connection',
+                });
+            });
+
+            expect(hoisted.mockMutate).not.toHaveBeenCalled();
         });
 
         describe('handleOnRemoveClick for cluster elements', () => {
@@ -727,6 +770,151 @@ describe('usePropertyCodeEditorDialogRightPanelConnections', () => {
                 id: 'workflow-1',
                 version: 2,
             });
+        });
+    });
+
+    describe('tasks the change does not touch, and declines', () => {
+        const otherTask = {connections: {}, name: 'otherNode', type: 'logger/v1/debug'};
+
+        const plainProps = (tasks: Array<unknown>) => ({
+            componentConnections: [
+                {
+                    componentName: 'slack',
+                    componentVersion: 1,
+                    key: 'slack_1',
+                    required: true,
+                    workflowNodeName: 'testNode',
+                },
+            ],
+            workflow: {definition: JSON.stringify({tasks}), id: 'workflow-1', version: 1},
+            workflowNodeName: 'testNode',
+        });
+
+        const clusterProps = (clusterElements: Record<string, unknown>, extra: Array<unknown> = []) => ({
+            componentConnections: [
+                {
+                    componentName: 'amazonS3',
+                    componentVersion: 1,
+                    key: 's3_connection',
+                    required: true,
+                    workflowNodeName: 'source_1',
+                },
+            ],
+            workflow: {
+                definition: JSON.stringify({
+                    tasks: [...extra, {clusterElements, name: 'dataStream_1', type: 'dataStream/v1/sync'}],
+                }),
+                id: 'workflow-1',
+                version: 1,
+            },
+            workflowNodeName: 'source_1',
+        });
+
+        const source = {
+            connections: {s3_connection: {componentName: 'amazonS3', componentVersion: 1}},
+            name: 'source_1',
+            type: 'amazonS3/v1/amazonS3Read',
+        };
+
+        beforeEach(async () => {
+            hoisted.storeState.currentNode = {clusterElementType: undefined, name: 'testNode'};
+            hoisted.storeState.rootClusterElementNodeData = undefined;
+            vi.clearAllMocks();
+            vi.resetModules();
+        });
+
+        it('leaves the other tasks alone when adding a connection', async () => {
+            const {usePropertyCodeEditorDialogRightPanelConnections} =
+                await import('../usePropertyCodeEditorDialogRightPanelConnections');
+            const {result} = renderConnectionsHook(
+                usePropertyCodeEditorDialogRightPanelConnections,
+                plainProps([otherTask, {connections: {}, name: 'testNode', type: 'script/v1/run'}])
+            );
+
+            act(() => {
+                result.current.handleOnSubmit({componentName: 'github', componentVersion: 2, name: 'gh'});
+            });
+
+            const definition = JSON.parse(hoisted.mockMutate.mock.calls[0][0].workflow.definition);
+
+            expect(definition.tasks[0]).toEqual(otherTask);
+            expect(definition.tasks[1].connections.gh).toEqual({componentName: 'github', componentVersion: 2});
+        });
+
+        it('leaves the other tasks alone when removing a connection', async () => {
+            const {usePropertyCodeEditorDialogRightPanelConnections} =
+                await import('../usePropertyCodeEditorDialogRightPanelConnections');
+            const {result} = renderConnectionsHook(
+                usePropertyCodeEditorDialogRightPanelConnections,
+                plainProps([
+                    otherTask,
+                    {
+                        connections: {slack_1: {componentName: 'slack', componentVersion: 1}},
+                        name: 'testNode',
+                        type: 'script/v1/run',
+                    },
+                ])
+            );
+
+            act(() => {
+                result.current.handleOnRemoveClick('slack_1');
+            });
+
+            const definition = JSON.parse(hoisted.mockMutate.mock.calls[0][0].workflow.definition);
+
+            expect(definition.tasks[0]).toEqual(otherTask);
+            expect(definition.tasks[1].connections).toEqual({});
+        });
+
+        it('declines the removal when the task is gone from the fresh definition', async () => {
+            const {usePropertyCodeEditorDialogRightPanelConnections} =
+                await import('../usePropertyCodeEditorDialogRightPanelConnections');
+            const {result} = renderConnectionsHook(
+                usePropertyCodeEditorDialogRightPanelConnections,
+                plainProps([otherTask])
+            );
+
+            act(() => {
+                result.current.handleOnRemoveClick('slack_1');
+            });
+
+            expect(hoisted.mockMutate).not.toHaveBeenCalled();
+        });
+
+        it('leaves the other tasks alone when changing a cluster element connection', async () => {
+            hoisted.storeState.currentNode = {clusterElementType: 'source', name: 'source_1'};
+            hoisted.storeState.rootClusterElementNodeData = {workflowNodeName: 'dataStream_1'};
+
+            const {usePropertyCodeEditorDialogRightPanelConnections} =
+                await import('../usePropertyCodeEditorDialogRightPanelConnections');
+            const {result} = renderConnectionsHook(
+                usePropertyCodeEditorDialogRightPanelConnections,
+                clusterProps({source}, [otherTask])
+            );
+
+            act(() => {
+                result.current.handleOnRemoveClick('s3_connection');
+            });
+
+            const definition = JSON.parse(hoisted.mockMutate.mock.calls[0][0].workflow.definition);
+
+            expect(definition.tasks[0]).toEqual(otherTask);
+            expect(definition.tasks[1].clusterElements.source.connections).toEqual({});
+        });
+
+        it('declines the cluster removal when the element is gone from the fresh definition', async () => {
+            hoisted.storeState.currentNode = {clusterElementType: 'source', name: 'source_1'};
+            hoisted.storeState.rootClusterElementNodeData = {workflowNodeName: 'dataStream_1'};
+
+            const {usePropertyCodeEditorDialogRightPanelConnections} =
+                await import('../usePropertyCodeEditorDialogRightPanelConnections');
+            const {result} = renderConnectionsHook(usePropertyCodeEditorDialogRightPanelConnections, clusterProps({}));
+
+            act(() => {
+                result.current.handleOnRemoveClick('s3_connection');
+            });
+
+            expect(hoisted.mockMutate).not.toHaveBeenCalled();
         });
     });
 });

--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-code-editor/property-code-editor-dialog/hooks/usePropertyCodeEditorDialogRightPanelConnections.ts
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-code-editor/property-code-editor-dialog/hooks/usePropertyCodeEditorDialogRightPanelConnections.ts
@@ -1,10 +1,9 @@
 import {connectionFormSchema} from '@/pages/platform/workflow-editor/components/properties/components/property-code-editor/property-code-editor-dialog/PropertyCodeEditorDialogRightPanelConnectionsPopover';
 import {useWorkflowEditor} from '@/pages/platform/workflow-editor/providers/workflowEditorProvider';
 import {useConnectionNoteStore} from '@/pages/platform/workflow-editor/stores/useConnectionNoteStore';
-import useWorkflowDataStore from '@/pages/platform/workflow-editor/stores/useWorkflowDataStore';
 import useWorkflowEditorStore from '@/pages/platform/workflow-editor/stores/useWorkflowEditorStore';
 import useWorkflowNodeDetailsPanelStore from '@/pages/platform/workflow-editor/stores/useWorkflowNodeDetailsPanelStore';
-import stringifyWorkflowDefinition from '@/pages/platform/workflow-editor/utils/stringifyWorkflowDefinition';
+import saveWorkflowDefinitionUpdate from '@/pages/platform/workflow-editor/utils/saveWorkflowDefinitionUpdate';
 import {ComponentConnection, Workflow} from '@/shared/middleware/platform/configuration';
 import {useGetWorkflowTestConfigurationConnectionsQuery} from '@/shared/queries/platform/workflowTestConfigurations.queries';
 import {useEnvironmentStore} from '@/shared/stores/useEnvironmentStore';
@@ -62,32 +61,20 @@ export const usePropertyCodeEditorDialogRightPanelConnections = ({
             : workflowNodeName,
     });
 
-    const saveConnections = (workflowDefinition: WorkflowDefinitionType) => {
-        const definition = stringifyWorkflowDefinition(workflowDefinition);
-
-        updateWorkflowMutation!.mutate(
-            {
-                id: workflow.id!,
-                workflow: {
-                    definition,
-                    version: workflow.version,
-                },
+    const saveConnections = (
+        updateDefinition: (workflowDefinition: WorkflowDefinitionType) => WorkflowDefinitionType | undefined
+    ) => {
+        saveWorkflowDefinitionUpdate({
+            onSuccess: () => {
+                if (isClusterElement) {
+                    queryClient.invalidateQueries({queryKey: ['clusterElementComponentConnections']});
+                } else {
+                    queryClient.invalidateQueries({queryKey: ['workflowNodeComponentConnections']});
+                }
             },
-            {
-                onSuccess: (updatedWorkflow) => {
-                    useWorkflowDataStore.getState().setWorkflow({
-                        ...updatedWorkflow,
-                        definition,
-                    });
-
-                    if (isClusterElement) {
-                        queryClient.invalidateQueries({queryKey: ['clusterElementComponentConnections']});
-                    } else {
-                        queryClient.invalidateQueries({queryKey: ['workflowNodeComponentConnections']});
-                    }
-                },
-            }
-        );
+            updateDefinition,
+            updateWorkflowMutation: updateWorkflowMutation!,
+        });
     };
 
     const handleOnSubmit = (values: z.infer<typeof connectionFormSchema>) => {
@@ -95,84 +82,86 @@ export const usePropertyCodeEditorDialogRightPanelConnections = ({
             return;
         }
 
-        let workflowDefinition: WorkflowDefinitionType = JSON.parse(workflow?.definition);
+        saveConnections((freshWorkflowDefinition) => {
+            let workflowDefinition = freshWorkflowDefinition;
 
-        if (isClusterElement) {
-            const parentTaskName = rootClusterElementNodeData?.workflowNodeName;
-            const clusterElementType = currentNode?.clusterElementType as keyof ClusterElementsType;
+            if (isClusterElement) {
+                const parentTaskName = rootClusterElementNodeData?.workflowNodeName;
+                const clusterElementType = currentNode?.clusterElementType as keyof ClusterElementsType;
 
-            const parentTask = workflowDefinition.tasks?.find((task) => task.name === parentTaskName);
+                const parentTask = workflowDefinition.tasks?.find((task) => task.name === parentTaskName);
 
-            const clusterElementValue = parentTask?.clusterElements?.[clusterElementType];
+                const clusterElementValue = parentTask?.clusterElements?.[clusterElementType];
 
-            if (!clusterElementValue) {
-                return;
-            }
+                if (!clusterElementValue) {
+                    return undefined;
+                }
 
-            const addConnection = (clusterElement: ClusterElementItemType): ClusterElementItemType => ({
-                ...clusterElement,
-                connections: {
-                    ...(clusterElement.connections ?? {}),
-                    [values.name]: {
-                        componentName: values.componentName,
-                        componentVersion: values.componentVersion,
-                    },
-                },
-            });
-
-            workflowDefinition = {
-                ...workflowDefinition,
-                tasks: workflowDefinition.tasks!.map((task) => {
-                    if (task.name !== parentTaskName) {
-                        return task;
-                    }
-
-                    const taskClusterElementValue = task.clusterElements![clusterElementType];
-
-                    return {
-                        ...task,
-                        clusterElements: {
-                            ...task.clusterElements,
-                            [clusterElementType]: Array.isArray(taskClusterElementValue)
-                                ? taskClusterElementValue.map((clusterElement) =>
-                                      clusterElement.name === workflowNodeName
-                                          ? addConnection(clusterElement)
-                                          : clusterElement
-                                  )
-                                : addConnection(taskClusterElementValue as ClusterElementItemType),
+                const addConnection = (clusterElement: ClusterElementItemType): ClusterElementItemType => ({
+                    ...clusterElement,
+                    connections: {
+                        ...(clusterElement.connections ?? {}),
+                        [values.name]: {
+                            componentName: values.componentName,
+                            componentVersion: values.componentVersion,
                         },
-                    } as WorkflowTaskType;
-                }),
-            };
-        } else {
-            const scriptWorkflowTask = workflowDefinition.tasks?.find((task) => task.name === workflowNodeName);
+                    },
+                });
 
-            if (!scriptWorkflowTask) {
-                return;
-            }
+                workflowDefinition = {
+                    ...workflowDefinition,
+                    tasks: workflowDefinition.tasks!.map((task) => {
+                        if (task.name !== parentTaskName) {
+                            return task;
+                        }
 
-            workflowDefinition = {
-                ...workflowDefinition,
-                tasks: workflowDefinition.tasks!.map((task) => {
-                    if (task.name === workflowNodeName) {
+                        const taskClusterElementValue = task.clusterElements![clusterElementType];
+
                         return {
-                            ...scriptWorkflowTask,
-                            connections: {
-                                ...(scriptWorkflowTask.connections ?? {}),
-                                [values.name]: {
-                                    componentName: values.componentName,
-                                    componentVersion: values.componentVersion,
-                                },
+                            ...task,
+                            clusterElements: {
+                                ...task.clusterElements,
+                                [clusterElementType]: Array.isArray(taskClusterElementValue)
+                                    ? taskClusterElementValue.map((clusterElement) =>
+                                          clusterElement.name === workflowNodeName
+                                              ? addConnection(clusterElement)
+                                              : clusterElement
+                                      )
+                                    : addConnection(taskClusterElementValue as ClusterElementItemType),
                             },
                         } as WorkflowTaskType;
-                    }
+                    }),
+                };
+            } else {
+                const scriptWorkflowTask = workflowDefinition.tasks?.find((task) => task.name === workflowNodeName);
 
-                    return task;
-                }),
-            };
-        }
+                if (!scriptWorkflowTask) {
+                    return undefined;
+                }
 
-        saveConnections(workflowDefinition);
+                workflowDefinition = {
+                    ...workflowDefinition,
+                    tasks: workflowDefinition.tasks!.map((task) => {
+                        if (task.name === workflowNodeName) {
+                            return {
+                                ...scriptWorkflowTask,
+                                connections: {
+                                    ...(scriptWorkflowTask.connections ?? {}),
+                                    [values.name]: {
+                                        componentName: values.componentName,
+                                        componentVersion: values.componentVersion,
+                                    },
+                                },
+                            } as WorkflowTaskType;
+                        }
+
+                        return task;
+                    }),
+                };
+            }
+
+            return workflowDefinition;
+        });
     };
 
     const handleOnRemoveClick = (workflowConnectionKey: string) => {
@@ -180,80 +169,84 @@ export const usePropertyCodeEditorDialogRightPanelConnections = ({
             return;
         }
 
-        let workflowDefinition: WorkflowDefinitionType = JSON.parse(workflow?.definition);
+        saveConnections((freshWorkflowDefinition) => {
+            let workflowDefinition = freshWorkflowDefinition;
 
-        if (isClusterElement) {
-            const parentTaskName = rootClusterElementNodeData?.workflowNodeName;
-            const clusterElementType = currentNode?.clusterElementType as keyof ClusterElementsType;
+            if (isClusterElement) {
+                const parentTaskName = rootClusterElementNodeData?.workflowNodeName;
+                const clusterElementType = currentNode?.clusterElementType as keyof ClusterElementsType;
 
-            const parentTask = workflowDefinition.tasks?.find((task) => task.name === parentTaskName);
+                const parentTask = workflowDefinition.tasks?.find((task) => task.name === parentTaskName);
 
-            const clusterElementValue = parentTask?.clusterElements?.[clusterElementType];
+                const clusterElementValue = parentTask?.clusterElements?.[clusterElementType];
 
-            if (!clusterElementValue) {
-                return;
-            }
+                if (!clusterElementValue) {
+                    return undefined;
+                }
 
-            const removeConnection = (clusterElement: ClusterElementItemType): ClusterElementItemType => {
-                // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                const {[workflowConnectionKey]: removed, ...remainingConnections} = clusterElement.connections ?? {};
-
-                return {
-                    ...clusterElement,
-                    connections: remainingConnections,
-                };
-            };
-
-            workflowDefinition = {
-                ...workflowDefinition,
-                tasks: workflowDefinition.tasks!.map((task) => {
-                    if (task.name !== parentTaskName) {
-                        return task;
-                    }
-
-                    const taskClusterElementValue = task.clusterElements![clusterElementType];
+                const removeConnection = (clusterElement: ClusterElementItemType): ClusterElementItemType => {
+                    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                    const {[workflowConnectionKey]: removed, ...remainingConnections} =
+                        clusterElement.connections ?? {};
 
                     return {
-                        ...task,
-                        clusterElements: {
-                            ...task.clusterElements,
-                            [clusterElementType]: Array.isArray(taskClusterElementValue)
-                                ? taskClusterElementValue.map((clusterElement) =>
-                                      clusterElement.name === workflowNodeName
-                                          ? removeConnection(clusterElement)
-                                          : clusterElement
-                                  )
-                                : removeConnection(taskClusterElementValue as ClusterElementItemType),
-                        },
-                    } as WorkflowTaskType;
-                }),
-            };
-        } else {
-            const scriptWorkflowTask = workflowDefinition.tasks?.find((task) => task.name === workflowNodeName);
+                        ...clusterElement,
+                        connections: remainingConnections,
+                    };
+                };
 
-            if (!scriptWorkflowTask) {
-                return;
+                workflowDefinition = {
+                    ...workflowDefinition,
+                    tasks: workflowDefinition.tasks!.map((task) => {
+                        if (task.name !== parentTaskName) {
+                            return task;
+                        }
+
+                        const taskClusterElementValue = task.clusterElements![clusterElementType];
+
+                        return {
+                            ...task,
+                            clusterElements: {
+                                ...task.clusterElements,
+                                [clusterElementType]: Array.isArray(taskClusterElementValue)
+                                    ? taskClusterElementValue.map((clusterElement) =>
+                                          clusterElement.name === workflowNodeName
+                                              ? removeConnection(clusterElement)
+                                              : clusterElement
+                                      )
+                                    : removeConnection(taskClusterElementValue as ClusterElementItemType),
+                            },
+                        } as WorkflowTaskType;
+                    }),
+                };
+            } else {
+                const scriptWorkflowTask = workflowDefinition.tasks?.find((task) => task.name === workflowNodeName);
+
+                if (!scriptWorkflowTask) {
+                    return undefined;
+                }
+
+                // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                const {[workflowConnectionKey]: removed, ...remainingConnections} =
+                    scriptWorkflowTask.connections ?? {};
+
+                workflowDefinition = {
+                    ...workflowDefinition,
+                    tasks: workflowDefinition.tasks!.map((task) => {
+                        if (task.name === workflowNodeName) {
+                            return {
+                                ...scriptWorkflowTask,
+                                connections: remainingConnections,
+                            } as WorkflowTaskType;
+                        }
+
+                        return task;
+                    }),
+                };
             }
 
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            const {[workflowConnectionKey]: removed, ...remainingConnections} = scriptWorkflowTask.connections ?? {};
-
-            workflowDefinition = {
-                ...workflowDefinition,
-                tasks: workflowDefinition.tasks!.map((task) => {
-                    if (task.name === workflowNodeName) {
-                        return {
-                            ...scriptWorkflowTask,
-                            connections: remainingConnections,
-                        } as WorkflowTaskType;
-                    }
-
-                    return task;
-                }),
-            };
-        }
-
-        saveConnections(workflowDefinition);
+            return workflowDefinition;
+        });
     };
 
     return {

--- a/client/src/pages/platform/workflow-editor/components/workflow-inputs/hooks/useWorkflowInputs.test.ts
+++ b/client/src/pages/platform/workflow-editor/components/workflow-inputs/hooks/useWorkflowInputs.test.ts
@@ -1,0 +1,259 @@
+import {WorkflowInput} from '@/shared/middleware/platform/configuration';
+import {act, renderHook} from '@testing-library/react';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+
+import {
+    clearAllWorkflowMutations,
+    drainPendingSaves,
+    hasPendingSaves,
+    setWorkflowMutating,
+} from '../../../utils/workflowMutationGuard';
+import useWorkflowInputs from './useWorkflowInputs';
+
+const {saveTestConfigurationInputsMock, updateWorkflowMutationMock, workflowDataState} = vi.hoisted(() => ({
+    saveTestConfigurationInputsMock: vi.fn(),
+    updateWorkflowMutationMock: {mutate: vi.fn()},
+    workflowDataState: {
+        setWorkflow: vi.fn(),
+        workflow: {definition: '', id: 'workflow-1', inputs: [] as WorkflowInput[], version: 1},
+    },
+}));
+
+vi.mock('@/pages/platform/workflow-editor/providers/workflowEditorProvider', () => ({
+    useWorkflowEditor: () => ({updateWorkflowMutation: updateWorkflowMutationMock}),
+}));
+
+vi.mock('@/shared/mutations/platform/workflowTestConfigurations.mutations', () => ({
+    useSaveWorkflowTestConfigurationInputsMutation: () => ({mutate: saveTestConfigurationInputsMock}),
+}));
+
+vi.mock('@/shared/stores/useEnvironmentStore', () => ({
+    useEnvironmentStore: (selector: (state: {currentEnvironmentId: number}) => unknown) =>
+        selector({currentEnvironmentId: 1}),
+}));
+
+vi.mock('../../../stores/useWorkflowDataStore', () => ({
+    default: Object.assign((selector: (state: typeof workflowDataState) => unknown) => selector(workflowDataState), {
+        getState: () => workflowDataState,
+    }),
+}));
+
+vi.mock('@tanstack/react-query', () => ({
+    useQueryClient: () => ({invalidateQueries: vi.fn()}),
+}));
+
+function setDefinition(inputs: Array<WorkflowInput>) {
+    workflowDataState.workflow = {
+        ...workflowDataState.workflow,
+        definition: JSON.stringify({inputs, tasks: []}),
+        inputs,
+    };
+}
+
+function sentDefinition(call = 0) {
+    return JSON.parse(updateWorkflowMutationMock.mutate.mock.calls[call][0].workflow.definition);
+}
+
+function renderInputs() {
+    return renderHook(() => useWorkflowInputs({invalidateWorkflowQueries: vi.fn()}));
+}
+
+describe('useWorkflowInputs', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+
+        setDefinition([]);
+    });
+
+    afterEach(() => {
+        clearAllWorkflowMutations();
+    });
+
+    it('appends a new input and sends it through the guarded save', () => {
+        const {result} = renderInputs();
+
+        act(() => {
+            result.current.saveWorkflowInput({label: 'City', name: 'city', required: false, type: 'string'} as never);
+        });
+
+        expect(updateWorkflowMutationMock.mutate).toHaveBeenCalledOnce();
+        expect(sentDefinition().inputs.map((input: WorkflowInput) => input.name)).toEqual(['city']);
+    });
+
+    it('renames a duplicate rather than overwriting the input already there', () => {
+        setDefinition([{label: 'City', name: 'city', required: false, type: 'string'} as WorkflowInput]);
+
+        const {result} = renderInputs();
+
+        act(() => {
+            result.current.saveWorkflowInput({label: 'City', name: 'city', required: false, type: 'string'} as never);
+        });
+
+        expect(sentDefinition().inputs.map((input: WorkflowInput) => input.name)).toEqual(['city', 'city_1']);
+    });
+
+    it('queues the save behind an in-flight one and builds on what that save left behind', () => {
+        const {result} = renderInputs();
+
+        setWorkflowMutating('workflow-1', true);
+
+        act(() => {
+            result.current.saveWorkflowInput({label: 'City', name: 'city', required: false, type: 'string'} as never);
+        });
+
+        expect(updateWorkflowMutationMock.mutate).not.toHaveBeenCalled();
+        expect(hasPendingSaves('workflow-1')).toBe(true);
+
+        // The in-flight save added an input of its own; the queued one must not drop it.
+        setDefinition([{label: 'Country', name: 'country', required: false, type: 'string'} as WorkflowInput]);
+
+        setWorkflowMutating('workflow-1', false);
+
+        drainPendingSaves('workflow-1');
+
+        expect(updateWorkflowMutationMock.mutate).toHaveBeenCalledOnce();
+        expect(sentDefinition().inputs.map((input: WorkflowInput) => input.name)).toEqual(['country', 'city']);
+    });
+
+    it('removes an input by name on delete', () => {
+        setDefinition([
+            {label: 'City', name: 'city', required: false, type: 'string'} as WorkflowInput,
+            {label: 'Country', name: 'country', required: false, type: 'string'} as WorkflowInput,
+        ]);
+
+        const {result} = renderInputs();
+
+        act(() => {
+            result.current.deleteWorkflowInput({name: 'city'} as WorkflowInput);
+        });
+
+        expect(sentDefinition().inputs.map((input: WorkflowInput) => input.name)).toEqual(['country']);
+    });
+
+    it('rolls the store back when a delete fails', () => {
+        const originalInputs = [{label: 'City', name: 'city', required: false, type: 'string'} as WorkflowInput];
+
+        setDefinition(originalInputs);
+
+        const {result} = renderInputs();
+
+        act(() => {
+            result.current.deleteWorkflowInput({name: 'city'} as WorkflowInput);
+        });
+
+        const callbacks = updateWorkflowMutationMock.mutate.mock.calls[0][1];
+
+        act(() => {
+            callbacks.onError(new Error('version conflict'));
+        });
+
+        const restored = workflowDataState.setWorkflow.mock.calls.at(-1)?.[0];
+
+        expect(restored.inputs.map((input: WorkflowInput) => input.name)).toEqual(['city']);
+    });
+
+    it('replaces the input at the index being edited', () => {
+        setDefinition([
+            {label: 'City', name: 'city', required: false, type: 'string'} as WorkflowInput,
+            {label: 'Country', name: 'country', required: false, type: 'string'} as WorkflowInput,
+        ]);
+
+        const {result} = renderInputs();
+
+        act(() => {
+            result.current.openEditDialog(1);
+        });
+
+        act(() => {
+            result.current.saveWorkflowInput({
+                label: 'Region',
+                name: 'region',
+                required: false,
+                type: 'string',
+            } as never);
+        });
+
+        expect(sentDefinition().inputs.map((input: WorkflowInput) => input.name)).toEqual(['city', 'region']);
+    });
+
+    it('stores the test value and refocuses the name field once the save lands', () => {
+        vi.useFakeTimers();
+
+        const nameInput = document.createElement('input');
+
+        nameInput.setAttribute('name', 'name');
+        document.body.appendChild(nameInput);
+
+        const {result} = renderInputs();
+
+        act(() => {
+            result.current.saveWorkflowInput({label: 'City', name: 'city', required: false, type: 'string'} as never);
+        });
+
+        const callbacks = updateWorkflowMutationMock.mutate.mock.calls[0][1];
+
+        act(() => {
+            callbacks.onSuccess({id: 'workflow-1', version: 2});
+        });
+
+        act(() => {
+            vi.runAllTimers();
+        });
+
+        expect(saveTestConfigurationInputsMock).toHaveBeenCalledOnce();
+        expect(document.activeElement).toBe(nameInput);
+
+        document.body.removeChild(nameInput);
+
+        vi.useRealTimers();
+    });
+
+    it('rolls the store back when a save fails', () => {
+        setDefinition([{label: 'City', name: 'city', required: false, type: 'string'} as WorkflowInput]);
+
+        const {result} = renderInputs();
+
+        act(() => {
+            result.current.saveWorkflowInput({
+                label: 'Country',
+                name: 'country',
+                required: false,
+                type: 'string',
+            } as never);
+        });
+
+        const callbacks = updateWorkflowMutationMock.mutate.mock.calls[0][1];
+
+        act(() => {
+            callbacks.onError(new Error('version conflict'));
+        });
+
+        const restored = workflowDataState.setWorkflow.mock.calls.at(-1)?.[0];
+
+        expect(restored.inputs.map((input: WorkflowInput) => input.name)).toEqual(['city']);
+    });
+
+    it('closes the delete dialog once the delete lands', () => {
+        setDefinition([{label: 'City', name: 'city', required: false, type: 'string'} as WorkflowInput]);
+
+        const {result} = renderInputs();
+
+        act(() => {
+            result.current.openDeleteDialog(0);
+        });
+
+        expect(result.current.isDeleteDialogOpen).toBe(true);
+
+        act(() => {
+            result.current.deleteWorkflowInput({name: 'city'} as WorkflowInput);
+        });
+
+        const callbacks = updateWorkflowMutationMock.mutate.mock.calls[0][1];
+
+        act(() => {
+            callbacks.onSuccess({id: 'workflow-1', version: 2});
+        });
+
+        expect(result.current.isDeleteDialogOpen).toBe(false);
+    });
+});

--- a/client/src/pages/platform/workflow-editor/components/workflow-inputs/hooks/useWorkflowInputs.ts
+++ b/client/src/pages/platform/workflow-editor/components/workflow-inputs/hooks/useWorkflowInputs.ts
@@ -10,7 +10,7 @@ import {useForm} from 'react-hook-form';
 import {useShallow} from 'zustand/react/shallow';
 
 import useWorkflowDataStore from '../../../stores/useWorkflowDataStore';
-import stringifyWorkflowDefinition from '../../../utils/stringifyWorkflowDefinition';
+import saveWorkflowDefinitionUpdate from '../../../utils/saveWorkflowDefinitionUpdate';
 
 interface UseWorkflowInputsProps {
     invalidateWorkflowQueries: () => void;
@@ -140,130 +140,96 @@ export default function useWorkflowInputs({
 
         const workflowDefinition: WorkflowDefinitionType = JSON.parse(workflow.definition!);
 
-        let inputs: WorkflowInput[] = workflowDefinition.inputs ?? [];
+        const previousInputs: WorkflowInput[] = workflowDefinition.inputs ?? [];
 
-        if (currentInputIndex === -1) {
-            const duplicateInput = inputs.find((existingInput) => existingInput.name === input.name);
-
-            if (duplicateInput) {
-                input.name = getFormattedInputName(input.name, inputs);
-            }
-
-            inputs = [...inputs, input];
-        } else {
-            inputs[currentInputIndex] = input;
+        if (currentInputIndex === -1 && previousInputs.some((existingInput) => existingInput.name === input.name)) {
+            input.name = getFormattedInputName(input.name, previousInputs);
         }
+
+        const applyInput = (inputs: WorkflowInput[]): WorkflowInput[] =>
+            currentInputIndex === -1
+                ? [...inputs, input]
+                : inputs.map((existingInput, index) => (index === currentInputIndex ? input : existingInput));
 
         setWorkflow({
             ...workflow,
-            inputs,
+            inputs: applyInput(previousInputs),
         });
 
-        updateWorkflowMutation!.mutate(
-            {
-                id: workflow.id!,
-                workflow: {
-                    definition: stringifyWorkflowDefinition({
-                        ...workflowDefinition,
-                        inputs,
-                    }),
-                    version: workflow.version,
-                },
+        saveWorkflowDefinitionUpdate({
+            onError: () => {
+                setWorkflow({
+                    ...useWorkflowDataStore.getState().workflow,
+                    inputs: previousInputs,
+                });
             },
-            {
-                onError: () => {
-                    const originalInputs = workflowDefinition.inputs ?? [];
+            onSuccess: () => {
+                saveWorkflowTestConfigurationInputsMutation.mutate({
+                    environmentId: currentEnvironmentId,
+                    saveWorkflowTestConfigurationInputsRequest: {
+                        key: input.name,
+                        value: getValues().testValue!,
+                    },
+                    workflowId: workflow.id!,
+                });
 
-                    setWorkflow({
-                        ...workflow,
-                        inputs: originalInputs,
-                    });
-                },
-                onSuccess: async () => {
-                    saveWorkflowTestConfigurationInputsMutation.mutate({
-                        environmentId: currentEnvironmentId,
-                        saveWorkflowTestConfigurationInputsRequest: {
-                            key: input.name,
-                            value: getValues().testValue!,
-                        },
-                        workflowId: workflow.id!,
-                    });
+                form.reset({
+                    label: '',
+                    name: '',
+                    required: false,
+                    testValue: '',
+                    type: undefined,
+                });
 
-                    setWorkflow({
-                        ...workflow,
-                        inputs,
-                        version: (workflow.version ?? 0) + 1,
-                    });
+                setTimeout(() => {
+                    const nameInput = document.querySelector('input[name="name"]') as HTMLInputElement;
 
-                    form.reset({
-                        label: '',
-                        name: '',
-                        required: false,
-                        testValue: '',
-                        type: undefined,
-                    });
+                    if (nameInput) {
+                        nameInput.focus();
+                    }
+                }, 0);
 
-                    setTimeout(() => {
-                        const nameInput = document.querySelector('input[name="name"]') as HTMLInputElement;
-
-                        if (nameInput) {
-                            nameInput.focus();
-                        }
-                    }, 0);
-
-                    invalidateWorkflowQueries();
-                },
-            }
-        );
+                invalidateWorkflowQueries();
+            },
+            updateDefinition: (freshWorkflowDefinition) => ({
+                ...freshWorkflowDefinition,
+                inputs: applyInput(freshWorkflowDefinition.inputs ?? []),
+            }),
+            updateWorkflowMutation: updateWorkflowMutation!,
+        });
     }
 
     function deleteWorkflowInput(input: WorkflowInput) {
         const definitionObject: WorkflowDefinitionType = JSON.parse(workflow.definition!);
 
-        const inputs: WorkflowInput[] = definitionObject.inputs ?? [];
+        const originalInputs: WorkflowInput[] = definitionObject.inputs ?? [];
 
-        const index = inputs.findIndex((curInput) => curInput.name === input.name);
-
-        inputs.splice(index, 1);
+        const removeInput = (inputs: WorkflowInput[]): WorkflowInput[] =>
+            inputs.filter((existingInput) => existingInput.name !== input.name);
 
         setWorkflow({
             ...workflow,
-            inputs,
+            inputs: removeInput(originalInputs),
         });
 
-        updateWorkflowMutation!.mutate(
-            {
-                id: workflow.id!,
-                workflow: {
-                    definition: stringifyWorkflowDefinition({
-                        ...definitionObject,
-                        inputs,
-                    }),
-                    version: workflow.version,
-                },
+        saveWorkflowDefinitionUpdate({
+            onError: () => {
+                setWorkflow({
+                    ...useWorkflowDataStore.getState().workflow,
+                    inputs: originalInputs,
+                });
             },
-            {
-                onError: () => {
-                    const originalInputs = definitionObject.inputs ?? [];
+            onSuccess: () => {
+                invalidateWorkflowQueries();
 
-                    setWorkflow({
-                        ...workflow,
-                        inputs: originalInputs,
-                    });
-                },
-                onSuccess: () => {
-                    setWorkflow({
-                        ...workflow,
-                        inputs,
-                        version: (workflow.version ?? 0) + 1,
-                    });
-
-                    invalidateWorkflowQueries();
-
-                    setIsDeleteDialogOpen(false);
-                },
-            }
-        );
+                setIsDeleteDialogOpen(false);
+            },
+            updateDefinition: (freshWorkflowDefinition) => ({
+                ...freshWorkflowDefinition,
+                inputs: removeInput(freshWorkflowDefinition.inputs ?? []),
+            }),
+            updateWorkflowMutation: updateWorkflowMutation!,
+        });
     }
 
     useEffect(() => {

--- a/client/src/pages/platform/workflow-editor/hooks/useWorkflowCodeEditorSheet.ts
+++ b/client/src/pages/platform/workflow-editor/hooks/useWorkflowCodeEditorSheet.ts
@@ -8,6 +8,7 @@ import {WorkflowTestApi, WorkflowTestExecution} from '@/shared/middleware/platfo
 import {useApplicationInfoStore} from '@/shared/stores/useApplicationInfoStore';
 import {useEnvironmentStore} from '@/shared/stores/useEnvironmentStore';
 import {useFeatureFlagsStore} from '@/shared/stores/useFeatureFlagsStore';
+import {WorkflowDefinitionType} from '@/shared/types';
 import {getTestWorkflowAttachRequest, getTestWorkflowStreamPostRequest} from '@/shared/util/testWorkflow-utils';
 import {MarkerSeverity} from 'monaco-editor';
 import {Ref, useCallback, useEffect, useState} from 'react';
@@ -16,6 +17,7 @@ import {useShallow} from 'zustand/shallow';
 
 import useWorkflowDataStore from '../stores/useWorkflowDataStore';
 import useWorkflowEditorStore from '../stores/useWorkflowEditorStore';
+import saveWorkflowDefinitionUpdate from '../utils/saveWorkflowDefinitionUpdate';
 
 import type {editor} from 'monaco-editor';
 
@@ -171,29 +173,26 @@ const useWorkflowCodeEditorSheet = ({
 
     const handleSaveClick = (workflow: Workflow, definition: string) => {
         if (workflow && workflow.id) {
+            let editedWorkflowDefinition: WorkflowDefinitionType;
+
             try {
-                JSON.parse(definition);
-
-                updateWorkflowMutation!.mutate(
-                    {
-                        id: workflow.id,
-                        workflow: {
-                            definition,
-                            version: workflow.version,
-                        },
-                    },
-                    {
-                        onError: () => setDirty(true),
-                        onSuccess: () => {
-                            setDirty(false);
-
-                            invalidateWorkflowQueries();
-                        },
-                    }
-                );
+                editedWorkflowDefinition = JSON.parse(definition);
             } catch (error) {
                 console.error(`Invalid JSON: ${error}`);
+
+                return;
             }
+
+            saveWorkflowDefinitionUpdate({
+                onError: () => setDirty(true),
+                onSuccess: () => {
+                    setDirty(false);
+
+                    invalidateWorkflowQueries();
+                },
+                updateDefinition: () => editedWorkflowDefinition,
+                updateWorkflowMutation: updateWorkflowMutation!,
+            });
         }
     };
 

--- a/client/src/pages/platform/workflow-editor/hooks/useWorkflowUndoRedo.ts
+++ b/client/src/pages/platform/workflow-editor/hooks/useWorkflowUndoRedo.ts
@@ -7,7 +7,7 @@ import useWorkflowDataStore, {
     useWorkflowTemporalStore,
 } from '../stores/useWorkflowDataStore';
 import useWorkflowNodeDetailsPanelStore from '../stores/useWorkflowNodeDetailsPanelStore';
-import {isWorkflowMutating, setWorkflowMutating} from '../utils/workflowMutationGuard';
+import {drainPendingSaves, isWorkflowMutating, setWorkflowMutating} from '../utils/workflowMutationGuard';
 
 interface UseWorkflowUndoRedoReturnI {
     canRedo: boolean;
@@ -61,6 +61,8 @@ export default function useWorkflowUndoRedo(): UseWorkflowUndoRedoReturnI {
                     },
                     onSettled: () => {
                         setWorkflowMutating(workflowId, false);
+
+                        drainPendingSaves(workflowId);
                     },
                     onSuccess: (updatedWorkflow) => {
                         const currentWorkflow = useWorkflowDataStore.getState().workflow;

--- a/client/src/pages/platform/workflow-editor/stores/useWorkflowNodeDetailsPanelStore.ts
+++ b/client/src/pages/platform/workflow-editor/stores/useWorkflowNodeDetailsPanelStore.ts
@@ -28,8 +28,9 @@ interface WorkflowNodeDetailsPanelStoreI {
     operationChangeInProgress: boolean;
     setOperationChangeInProgress: (operationChangeInProgress: boolean) => void;
 
-    pendingSaveNodeName: string | undefined;
-    setPendingSaveNodeName: (pendingSaveNodeName: string | undefined) => void;
+    pendingSaveNodeNames: ReadonlySet<string>;
+    addPendingSaveNodeName: (nodeName: string) => void;
+    removePendingSaveNodeName: (nodeName: string) => void;
 
     reset: () => void;
 
@@ -65,8 +66,21 @@ const useWorkflowNodeDetailsPanelStore = create<WorkflowNodeDetailsPanelStoreI>(
             setOperationChangeInProgress: (operationChangeInProgress) =>
                 set((state) => ({...state, operationChangeInProgress})),
 
-            pendingSaveNodeName: undefined,
-            setPendingSaveNodeName: (pendingSaveNodeName) => set((state) => ({...state, pendingSaveNodeName})),
+            pendingSaveNodeNames: new Set<string>(),
+            addPendingSaveNodeName: (nodeName) =>
+                set((state) => ({...state, pendingSaveNodeNames: new Set([...state.pendingSaveNodeNames, nodeName])})),
+            removePendingSaveNodeName: (nodeName) =>
+                set((state) => {
+                    if (!state.pendingSaveNodeNames.has(nodeName)) {
+                        return state;
+                    }
+
+                    const pendingSaveNodeNames = new Set(state.pendingSaveNodeNames);
+
+                    pendingSaveNodeNames.delete(nodeName);
+
+                    return {...state, pendingSaveNodeNames};
+                }),
 
             reset: () =>
                 set(() => ({
@@ -74,7 +88,6 @@ const useWorkflowNodeDetailsPanelStore = create<WorkflowNodeDetailsPanelStoreI>(
                     currentNode: undefined,
                     focusedInput: null,
                     operationChangeInProgress: false,
-                    pendingSaveNodeName: undefined,
                     workflowNodeDetailsPanelOpen: false,
                 })),
 

--- a/client/src/pages/platform/workflow-editor/stores/useWorkflowNodeDetailsPanelStore.ts
+++ b/client/src/pages/platform/workflow-editor/stores/useWorkflowNodeDetailsPanelStore.ts
@@ -30,6 +30,7 @@ interface WorkflowNodeDetailsPanelStoreI {
 
     pendingSaveNodeNames: ReadonlySet<string>;
     addPendingSaveNodeName: (nodeName: string) => void;
+    clearPendingSaveNodeNames: () => void;
     removePendingSaveNodeName: (nodeName: string) => void;
 
     reset: () => void;
@@ -69,6 +70,7 @@ const useWorkflowNodeDetailsPanelStore = create<WorkflowNodeDetailsPanelStoreI>(
             pendingSaveNodeNames: new Set<string>(),
             addPendingSaveNodeName: (nodeName) =>
                 set((state) => ({...state, pendingSaveNodeNames: new Set([...state.pendingSaveNodeNames, nodeName])})),
+            clearPendingSaveNodeNames: () => set((state) => ({...state, pendingSaveNodeNames: new Set<string>()})),
             removePendingSaveNodeName: (nodeName) =>
                 set((state) => {
                     if (!state.pendingSaveNodeNames.has(nodeName)) {

--- a/client/src/pages/platform/workflow-editor/utils/handleComponentAddedSuccess.ts
+++ b/client/src/pages/platform/workflow-editor/utils/handleComponentAddedSuccess.ts
@@ -21,16 +21,16 @@ export function openNodeDetailsPanelForNewNode(nodeData: NodeDataType): void {
     }
 
     const {
+        addPendingSaveNodeName,
         currentNode,
         setActiveTab,
         setCurrentNode,
-        setPendingSaveNodeName,
         setWorkflowNodeDetailsPanelOpen,
         workflowNodeDetailsPanelOpen,
     } = useWorkflowNodeDetailsPanelStore.getState();
 
     if (nodeData.name) {
-        setPendingSaveNodeName(nodeData.name);
+        addPendingSaveNodeName(nodeData.name);
     }
 
     if (workflowNodeDetailsPanelOpen) {
@@ -51,9 +51,7 @@ export default function handleComponentAddedSuccess({
 }: HandleComponentAddedSuccessProps) {
     invalidatePreviousWorkflowNodeOutputsForWorkflow(queryClient, workflow.id!);
 
-    const {pendingSaveNodeName, setPendingSaveNodeName} = useWorkflowNodeDetailsPanelStore.getState();
-
-    if (nodeData.name && pendingSaveNodeName === nodeData.name) {
-        setPendingSaveNodeName(undefined);
+    if (nodeData.name) {
+        useWorkflowNodeDetailsPanelStore.getState().removePendingSaveNodeName(nodeData.name);
     }
 }

--- a/client/src/pages/platform/workflow-editor/utils/handleComponentAddedSuccess.ts
+++ b/client/src/pages/platform/workflow-editor/utils/handleComponentAddedSuccess.ts
@@ -44,6 +44,22 @@ export function openNodeDetailsPanelForNewNode(nodeData: NodeDataType): void {
     }
 }
 
+export function handleComponentAddedError({nodeData}: {nodeData: NodeDataType}): void {
+    const {currentNode, removePendingSaveNodeName, setCurrentNode, setWorkflowNodeDetailsPanelOpen} =
+        useWorkflowNodeDetailsPanelStore.getState();
+
+    if (!nodeData.name) {
+        return;
+    }
+
+    removePendingSaveNodeName(nodeData.name);
+
+    if (currentNode?.name === nodeData.name) {
+        setCurrentNode(undefined);
+        setWorkflowNodeDetailsPanelOpen(false);
+    }
+}
+
 export default function handleComponentAddedSuccess({
     nodeData,
     queryClient,

--- a/client/src/pages/platform/workflow-editor/utils/handleDeleteTask.test.ts
+++ b/client/src/pages/platform/workflow-editor/utils/handleDeleteTask.test.ts
@@ -14,6 +14,7 @@ const mockSetWorkflow = vi.fn((newWorkflow) => {
     mockWorkflowState = newWorkflow;
 });
 const mockReset = vi.fn();
+const mockRemovePendingSaveNodeName = vi.fn();
 const mockSetWorkflowTestChatPanelOpen = vi.fn();
 
 vi.mock('../stores/useWorkflowDataStore', () => ({
@@ -29,6 +30,7 @@ vi.mock('../stores/useWorkflowDataStore', () => ({
 vi.mock('../stores/useWorkflowNodeDetailsPanelStore', () => ({
     default: {
         getState: () => ({
+            removePendingSaveNodeName: mockRemovePendingSaveNodeName,
             reset: mockReset,
             setWorkflowNodeDetailsPanelOpen: vi.fn(),
         }),
@@ -504,6 +506,24 @@ describe('handleDeleteTask', () => {
 
         expect(mockReset).toHaveBeenCalledOnce();
         expect(mockSetWorkflowTestChatPanelOpen).toHaveBeenCalledWith(false);
+    });
+
+    it('releases the deleted node from the pending-first-save markers', () => {
+        const tasks = [makeTask('task_1')];
+        const workflow = makeWorkflow(tasks);
+        const mutation = makeMockMutation();
+
+        handleDeleteTask({
+            cancelWorkflowQueries: vi.fn(),
+            currentNode: undefined,
+            data: {componentName: 'test', name: 'task_1'} as NodeDataType,
+            invalidateWorkflowQueries: vi.fn(),
+            queryClient: makeQueryClient(),
+            updateWorkflowMutation: mutation,
+            workflow,
+        });
+
+        expect(mockRemovePendingSaveNodeName).toHaveBeenCalledWith('task_1');
     });
 
     it('should not close panel when deleting a different node', () => {

--- a/client/src/pages/platform/workflow-editor/utils/handleDeleteTask.ts
+++ b/client/src/pages/platform/workflow-editor/utils/handleDeleteTask.ts
@@ -324,6 +324,8 @@ export default function handleDeleteTask({
         return;
     }
 
+    useWorkflowNodeDetailsPanelStore.getState().removePendingSaveNodeName(data.name);
+
     // Cancel any in-flight workflow query refetches from previous mutations
     // to prevent stale server data from overwriting the upcoming optimistic update.
     cancelWorkflowQueries();

--- a/client/src/pages/platform/workflow-editor/utils/handleDeleteTask.ts
+++ b/client/src/pages/platform/workflow-editor/utils/handleDeleteTask.ts
@@ -19,7 +19,7 @@ import {getTask} from './getTask';
 import stringifyWorkflowDefinition from './stringifyWorkflowDefinition';
 import {TASK_DISPATCHER_CONFIG} from './taskDispatcherConfig';
 import {forEachNestedTaskGroup} from './taskTraversalUtils';
-import {isWorkflowMutating, setWorkflowMutating} from './workflowMutationGuard';
+import {drainPendingSaves, isWorkflowMutating, setWorkflowMutating} from './workflowMutationGuard';
 
 interface HandleDeleteTaskProps {
     cancelWorkflowQueries: () => void;
@@ -372,6 +372,8 @@ export default function handleDeleteTask({
                 invalidatePreviousWorkflowNodeOutputsForWorkflow(queryClient, workflow.id!);
 
                 invalidateWorkflowQueries();
+
+                drainPendingSaves(workflow.id!);
             },
             onSuccess: (updatedWorkflow) => {
                 // Update the version from the server response so that the next mutation

--- a/client/src/pages/platform/workflow-editor/utils/handleTaskDispatcherClick.tsx
+++ b/client/src/pages/platform/workflow-editor/utils/handleTaskDispatcherClick.tsx
@@ -15,7 +15,10 @@ import InlineSVG from 'react-inlinesvg';
 import {WorkflowDataType} from '../stores/useWorkflowDataStore';
 import calculateNodeInsertIndex from './calculateNodeInsertIndex';
 import getFormattedName from './getFormattedName';
-import handleComponentAddedSuccess, {openNodeDetailsPanelForNewNode} from './handleComponentAddedSuccess';
+import handleComponentAddedSuccess, {
+    handleComponentAddedError,
+    openNodeDetailsPanelForNewNode,
+} from './handleComponentAddedSuccess';
 import saveWorkflowDefinition from './saveWorkflowDefinition';
 import {TASK_DISPATCHER_CONFIG} from './taskDispatcherConfig';
 
@@ -134,6 +137,7 @@ export default async function handleTaskDispatcherClick({
             workflowNodeName,
         },
         nodeIndex,
+        onError: () => handleComponentAddedError({nodeData: newNodeData}),
         onSuccess: () =>
             handleComponentAddedSuccess({
                 nodeData: newNodeData,

--- a/client/src/pages/platform/workflow-editor/utils/handleTaskDispatcherSubtaskOperationClick.tsx
+++ b/client/src/pages/platform/workflow-editor/utils/handleTaskDispatcherSubtaskOperationClick.tsx
@@ -13,7 +13,10 @@ import InlineSVG from 'react-inlinesvg';
 import {WorkflowDataType} from '../stores/useWorkflowDataStore';
 import getFormattedName from './getFormattedName';
 import getParametersWithDefaultValues from './getParametersWithDefaultValues';
-import handleComponentAddedSuccess, {openNodeDetailsPanelForNewNode} from './handleComponentAddedSuccess';
+import handleComponentAddedSuccess, {
+    handleComponentAddedError,
+    openNodeDetailsPanelForNewNode,
+} from './handleComponentAddedSuccess';
 import saveWorkflowDefinition from './saveWorkflowDefinition';
 import {TASK_DISPATCHER_CONFIG} from './taskDispatcherConfig';
 
@@ -87,6 +90,7 @@ export default function handleTaskDispatcherSubtaskOperationClick({
             }),
         },
         nodeIndex: taskAfterCurrentIndex,
+        onError: () => handleComponentAddedError({nodeData: newWorkflowNodeData}),
         onSuccess: () =>
             handleComponentAddedSuccess({
                 nodeData: newWorkflowNodeData,

--- a/client/src/pages/platform/workflow-editor/utils/saveTaskDispatcherSubtaskFieldChange.ts
+++ b/client/src/pages/platform/workflow-editor/utils/saveTaskDispatcherSubtaskFieldChange.ts
@@ -8,6 +8,7 @@ import getParametersWithDefaultValues from './getParametersWithDefaultValues';
 import getRecursivelyUpdatedTasks from './getRecursivelyUpdatedTasks';
 import saveWorkflowDefinition from './saveWorkflowDefinition';
 import {TASK_DISPATCHER_CONFIG} from './taskDispatcherConfig';
+import {enqueuePendingSave, isWorkflowMutating} from './workflowMutationGuard';
 
 type FieldUpdateType = {
     field: 'description' | 'label' | 'maxRetries' | 'operation';
@@ -22,18 +23,26 @@ interface SaveTaskDispatcherSubtaskFieldChangeProps {
     updateWorkflowMutation: UpdateWorkflowMutationType;
 }
 
-export default function saveTaskDispatcherSubtaskFieldChange({
-    currentComponentDefinition,
-    currentNodeIndex,
-    currentOperationProperties,
-    fieldUpdate,
-    updateWorkflowMutation,
-}: SaveTaskDispatcherSubtaskFieldChangeProps): void {
+export default function saveTaskDispatcherSubtaskFieldChange(props: SaveTaskDispatcherSubtaskFieldChangeProps): void {
+    const {
+        currentComponentDefinition,
+        currentNodeIndex,
+        currentOperationProperties,
+        fieldUpdate,
+        updateWorkflowMutation,
+    } = props;
+
     const {currentNode, setCurrentNode} = useWorkflowNodeDetailsPanelStore.getState();
 
     const {workflow} = useWorkflowDataStore.getState();
 
     if (!currentNode || !workflow.definition) {
+        return;
+    }
+
+    if (workflow.id && isWorkflowMutating(workflow.id)) {
+        enqueuePendingSave(workflow.id, () => saveTaskDispatcherSubtaskFieldChange(props));
+
         return;
     }
 

--- a/client/src/pages/platform/workflow-editor/utils/saveWorkflowDefinition.test.ts
+++ b/client/src/pages/platform/workflow-editor/utils/saveWorkflowDefinition.test.ts
@@ -300,13 +300,12 @@ describe('saveWorkflowDefinition', () => {
     });
 
     describe('mutation guard', () => {
-        it('should not mutate when workflow is already mutating', async () => {
+        it('queues the save while another mutation is in flight and fires it from fresh state once released', async () => {
             mockWorkflowState = makeWorkflowState();
 
             const mutation = makeMutation();
 
-            // Pre-set mutation flag
-            const {setWorkflowMutating} = await import('./workflowMutationGuard');
+            const {drainPendingSaves, hasPendingSaves, setWorkflowMutating} = await import('./workflowMutationGuard');
 
             setWorkflowMutating('workflow-1', true);
 
@@ -321,6 +320,79 @@ describe('saveWorkflowDefinition', () => {
             });
 
             expect(mutation.mutate).not.toHaveBeenCalled();
+            expect(mockWorkflowState.setWorkflow).not.toHaveBeenCalled();
+            expect(hasPendingSaves('workflow-1')).toBe(true);
+
+            mockWorkflowState = makeWorkflowState([{name: 'email_1', type: 'email/v1/send'}]);
+
+            setWorkflowMutating('workflow-1', false);
+
+            drainPendingSaves('workflow-1');
+
+            expect(mutation.mutate).toHaveBeenCalledTimes(1);
+
+            const savedDefinition = JSON.parse(
+                (mutation.mutate as ReturnType<typeof vi.fn>).mock.calls[0][0].workflow.definition
+            );
+
+            expect(savedDefinition.tasks.map((task: {name: string}) => task.name)).toEqual(['email_1', 'httpClient_1']);
+            expect(hasPendingSaves('workflow-1')).toBe(false);
+            expect(isWorkflowMutating('workflow-1')).toBe(true);
+        });
+
+        it('drains the next queued save when its own mutation settles', async () => {
+            mockWorkflowState = makeWorkflowState();
+
+            const mutation = makeMutation();
+
+            const {setWorkflowMutating} = await import('./workflowMutationGuard');
+
+            await saveWorkflowDefinition({
+                nodeData: {componentName: 'httpClient', name: 'httpClient_1', operationName: 'get', version: 1},
+                updateWorkflowMutation: mutation,
+            } as unknown as Parameters<typeof saveWorkflowDefinition>[0]);
+
+            expect(isWorkflowMutating('workflow-1')).toBe(true);
+
+            await saveWorkflowDefinition({
+                nodeData: {componentName: 'logger', name: 'logger_1', operationName: 'debug', version: 1},
+                updateWorkflowMutation: mutation,
+            } as unknown as Parameters<typeof saveWorkflowDefinition>[0]);
+
+            expect(mutation.mutate).toHaveBeenCalledTimes(1);
+
+            const firstCallbacks = (mutation.mutate as ReturnType<typeof vi.fn>).mock.calls[0][1];
+
+            firstCallbacks.onSettled();
+
+            expect(mutation.mutate).toHaveBeenCalledTimes(2);
+
+            const secondDefinition = JSON.parse(
+                (mutation.mutate as ReturnType<typeof vi.fn>).mock.calls[1][0].workflow.definition
+            );
+
+            expect(secondDefinition.tasks.map((task: {name: string}) => task.name)).toContain('logger_1');
+            expect(isWorkflowMutating('workflow-1')).toBe(true);
+
+            setWorkflowMutating('workflow-1', false);
+        });
+
+        it('drops a precomputed-tasks save while another mutation is in flight instead of replaying stale tasks', async () => {
+            mockWorkflowState = makeWorkflowState();
+
+            const mutation = makeMutation();
+
+            const {hasPendingSaves, setWorkflowMutating} = await import('./workflowMutationGuard');
+
+            setWorkflowMutating('workflow-1', true);
+
+            await saveWorkflowDefinition({
+                updateWorkflowMutation: mutation,
+                updatedWorkflowTasks: [{name: 'stale_1', type: 'logger/v1/debug'}],
+            });
+
+            expect(mutation.mutate).not.toHaveBeenCalled();
+            expect(hasPendingSaves('workflow-1')).toBe(false);
         });
 
         it('should set and clear mutation flag around mutate', async () => {

--- a/client/src/pages/platform/workflow-editor/utils/saveWorkflowDefinition.test.ts
+++ b/client/src/pages/platform/workflow-editor/utils/saveWorkflowDefinition.test.ts
@@ -619,6 +619,29 @@ describe('saveWorkflowDefinition', () => {
             expect(rolledBackWorkflow.id).toBe('workflow-1');
         });
 
+        it('calls onError after rolling back so the caller can undo what it did optimistically', async () => {
+            mockWorkflowState = makeWorkflowState();
+            const mutation = makeMutation();
+            const onError = vi.fn();
+
+            await saveWorkflowDefinition({
+                nodeData: {
+                    componentName: 'httpClient',
+                    name: 'httpClient_1',
+                    operationName: 'get',
+                    version: 1,
+                } as unknown as NodeDataType,
+                onError,
+                updateWorkflowMutation: mutation,
+            });
+
+            const callbacks = (mutation.mutate as ReturnType<typeof vi.fn>).mock.calls[0][1];
+
+            callbacks.onError(new Error('version conflict'));
+
+            expect(onError).toHaveBeenCalledOnce();
+        });
+
         it('should update store with server response on mutation success', async () => {
             mockWorkflowState = makeWorkflowState();
             const mutation = makeMutation();

--- a/client/src/pages/platform/workflow-editor/utils/saveWorkflowDefinition.ts
+++ b/client/src/pages/platform/workflow-editor/utils/saveWorkflowDefinition.ts
@@ -20,6 +20,7 @@ interface SaveWorkflowDefinitionProps {
     decorative?: boolean;
     nodeData?: NodeDataType;
     nodeIndex?: number;
+    onError?: () => void;
     onSuccess?: () => void;
     placeholderId?: string;
     taskDispatcherContext?: TaskDispatcherContextType;
@@ -32,6 +33,7 @@ export default async function saveWorkflowDefinition(props: SaveWorkflowDefiniti
         decorative,
         nodeData,
         nodeIndex,
+        onError,
         onSuccess,
         placeholderId,
         taskDispatcherContext,
@@ -100,6 +102,7 @@ export default async function saveWorkflowDefinition(props: SaveWorkflowDefiniti
 
         executeWorkflowMutation({
             definitionUpdate: {triggers: [newTrigger]},
+            onError,
             onSuccess: () => {
                 if (onSuccess) {
                     onSuccess();
@@ -284,6 +287,7 @@ export default async function saveWorkflowDefinition(props: SaveWorkflowDefiniti
     executeWorkflowMutation({
         definitionUpdate: {tasks: updatedWorkflowDefinitionTasks},
         newTask: existingWorkflowTask ? undefined : newTask,
+        onError,
         onSuccess,
         updateWorkflowMutation,
         workflow,
@@ -297,6 +301,7 @@ interface ExecuteWorkflowMutationProps {
         triggers?: Array<WorkflowTrigger>;
     };
     newTask?: WorkflowTask;
+    onError?: () => void;
     onSuccess?: () => void;
     updateWorkflowMutation: UpdateWorkflowMutationType;
     workflow: Workflow;
@@ -306,6 +311,7 @@ interface ExecuteWorkflowMutationProps {
 function executeWorkflowMutation({
     definitionUpdate,
     newTask,
+    onError,
     onSuccess,
     updateWorkflowMutation,
     workflow,
@@ -365,6 +371,10 @@ function executeWorkflowMutation({
                 console.error('Failed to save workflow definition:', error);
 
                 setWorkflowWithoutHistory(previousWorkflow);
+
+                if (onError) {
+                    onError();
+                }
             },
             onSettled: () => {
                 setWorkflowMutating(workflow.id!, false);

--- a/client/src/pages/platform/workflow-editor/utils/saveWorkflowDefinition.ts
+++ b/client/src/pages/platform/workflow-editor/utils/saveWorkflowDefinition.ts
@@ -14,7 +14,7 @@ import getRecursivelyUpdatedTasks from './getRecursivelyUpdatedTasks';
 import {getTask} from './getTask';
 import insertTaskDispatcherSubtask from './insertTaskDispatcherSubtask';
 import stringifyWorkflowDefinition from './stringifyWorkflowDefinition';
-import {isWorkflowMutating, setWorkflowMutating} from './workflowMutationGuard';
+import {drainPendingSaves, enqueuePendingSave, isWorkflowMutating, setWorkflowMutating} from './workflowMutationGuard';
 
 interface SaveWorkflowDefinitionProps {
     decorative?: boolean;
@@ -27,17 +27,33 @@ interface SaveWorkflowDefinitionProps {
     updatedWorkflowTasks?: Array<WorkflowTask>;
 }
 
-export default async function saveWorkflowDefinition({
-    decorative,
-    nodeData,
-    nodeIndex,
-    onSuccess,
-    placeholderId,
-    taskDispatcherContext,
-    updateWorkflowMutation,
-    updatedWorkflowTasks,
-}: SaveWorkflowDefinitionProps) {
+export default async function saveWorkflowDefinition(props: SaveWorkflowDefinitionProps) {
+    const {
+        decorative,
+        nodeData,
+        nodeIndex,
+        onSuccess,
+        placeholderId,
+        taskDispatcherContext,
+        updateWorkflowMutation,
+        updatedWorkflowTasks,
+    } = props;
+
     const {workflow} = useWorkflowDataStore.getState();
+
+    if (workflow.id && isWorkflowMutating(workflow.id)) {
+        if (updatedWorkflowTasks) {
+            console.warn('Dropped a workflow save with precomputed tasks while another save was in flight');
+
+            return;
+        }
+
+        enqueuePendingSave(workflow.id, () => {
+            saveWorkflowDefinition(props);
+        });
+
+        return;
+    }
 
     let workflowDefinition: WorkflowDefinitionType;
 
@@ -296,6 +312,8 @@ function executeWorkflowMutation({
     workflowDefinition,
 }: ExecuteWorkflowMutationProps) {
     if (isWorkflowMutating(workflow.id!)) {
+        console.warn('Dropped a workflow save that raced another save for the guard');
+
         return;
     }
 
@@ -350,6 +368,8 @@ function executeWorkflowMutation({
             },
             onSettled: () => {
                 setWorkflowMutating(workflow.id!, false);
+
+                drainPendingSaves(workflow.id!);
             },
             onSuccess: (updatedWorkflow) => {
                 useWorkflowDataStore.getState().setWorkflow({

--- a/client/src/pages/platform/workflow-editor/utils/saveWorkflowDefinitionUpdate.test.ts
+++ b/client/src/pages/platform/workflow-editor/utils/saveWorkflowDefinitionUpdate.test.ts
@@ -1,0 +1,172 @@
+import {SPACE} from '@/shared/constants';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+
+import saveWorkflowDefinitionUpdate from './saveWorkflowDefinitionUpdate';
+import {
+    clearAllWorkflowMutations,
+    drainPendingSaves,
+    hasPendingSaves,
+    isWorkflowMutating,
+    setWorkflowMutating,
+} from './workflowMutationGuard';
+
+let mockWorkflowState: ReturnType<typeof makeWorkflowState>;
+
+vi.mock('../stores/useWorkflowDataStore', () => ({
+    default: {
+        getState: () => mockWorkflowState,
+    },
+}));
+
+function makeWorkflowState(definition: Record<string, unknown>, version = 1) {
+    return {
+        setWorkflow: vi.fn(),
+        workflow: {
+            definition: JSON.stringify(definition, null, SPACE),
+            id: 'workflow-1',
+            version,
+        },
+    };
+}
+
+function makeMutation() {
+    return {mutate: vi.fn()} as unknown as Parameters<typeof saveWorkflowDefinitionUpdate>[0]['updateWorkflowMutation'];
+}
+
+function sentDefinition(mutation: ReturnType<typeof makeMutation>, call = 0) {
+    return JSON.parse((mutation.mutate as ReturnType<typeof vi.fn>).mock.calls[call][0].workflow.definition);
+}
+
+function sentVersion(mutation: ReturnType<typeof makeMutation>, call = 0) {
+    return (mutation.mutate as ReturnType<typeof vi.fn>).mock.calls[call][0].workflow.version;
+}
+
+function callbacks(mutation: ReturnType<typeof makeMutation>, call = 0) {
+    return (mutation.mutate as ReturnType<typeof vi.fn>).mock.calls[call][1];
+}
+
+describe('saveWorkflowDefinitionUpdate', () => {
+    beforeEach(() => {
+        mockWorkflowState = makeWorkflowState({inputs: [], tasks: []});
+    });
+
+    afterEach(() => {
+        clearAllWorkflowMutations();
+    });
+
+    it('takes the guard, sends the updated definition with the store version, and releases on settle', () => {
+        const mutation = makeMutation();
+
+        saveWorkflowDefinitionUpdate({
+            updateDefinition: (definition) => ({...definition, inputs: [{name: 'city', type: 'STRING'}]}),
+            updateWorkflowMutation: mutation,
+        });
+
+        expect(isWorkflowMutating('workflow-1')).toBe(true);
+        expect(sentDefinition(mutation).inputs).toEqual([{name: 'city', type: 'STRING'}]);
+        expect(sentVersion(mutation)).toBe(1);
+
+        callbacks(mutation).onSettled();
+
+        expect(isWorkflowMutating('workflow-1')).toBe(false);
+    });
+
+    it('queues itself while another save is in flight and rebuilds from the fresh definition at drain', () => {
+        const mutation = makeMutation();
+
+        setWorkflowMutating('workflow-1', true);
+
+        saveWorkflowDefinitionUpdate({
+            updateDefinition: (definition) => ({...definition, inputs: [{name: 'city', type: 'STRING'}]}),
+            updateWorkflowMutation: mutation,
+        });
+
+        expect(mutation.mutate).not.toHaveBeenCalled();
+        expect(hasPendingSaves('workflow-1')).toBe(true);
+
+        mockWorkflowState = makeWorkflowState({inputs: [], tasks: [{name: 'logger_1', type: 'logger/v1/debug'}]}, 2);
+
+        setWorkflowMutating('workflow-1', false);
+
+        drainPendingSaves('workflow-1');
+
+        expect(mutation.mutate).toHaveBeenCalledTimes(1);
+        expect(sentDefinition(mutation).tasks).toEqual([{name: 'logger_1', type: 'logger/v1/debug'}]);
+        expect(sentDefinition(mutation).inputs).toEqual([{name: 'city', type: 'STRING'}]);
+        expect(sentVersion(mutation)).toBe(2);
+        expect(isWorkflowMutating('workflow-1')).toBe(true);
+    });
+
+    it('drains the next queued save when its own mutation settles', () => {
+        const mutation = makeMutation();
+
+        saveWorkflowDefinitionUpdate({
+            updateDefinition: (definition) => ({...definition, inputs: [{name: 'first', type: 'STRING'}]}),
+            updateWorkflowMutation: mutation,
+        });
+
+        saveWorkflowDefinitionUpdate({
+            updateDefinition: (definition) => ({...definition, inputs: [{name: 'second', type: 'STRING'}]}),
+            updateWorkflowMutation: mutation,
+        });
+
+        expect(mutation.mutate).toHaveBeenCalledTimes(1);
+
+        callbacks(mutation).onSettled();
+
+        expect(mutation.mutate).toHaveBeenCalledTimes(2);
+        expect(sentDefinition(mutation, 1).inputs).toEqual([{name: 'second', type: 'STRING'}]);
+    });
+
+    it('saves nothing when the updater declines, e.g. the node it targets is gone from the fresh definition', () => {
+        const mutation = makeMutation();
+
+        saveWorkflowDefinitionUpdate({
+            updateDefinition: () => undefined,
+            updateWorkflowMutation: mutation,
+        });
+
+        expect(mutation.mutate).not.toHaveBeenCalled();
+        expect(isWorkflowMutating('workflow-1')).toBe(false);
+    });
+
+    it('puts the server response into the store on success, keeping the definition it sent', () => {
+        const mutation = makeMutation();
+        const onSuccess = vi.fn();
+
+        saveWorkflowDefinitionUpdate({
+            onSuccess,
+            updateDefinition: (definition) => ({...definition, inputs: [{name: 'city', type: 'STRING'}]}),
+            updateWorkflowMutation: mutation,
+        });
+
+        const updatedWorkflow = {id: 'workflow-1', inputs: [{name: 'city', type: 'STRING'}], version: 2};
+
+        callbacks(mutation).onSuccess(updatedWorkflow);
+
+        expect(mockWorkflowState.setWorkflow).toHaveBeenCalledOnce();
+
+        const storedWorkflow = mockWorkflowState.setWorkflow.mock.calls[0][0];
+
+        expect(storedWorkflow.version).toBe(2);
+        expect(storedWorkflow.inputs).toEqual([{name: 'city', type: 'STRING'}]);
+        expect(JSON.parse(storedWorkflow.definition).inputs).toEqual([{name: 'city', type: 'STRING'}]);
+        expect(onSuccess).toHaveBeenCalledWith(updatedWorkflow);
+    });
+
+    it('forwards a failure to onError and leaves the store alone', () => {
+        const mutation = makeMutation();
+        const onError = vi.fn();
+
+        saveWorkflowDefinitionUpdate({
+            onError,
+            updateDefinition: (definition) => definition,
+            updateWorkflowMutation: mutation,
+        });
+
+        callbacks(mutation).onError(new Error('version conflict'));
+
+        expect(onError).toHaveBeenCalledOnce();
+        expect(mockWorkflowState.setWorkflow).not.toHaveBeenCalled();
+    });
+});

--- a/client/src/pages/platform/workflow-editor/utils/saveWorkflowDefinitionUpdate.test.ts
+++ b/client/src/pages/platform/workflow-editor/utils/saveWorkflowDefinitionUpdate.test.ts
@@ -169,4 +169,36 @@ describe('saveWorkflowDefinitionUpdate', () => {
         expect(onError).toHaveBeenCalledOnce();
         expect(mockWorkflowState.setWorkflow).not.toHaveBeenCalled();
     });
+
+    it('saves nothing before the store holds a workflow', () => {
+        mockWorkflowState = makeWorkflowState({tasks: []});
+        mockWorkflowState.workflow = {...mockWorkflowState.workflow, id: ''};
+
+        const mutation = makeMutation();
+
+        saveWorkflowDefinitionUpdate({
+            updateDefinition: (definition) => definition,
+            updateWorkflowMutation: mutation,
+        });
+
+        expect(mutation.mutate).not.toHaveBeenCalled();
+    });
+
+    it('saves nothing when the stored definition is not valid JSON', () => {
+        mockWorkflowState = makeWorkflowState({tasks: []});
+        mockWorkflowState.workflow = {...mockWorkflowState.workflow, definition: '{not json'};
+
+        const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+        const mutation = makeMutation();
+
+        saveWorkflowDefinitionUpdate({
+            updateDefinition: (definition) => definition,
+            updateWorkflowMutation: mutation,
+        });
+
+        expect(mutation.mutate).not.toHaveBeenCalled();
+        expect(isWorkflowMutating('workflow-1')).toBe(false);
+
+        consoleError.mockRestore();
+    });
 });

--- a/client/src/pages/platform/workflow-editor/utils/saveWorkflowDefinitionUpdate.ts
+++ b/client/src/pages/platform/workflow-editor/utils/saveWorkflowDefinitionUpdate.ts
@@ -1,0 +1,84 @@
+import {Workflow} from '@/shared/middleware/platform/configuration';
+import {UpdateWorkflowMutationType, WorkflowDefinitionType} from '@/shared/types';
+
+import useWorkflowDataStore from '../stores/useWorkflowDataStore';
+import stringifyWorkflowDefinition from './stringifyWorkflowDefinition';
+import {drainPendingSaves, enqueuePendingSave, isWorkflowMutating, setWorkflowMutating} from './workflowMutationGuard';
+
+interface SaveWorkflowDefinitionUpdateProps {
+    onError?: (error: Error) => void;
+    onSuccess?: (updatedWorkflow: Workflow) => void;
+    updateDefinition: (workflowDefinition: WorkflowDefinitionType) => WorkflowDefinitionType | undefined;
+    updateWorkflowMutation: UpdateWorkflowMutationType;
+}
+
+export default function saveWorkflowDefinitionUpdate(props: SaveWorkflowDefinitionUpdateProps): void {
+    const {onError, onSuccess, updateDefinition, updateWorkflowMutation} = props;
+
+    const {workflow} = useWorkflowDataStore.getState();
+
+    if (!workflow.id || !workflow.definition) {
+        return;
+    }
+
+    if (isWorkflowMutating(workflow.id)) {
+        enqueuePendingSave(workflow.id, () => saveWorkflowDefinitionUpdate(props));
+
+        return;
+    }
+
+    let workflowDefinition: WorkflowDefinitionType;
+
+    try {
+        workflowDefinition = JSON.parse(workflow.definition);
+    } catch (error) {
+        console.error('Failed to parse workflow definition:', error);
+
+        return;
+    }
+
+    const updatedWorkflowDefinition = updateDefinition(workflowDefinition);
+
+    if (!updatedWorkflowDefinition) {
+        return;
+    }
+
+    const definition = stringifyWorkflowDefinition(updatedWorkflowDefinition);
+    const workflowId = workflow.id;
+
+    setWorkflowMutating(workflowId, true);
+
+    updateWorkflowMutation.mutate(
+        {
+            id: workflowId,
+            workflow: {
+                definition,
+                version: workflow.version,
+            },
+        },
+        {
+            onError: (error) => {
+                console.error('Failed to save workflow definition:', error);
+
+                if (onError) {
+                    onError(error);
+                }
+            },
+            onSettled: () => {
+                setWorkflowMutating(workflowId, false);
+
+                drainPendingSaves(workflowId);
+            },
+            onSuccess: (updatedWorkflow) => {
+                useWorkflowDataStore.getState().setWorkflow({
+                    ...updatedWorkflow,
+                    definition,
+                });
+
+                if (onSuccess) {
+                    onSuccess(updatedWorkflow);
+                }
+            },
+        }
+    );
+}

--- a/client/src/pages/platform/workflow-editor/utils/saveWorkflowNodesPosition.ts
+++ b/client/src/pages/platform/workflow-editor/utils/saveWorkflowNodesPosition.ts
@@ -6,6 +6,7 @@ import useWorkflowDataStore, {runWithoutHistory} from '../stores/useWorkflowData
 import stringifyWorkflowDefinition from './stringifyWorkflowDefinition';
 import {
     consumePendingDefinition,
+    drainPendingSaves,
     isWorkflowMutating,
     setPendingDefinition,
     setWorkflowMutating,
@@ -345,6 +346,8 @@ function firePositionMutation({
                         version: currentWorkflow.version,
                         workflowId,
                     });
+                } else {
+                    drainPendingSaves(workflowId);
                 }
             },
             onSuccess: (updatedWorkflow) => {

--- a/client/src/pages/platform/workflow-editor/utils/tests/handleComponentAddedSuccess.test.ts
+++ b/client/src/pages/platform/workflow-editor/utils/tests/handleComponentAddedSuccess.test.ts
@@ -24,7 +24,7 @@ describe('openNodeDetailsPanelForNewNode', () => {
         useWorkflowNodeDetailsPanelStore.setState({
             activeTab: 'description',
             currentNode: undefined,
-            pendingSaveNodeName: undefined,
+            pendingSaveNodeNames: new Set<string>(),
             workflowNodeDetailsPanelOpen: false,
         });
     });
@@ -45,7 +45,28 @@ describe('openNodeDetailsPanelForNewNode', () => {
     it('should mark the new node as pending its first save so node-scoped queries wait for persistence', () => {
         openNodeDetailsPanelForNewNode(makeNodeData());
 
-        expect(useWorkflowNodeDetailsPanelStore.getState().pendingSaveNodeName).toBe('slack_1');
+        expect(useWorkflowNodeDetailsPanelStore.getState().pendingSaveNodeNames.has('slack_1')).toBe(true);
+    });
+
+    it('keeps the first node pending when a second node is added before the first save lands', () => {
+        openNodeDetailsPanelForNewNode(makeNodeData({name: 'slack_1'}));
+        openNodeDetailsPanelForNewNode(makeNodeData({componentName: 'logger', name: 'logger_1'}));
+
+        const {pendingSaveNodeNames} = useWorkflowNodeDetailsPanelStore.getState();
+
+        expect(pendingSaveNodeNames.has('slack_1')).toBe(true);
+        expect(pendingSaveNodeNames.has('logger_1')).toBe(true);
+
+        handleComponentAddedSuccess({
+            nodeData: makeNodeData({componentName: 'logger', name: 'logger_1'}),
+            queryClient: new QueryClient(),
+            workflow: {id: 'workflow_1'} as Workflow,
+        });
+
+        const afterSecondSave = useWorkflowNodeDetailsPanelStore.getState().pendingSaveNodeNames;
+
+        expect(afterSecondSave.has('slack_1')).toBe(true);
+        expect(afterSecondSave.has('logger_1')).toBe(false);
     });
 
     it('should reset activeTab to description when opening the panel for a new node', () => {
@@ -86,7 +107,7 @@ describe('openNodeDetailsPanelForNewNode', () => {
     });
 
     it('should clear the pending-save marker when the added node is confirmed persisted', () => {
-        useWorkflowNodeDetailsPanelStore.setState({pendingSaveNodeName: 'slack_1'});
+        useWorkflowNodeDetailsPanelStore.setState({pendingSaveNodeNames: new Set(['slack_1'])});
 
         handleComponentAddedSuccess({
             nodeData: makeNodeData(),
@@ -94,11 +115,11 @@ describe('openNodeDetailsPanelForNewNode', () => {
             workflow: {id: 'workflow_1'} as Workflow,
         });
 
-        expect(useWorkflowNodeDetailsPanelStore.getState().pendingSaveNodeName).toBeUndefined();
+        expect(useWorkflowNodeDetailsPanelStore.getState().pendingSaveNodeNames.has('slack_1')).toBe(false);
     });
 
     it('should not clear the pending-save marker of a different node still awaiting its save', () => {
-        useWorkflowNodeDetailsPanelStore.setState({pendingSaveNodeName: 'accelo_1'});
+        useWorkflowNodeDetailsPanelStore.setState({pendingSaveNodeNames: new Set(['accelo_1'])});
 
         handleComponentAddedSuccess({
             nodeData: makeNodeData({name: 'slack_1'}),
@@ -106,7 +127,15 @@ describe('openNodeDetailsPanelForNewNode', () => {
             workflow: {id: 'workflow_1'} as Workflow,
         });
 
-        expect(useWorkflowNodeDetailsPanelStore.getState().pendingSaveNodeName).toBe('accelo_1');
+        expect(useWorkflowNodeDetailsPanelStore.getState().pendingSaveNodeNames.has('accelo_1')).toBe(true);
+    });
+
+    it('keeps the pending-save markers when the panel is reset, since they track saves rather than the panel', () => {
+        openNodeDetailsPanelForNewNode(makeNodeData());
+
+        useWorkflowNodeDetailsPanelStore.getState().reset();
+
+        expect(useWorkflowNodeDetailsPanelStore.getState().pendingSaveNodeNames.has('slack_1')).toBe(true);
     });
 
     it('should update panel when replacing a trigger while panel is open', () => {

--- a/client/src/pages/platform/workflow-editor/utils/tests/handleComponentAddedSuccess.test.ts
+++ b/client/src/pages/platform/workflow-editor/utils/tests/handleComponentAddedSuccess.test.ts
@@ -163,6 +163,17 @@ describe('openNodeDetailsPanelForNewNode', () => {
             expect(state.currentNode).toBeUndefined();
         });
 
+        it('does nothing for a node that never got a name', () => {
+            openNodeDetailsPanelForNewNode(makeNodeData());
+
+            handleComponentAddedError({nodeData: makeNodeData({name: undefined})});
+
+            const state = useWorkflowNodeDetailsPanelStore.getState();
+
+            expect(state.pendingSaveNodeNames.has('slack_1')).toBe(true);
+            expect(state.workflowNodeDetailsPanelOpen).toBe(true);
+        });
+
         it('leaves the panel alone when it shows a different node', () => {
             openNodeDetailsPanelForNewNode(makeNodeData({componentName: 'http', name: 'http_1'}));
             openNodeDetailsPanelForNewNode(makeNodeData());

--- a/client/src/pages/platform/workflow-editor/utils/tests/handleComponentAddedSuccess.test.ts
+++ b/client/src/pages/platform/workflow-editor/utils/tests/handleComponentAddedSuccess.test.ts
@@ -138,6 +138,15 @@ describe('openNodeDetailsPanelForNewNode', () => {
         expect(useWorkflowNodeDetailsPanelStore.getState().pendingSaveNodeNames.has('slack_1')).toBe(true);
     });
 
+    it('drops every marker when the editor asks for an explicit clear, e.g. on a workflow switch', () => {
+        openNodeDetailsPanelForNewNode(makeNodeData({name: 'slack_1'}));
+        openNodeDetailsPanelForNewNode(makeNodeData({componentName: 'logger', name: 'logger_1'}));
+
+        useWorkflowNodeDetailsPanelStore.getState().clearPendingSaveNodeNames();
+
+        expect(useWorkflowNodeDetailsPanelStore.getState().pendingSaveNodeNames.size).toBe(0);
+    });
+
     it('should update panel when replacing a trigger while panel is open', () => {
         const existingTrigger = makeNodeData({
             componentName: 'manual',

--- a/client/src/pages/platform/workflow-editor/utils/tests/handleComponentAddedSuccess.test.ts
+++ b/client/src/pages/platform/workflow-editor/utils/tests/handleComponentAddedSuccess.test.ts
@@ -4,7 +4,10 @@ import {NodeDataType} from '@/shared/types';
 import {QueryClient} from '@tanstack/react-query';
 import {beforeEach, describe, expect, it} from 'vitest';
 
-import handleComponentAddedSuccess, {openNodeDetailsPanelForNewNode} from '../handleComponentAddedSuccess';
+import handleComponentAddedSuccess, {
+    handleComponentAddedError,
+    openNodeDetailsPanelForNewNode,
+} from '../handleComponentAddedSuccess';
 
 const makeNodeData = (overrides: Partial<NodeDataType> = {}): NodeDataType =>
     ({
@@ -145,6 +148,34 @@ describe('openNodeDetailsPanelForNewNode', () => {
         useWorkflowNodeDetailsPanelStore.getState().clearPendingSaveNodeNames();
 
         expect(useWorkflowNodeDetailsPanelStore.getState().pendingSaveNodeNames.size).toBe(0);
+    });
+
+    describe('handleComponentAddedError', () => {
+        it('releases the marker and closes the panel that was opened optimistically for the node', () => {
+            openNodeDetailsPanelForNewNode(makeNodeData());
+
+            handleComponentAddedError({nodeData: makeNodeData()});
+
+            const state = useWorkflowNodeDetailsPanelStore.getState();
+
+            expect(state.pendingSaveNodeNames.has('slack_1')).toBe(false);
+            expect(state.workflowNodeDetailsPanelOpen).toBe(false);
+            expect(state.currentNode).toBeUndefined();
+        });
+
+        it('leaves the panel alone when it shows a different node', () => {
+            openNodeDetailsPanelForNewNode(makeNodeData({componentName: 'http', name: 'http_1'}));
+            openNodeDetailsPanelForNewNode(makeNodeData());
+
+            handleComponentAddedError({nodeData: makeNodeData()});
+
+            const state = useWorkflowNodeDetailsPanelStore.getState();
+
+            expect(state.pendingSaveNodeNames.has('slack_1')).toBe(false);
+            expect(state.pendingSaveNodeNames.has('http_1')).toBe(true);
+            expect(state.workflowNodeDetailsPanelOpen).toBe(true);
+            expect(state.currentNode?.name).toBe('http_1');
+        });
     });
 
     it('should update panel when replacing a trigger while panel is open', () => {

--- a/client/src/pages/platform/workflow-editor/utils/tests/handleTaskDispatcherSubtaskOperationClick.test.tsx
+++ b/client/src/pages/platform/workflow-editor/utils/tests/handleTaskDispatcherSubtaskOperationClick.test.tsx
@@ -63,7 +63,7 @@ describe('handleTaskDispatcherSubtaskOperationClick', () => {
         useWorkflowNodeDetailsPanelStore.setState({
             activeTab: 'description',
             currentNode: undefined,
-            pendingSaveNodeName: undefined,
+            pendingSaveNodeNames: new Set<string>(),
             workflowNodeDetailsPanelOpen: false,
         });
     });

--- a/client/src/pages/platform/workflow-editor/utils/tests/handleTaskDispatcherSubtaskOperationClick.test.tsx
+++ b/client/src/pages/platform/workflow-editor/utils/tests/handleTaskDispatcherSubtaskOperationClick.test.tsx
@@ -88,4 +88,17 @@ describe('handleTaskDispatcherSubtaskOperationClick', () => {
 
         expect(nodeData.clusterElements).toEqual({});
     });
+
+    it('closes the optimistically opened panel when the add fails', () => {
+        callHandler(false);
+
+        expect(useWorkflowNodeDetailsPanelStore.getState().workflowNodeDetailsPanelOpen).toBe(true);
+
+        const {onError} = saveWorkflowDefinitionMock.mock.calls[0][0] as {onError: () => void};
+
+        onError();
+
+        expect(useWorkflowNodeDetailsPanelStore.getState().workflowNodeDetailsPanelOpen).toBe(false);
+        expect(useWorkflowNodeDetailsPanelStore.getState().currentNode).toBeUndefined();
+    });
 });

--- a/client/src/pages/platform/workflow-editor/utils/tests/saveTaskDispatcherSubtaskFieldChange.test.ts
+++ b/client/src/pages/platform/workflow-editor/utils/tests/saveTaskDispatcherSubtaskFieldChange.test.ts
@@ -1,0 +1,97 @@
+import {ComponentDefinition} from '@/shared/middleware/platform/configuration';
+import {UpdateWorkflowMutationType} from '@/shared/types';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+
+import saveTaskDispatcherSubtaskFieldChange from '../saveTaskDispatcherSubtaskFieldChange';
+import {
+    clearAllWorkflowMutations,
+    drainPendingSaves,
+    hasPendingSaves,
+    setWorkflowMutating,
+} from '../workflowMutationGuard';
+
+const {panelState, saveWorkflowDefinitionMock, workflowDataState} = vi.hoisted(() => ({
+    panelState: {
+        currentNode: undefined as Record<string, unknown> | undefined,
+        setCurrentNode: vi.fn(),
+        setOperationChangeInProgress: vi.fn(),
+    },
+    saveWorkflowDefinitionMock: vi.fn(),
+    workflowDataState: {
+        workflow: {definition: undefined as string | undefined, id: 'workflow-1' as string | undefined},
+    },
+}));
+
+vi.mock('../../stores/useWorkflowNodeDetailsPanelStore', () => ({
+    default: {getState: () => panelState},
+}));
+
+vi.mock('../../stores/useWorkflowDataStore', () => ({
+    default: {getState: () => workflowDataState},
+}));
+
+vi.mock('../saveWorkflowDefinition', () => ({default: saveWorkflowDefinitionMock}));
+
+function callSave() {
+    saveTaskDispatcherSubtaskFieldChange({
+        currentComponentDefinition: {name: 'logger', version: 1} as ComponentDefinition,
+        currentNodeIndex: 0,
+        fieldUpdate: {field: 'label', value: 'Renamed'},
+        updateWorkflowMutation: {mutate: vi.fn()} as unknown as UpdateWorkflowMutationType,
+    });
+}
+
+describe('saveTaskDispatcherSubtaskFieldChange', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+
+        panelState.currentNode = {
+            componentName: 'logger',
+            conditionData: {conditionCase: 'caseTrue', conditionId: 'condition_1'},
+            name: 'logger_1',
+            workflowNodeName: 'logger_1',
+        };
+
+        workflowDataState.workflow = {
+            definition: JSON.stringify({tasks: [{name: 'condition_1', type: 'condition/v1'}]}),
+            id: 'workflow-1',
+        };
+    });
+
+    afterEach(() => {
+        clearAllWorkflowMutations();
+    });
+
+    it('saves nothing when no node is focused', () => {
+        panelState.currentNode = undefined;
+
+        callSave();
+
+        expect(saveWorkflowDefinitionMock).not.toHaveBeenCalled();
+        expect(hasPendingSaves('workflow-1')).toBe(false);
+    });
+
+    it('queues a re-run of itself while another save is in flight', () => {
+        // The task list it hands to saveWorkflowDefinition is precomputed from the definition read at call
+        // time, so it must be rebuilt at drain time rather than replayed.
+        setWorkflowMutating('workflow-1', true);
+
+        callSave();
+
+        expect(saveWorkflowDefinitionMock).not.toHaveBeenCalled();
+        expect(hasPendingSaves('workflow-1')).toBe(true);
+
+        setWorkflowMutating('workflow-1', false);
+
+        drainPendingSaves('workflow-1');
+
+        expect(hasPendingSaves('workflow-1')).toBe(false);
+    });
+
+    it('saves straight through when no other save holds the guard', () => {
+        callSave();
+
+        expect(saveWorkflowDefinitionMock).toHaveBeenCalledOnce();
+        expect(hasPendingSaves('workflow-1')).toBe(false);
+    });
+});

--- a/client/src/pages/platform/workflow-editor/utils/workflowMutationGuard.test.ts
+++ b/client/src/pages/platform/workflow-editor/utils/workflowMutationGuard.test.ts
@@ -3,7 +3,10 @@ import {afterEach, describe, expect, it} from 'vitest';
 import {
     clearAllWorkflowMutations,
     consumePendingDefinition,
+    drainPendingSaves,
+    enqueuePendingSave,
     hasPendingDefinition,
+    hasPendingSaves,
     isWorkflowMutating,
     setPendingDefinition,
     setWorkflowMutating,
@@ -58,6 +61,78 @@ describe('workflowMutationGuard', () => {
         expect(isWorkflowMutating('workflow-1')).toBe(false);
         expect(isWorkflowMutating('workflow-2')).toBe(false);
         expect(isWorkflowMutating()).toBe(false);
+    });
+
+    describe('pending saves queue', () => {
+        it('reports no pending saves initially', () => {
+            expect(hasPendingSaves('workflow-1')).toBe(false);
+        });
+
+        it('runs queued saves in the order they were enqueued and empties the queue', () => {
+            const order: Array<string> = [];
+
+            enqueuePendingSave('workflow-1', () => order.push('first'));
+            enqueuePendingSave('workflow-1', () => order.push('second'));
+
+            expect(hasPendingSaves('workflow-1')).toBe(true);
+
+            drainPendingSaves('workflow-1');
+
+            expect(order).toEqual(['first', 'second']);
+            expect(hasPendingSaves('workflow-1')).toBe(false);
+        });
+
+        it('lets a drained save re-enqueue itself behind the save that fired before it', () => {
+            const order: Array<string> = [];
+
+            enqueuePendingSave('workflow-1', () => {
+                setWorkflowMutating('workflow-1', true);
+
+                order.push('first');
+            });
+
+            enqueuePendingSave('workflow-1', () => {
+                if (isWorkflowMutating('workflow-1')) {
+                    enqueuePendingSave('workflow-1', () => order.push('second'));
+
+                    return;
+                }
+
+                order.push('second');
+            });
+
+            drainPendingSaves('workflow-1');
+
+            expect(order).toEqual(['first']);
+            expect(hasPendingSaves('workflow-1')).toBe(true);
+
+            setWorkflowMutating('workflow-1', false);
+
+            drainPendingSaves('workflow-1');
+
+            expect(order).toEqual(['first', 'second']);
+            expect(hasPendingSaves('workflow-1')).toBe(false);
+        });
+
+        it('isolates pending saves per workflow', () => {
+            const order: Array<string> = [];
+
+            enqueuePendingSave('workflow-1', () => order.push('one'));
+            enqueuePendingSave('workflow-2', () => order.push('two'));
+
+            drainPendingSaves('workflow-2');
+
+            expect(order).toEqual(['two']);
+            expect(hasPendingSaves('workflow-1')).toBe(true);
+        });
+
+        it('clears pending saves along with mutation flags', () => {
+            enqueuePendingSave('workflow-1', () => undefined);
+
+            clearAllWorkflowMutations();
+
+            expect(hasPendingSaves('workflow-1')).toBe(false);
+        });
     });
 
     describe('pending definition queue', () => {

--- a/client/src/pages/platform/workflow-editor/utils/workflowMutationGuard.ts
+++ b/client/src/pages/platform/workflow-editor/utils/workflowMutationGuard.ts
@@ -28,6 +28,8 @@ const mutatingWorkflows = new Set<string>();
  */
 const pendingDefinitions = new Map<string, string>();
 
+const pendingSaves = new Map<string, Array<() => void>>();
+
 export function isWorkflowMutating(workflowId?: string): boolean {
     if (!workflowId) {
         return mutatingWorkflows.size > 0;
@@ -60,6 +62,34 @@ export function consumePendingDefinition(workflowId: string): string | undefined
     return definition;
 }
 
+export function enqueuePendingSave(workflowId: string, save: () => void): void {
+    const saves = pendingSaves.get(workflowId) ?? [];
+
+    saves.push(save);
+
+    pendingSaves.set(workflowId, saves);
+}
+
+export function hasPendingSaves(workflowId: string): boolean {
+    return !!pendingSaves.get(workflowId)?.length;
+}
+
+export function drainPendingSaves(workflowId: string): void {
+    const saves = pendingSaves.get(workflowId);
+
+    if (!saves?.length) {
+        return;
+    }
+
+    pendingSaves.delete(workflowId);
+
+    for (const save of saves) {
+        save();
+    }
+}
+
+/**
+ */
 /**
  * Clears all mutation flags and pending definitions. Useful for cleanup
  * when a workflow editor unmounts to prevent stale flags from blocking
@@ -68,6 +98,7 @@ export function consumePendingDefinition(workflowId: string): string | undefined
 export function clearAllWorkflowMutations(): void {
     mutatingWorkflows.clear();
     pendingDefinitions.clear();
+    pendingSaves.clear();
 }
 
 interface DrainPendingMutationProps {

--- a/client/src/pages/platform/workflow-editor/utils/workflowMutationGuard.ts
+++ b/client/src/pages/platform/workflow-editor/utils/workflowMutationGuard.ts
@@ -125,6 +125,8 @@ export function drainPendingDefinitionMutation({
     const pendingDefinition = consumePendingDefinition(workflowId);
 
     if (!pendingDefinition) {
+        drainPendingSaves(workflowId);
+
         return;
     }
 

--- a/client/src/pages/platform/workflow-editor/utils/workflowMutationGuard.ts
+++ b/client/src/pages/platform/workflow-editor/utils/workflowMutationGuard.ts
@@ -89,8 +89,6 @@ export function drainPendingSaves(workflowId: string): void {
 }
 
 /**
- */
-/**
  * Clears all mutation flags and pending definitions. Useful for cleanup
  * when a workflow editor unmounts to prevent stale flags from blocking
  * future saves.


### PR DESCRIPTION
Fixes #5632

## The bug

Two failures with one shared cause: the workflow editor's per-workflow mutation guard was not
respected by every save.

**"Workflow node with name: X does not exist" toast.** The node details panel opens
optimistically for a freshly added node, before its save reaches the server. Its by-name
requests (display conditions, missing required properties, hidden-property default saves,
parameter saves) then resolve against the stale server definition and 400. Reproduced by
holding the add PUT for a few seconds and opening the Properties tab.

**A jammed guard.** Five surfaces persisted a definition straight through
`updateWorkflowMutation.mutate`, past the guard every canvas save takes. TanStack Query v5
detaches the observer from the previous mutation on every `mutate` call, so one of those firing
while a guarded save was in flight dropped that save's own callbacks. The guard then stayed set
until the editor unmounted, and every later save was dropped or queued forever.

## What changed

**Queue instead of drop.** `executeWorkflowMutation` used to return early when the guard was
set, losing the edit silently. A save now re-runs itself from the store once the in-flight save
settles, so it is rebuilt from the definition that save left behind and sends that version.
Callers that hand over a precomputed task list re-run themselves for the same reason. Every
guard release drains the queue.

**One marker per added node.** The panel held its by-name queries behind a single pending-save
name, so a second add released the first node's queries early, and the panel store's `reset`
wiped the name on every panel close and delete. It is now a set with one entry per node; `reset`
leaves it alone, and the set is cleared where a stale name could collide with a same-named node
in the next workflow. A failed add or a delete releases its own entry.

**A guarded save for the surfaces outside the canvas.** `saveWorkflowDefinitionUpdate` is now
the only way the outputs sheet, the inputs sheet, the code editor sheet and the property code
editor's connections persist a definition. It reads the fresh workflow from the store, takes the
guard, applies the caller's updater to the fresh definition, sends the fresh version, and
releases and drains on settle.

## Testing

`npm run check` passes: prettier, eslint, tsc and 4023 tests across 377 files. Every commit
type-checks on its own. New coverage for the guard queue, the marker lifecycle, the failure and
delete paths, and the new guarded save.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
