### PR TITLE
5634 client - Drop the horizontal scrollbars from nested subflow execution tables

### DIFF
--- a/client/src/pages/automation/workflow-executions/components/WorkflowExecutionsTable.tsx
+++ b/client/src/pages/automation/workflow-executions/components/WorkflowExecutionsTable.tsx
@@ -178,10 +178,10 @@ const ExecutionRows = ({
 
                     {expandable && expanded && (
                         <TableRow className="border-0 even:bg-surface-neutral-primary">
-                            <TableCell className="p-0" colSpan={columns.length + 1}>
+                            <TableCell className="py-0 pr-0 pl-9" colSpan={columns.length + 1}>
                                 <Table
                                     className={twMerge(
-                                        'ml-9 border border-stroke-brand-secondary',
+                                        'border border-stroke-brand-secondary',
                                         depth > 0 && 'border-r-0 border-b-0'
                                     )}
                                 >


### PR DESCRIPTION
Fixes #5634.

## What

Expanding an execution with subflows on the Workflow Executions page drew a horizontal scrollbar under every nested subflow table — one per nesting level — and clipped the `Actions` column to `Acti`, even on a wide viewport.

## Why

The shadcn `Table` wraps every `<table class="w-full">` in a `<div class="overflow-x-auto w-full">`. The nested subflow table carried its 36px indent as `ml-9` on the table itself, making it `100% + 2.25rem` wide inside a 100% wrapper; `overflow-x-auto` then showed a scrollbar for exactly that 36px of self-inflicted overflow.

## How

Move the indent from `ml-9` on the nested `Table` to `pl-9` on the `TableCell` that hosts it, so the table's `w-full` resolves against a box that already accounts for the indent. Borders and per-depth styling are unchanged.

## Verification

- `eslint`, `prettier --check` and `tsc --noEmit` pass on the client.
- A standalone repro of the same `div.overflow-x-auto > table.w-full` structure nested three deep measures `scrollWidth − clientWidth` per wrapper: nested levels go from `[36, 36]` before to `[0, 0]` after, while the outer table's genuine narrow-viewport overflow is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)