### PR TITLE
5651 Make the dynamic webhook trigger refresh actually run under Quartz

### DIFF
--- a/server/libs/platform/platform-scheduler/platform-scheduler-impl/src/main/java/com/bytechef/platform/scheduler/QuartzTriggerScheduler.java
+++ b/server/libs/platform/platform-scheduler/platform-scheduler-impl/src/main/java/com/bytechef/platform/scheduler/QuartzTriggerScheduler.java
@@ -16,6 +16,12 @@
 
 package com.bytechef.platform.scheduler;
 
+import static com.bytechef.platform.scheduler.constant.QuartzTriggerSchedulerConstants.CONNECTION_ID;
+import static com.bytechef.platform.scheduler.constant.QuartzTriggerSchedulerConstants.DYNAMIC_WEBHOOK_TRIGGER_REFRESH;
+import static com.bytechef.platform.scheduler.constant.QuartzTriggerSchedulerConstants.ONE_TIME_TASK;
+import static com.bytechef.platform.scheduler.constant.QuartzTriggerSchedulerConstants.POLLING_TRIGGER;
+import static com.bytechef.platform.scheduler.constant.QuartzTriggerSchedulerConstants.SCHEDULE_TRIGGER;
+
 import com.bytechef.commons.util.JsonUtils;
 import com.bytechef.config.ApplicationProperties;
 import com.bytechef.platform.scheduler.job.DynamicWebhookTriggerRefreshJob;
@@ -61,17 +67,17 @@ public class QuartzTriggerScheduler implements TriggerScheduler {
     }
 
     public void cancelDynamicWebhookTriggerRefresh(String workflowExecutionId) {
-        deleteJob(workflowExecutionId, "DynamicWebhookTriggerRefresh");
+        deleteJob(workflowExecutionId, DYNAMIC_WEBHOOK_TRIGGER_REFRESH);
     }
 
     @Override
     public void cancelScheduleTrigger(String workflowExecutionId) {
-        deleteJob(workflowExecutionId, "ScheduleTrigger");
+        deleteJob(workflowExecutionId, SCHEDULE_TRIGGER);
     }
 
     @Override
     public void cancelPollingTrigger(String workflowExecutionId) {
-        deleteJob(workflowExecutionId, "PollingTrigger");
+        deleteJob(workflowExecutionId, POLLING_TRIGGER);
     }
 
     @Override
@@ -80,13 +86,13 @@ public class QuartzTriggerScheduler implements TriggerScheduler {
         WorkflowExecutionId workflowExecutionId, Long connectionId) {
 
         JobDetail jobDetail = JobBuilder.newJob(DynamicWebhookTriggerRefreshJob.class)
-            .withIdentity(JobKey.jobKey(workflowExecutionId.toString(), "ScheduleTrigger"))
+            .withIdentity(JobKey.jobKey(workflowExecutionId.toString(), DYNAMIC_WEBHOOK_TRIGGER_REFRESH))
             .usingJobData("workflowExecutionId", workflowExecutionId.toString())
-            .usingJobData("connectionId", connectionId)
+            .usingJobData(CONNECTION_ID, connectionId)
             .build();
 
         Trigger trigger = TriggerBuilder.newTrigger()
-            .withIdentity(TriggerKey.triggerKey(workflowExecutionId.toString(), "ScheduleTrigger"))
+            .withIdentity(TriggerKey.triggerKey(workflowExecutionId.toString(), DYNAMIC_WEBHOOK_TRIGGER_REFRESH))
             .startAt(Date.from(webhookExpirationDate))
             .build();
 
@@ -98,7 +104,7 @@ public class QuartzTriggerScheduler implements TriggerScheduler {
         String pattern, String zoneId, Map<String, Object> output, WorkflowExecutionId workflowExecutionId) {
 
         JobDetail jobDetail = JobBuilder.newJob(ScheduleTriggerJob.class)
-            .withIdentity(JobKey.jobKey(workflowExecutionId.toString(), "ScheduleTrigger"))
+            .withIdentity(JobKey.jobKey(workflowExecutionId.toString(), SCHEDULE_TRIGGER))
             .usingJobData("output", JsonUtils.write(output))
             .usingJobData("workflowExecutionId", workflowExecutionId.toString())
             .build();
@@ -107,7 +113,7 @@ public class QuartzTriggerScheduler implements TriggerScheduler {
             .inTimeZone(TimeZone.getTimeZone(ZoneId.of(zoneId)));
 
         Trigger trigger = TriggerBuilder.newTrigger()
-            .withIdentity(TriggerKey.triggerKey(workflowExecutionId.toString(), "ScheduleTrigger"))
+            .withIdentity(TriggerKey.triggerKey(workflowExecutionId.toString(), SCHEDULE_TRIGGER))
             .withSchedule(cronScheduleBuilder)
             .startNow()
             .build();
@@ -118,12 +124,12 @@ public class QuartzTriggerScheduler implements TriggerScheduler {
     @Override
     public void schedulePollingTrigger(WorkflowExecutionId workflowExecutionId) {
         JobDetail jobDetail = JobBuilder.newJob(PollingTriggerJob.class)
-            .withIdentity(JobKey.jobKey(workflowExecutionId.toString(), "PollingTrigger"))
+            .withIdentity(JobKey.jobKey(workflowExecutionId.toString(), POLLING_TRIGGER))
             .usingJobData("workflowExecutionId", workflowExecutionId.toString())
             .build();
 
         Trigger trigger = TriggerBuilder.newTrigger()
-            .withIdentity(TriggerKey.triggerKey(workflowExecutionId.toString(), "PollingTrigger"))
+            .withIdentity(TriggerKey.triggerKey(workflowExecutionId.toString(), POLLING_TRIGGER))
             .withSchedule(
                 SimpleScheduleBuilder.repeatMinutelyForever(pollingTriggerCheckPeriod))
             .startNow()
@@ -137,7 +143,7 @@ public class QuartzTriggerScheduler implements TriggerScheduler {
         String jobIdStr = String.valueOf(jobId);
 
         JobBuilder jobBuilder = JobBuilder.newJob(OneTimeSchedulerJob.class)
-            .withIdentity(JobKey.jobKey(jobIdStr, "OneTimeTask"))
+            .withIdentity(JobKey.jobKey(jobIdStr, ONE_TIME_TASK))
             .usingJobData("jobId", jobId);
 
         if (output != null && !output.isEmpty()) {
@@ -147,32 +153,30 @@ public class QuartzTriggerScheduler implements TriggerScheduler {
         JobDetail jobDetail = jobBuilder.build();
 
         Trigger trigger = TriggerBuilder.newTrigger()
-            .withIdentity(TriggerKey.triggerKey(jobIdStr, "OneTimeTask"))
+            .withIdentity(TriggerKey.triggerKey(jobIdStr, ONE_TIME_TASK))
             .startAt(Date.from(executeAt))
             .build();
 
         schedule(jobDetail, trigger);
     }
 
-    private void deleteJob(String workflowExecutionId, String pollingTrigger) {
+    private void deleteJob(String workflowExecutionId, String jobGroup) {
         try {
-            JobKey jobKey = JobKey.jobKey(workflowExecutionId, pollingTrigger);
+            JobKey jobKey = JobKey.jobKey(workflowExecutionId, jobGroup);
 
             if (scheduler.checkExists(jobKey) && scheduler.deleteJob(jobKey)) {
                 log.trace(
-                    "Trigger job removed for workflowExecutionId: {}, pollingTrigger: {}", workflowExecutionId,
-                    pollingTrigger);
+                    "Trigger job removed for workflowExecutionId: {}, jobGroup: {}", workflowExecutionId, jobGroup);
 
                 return;
             }
 
-            log.error(
-                "Trigger job not found for workflowExecutionId: {}, pollingTrigger: {}", workflowExecutionId,
-                pollingTrigger);
+            log.debug(
+                "Trigger job not found for workflowExecutionId: {}, jobGroup: {}", workflowExecutionId, jobGroup);
         } catch (SchedulerException e) {
             log.error(
-                "Unable to delete trigger job for workflowExecutionId: {}, pollingTrigger: {}", workflowExecutionId,
-                pollingTrigger);
+                "Unable to delete trigger job for workflowExecutionId: {}, jobGroup: {}", workflowExecutionId,
+                jobGroup, e);
         }
     }
 
@@ -186,7 +190,7 @@ public class QuartzTriggerScheduler implements TriggerScheduler {
 
             log.trace("Re-scheduled trigger job with key: {}", jobDetail.getKey());
         } catch (SchedulerException e) {
-            log.error("Unable to re-schedule trigger job with key: {}", jobDetail.getKey());
+            log.error("Unable to re-schedule trigger job with key: {}", jobDetail.getKey(), e);
         }
     }
 }

--- a/server/libs/platform/platform-scheduler/platform-scheduler-impl/src/main/java/com/bytechef/platform/scheduler/constant/QuartzTriggerSchedulerConstants.java
+++ b/server/libs/platform/platform-scheduler/platform-scheduler-impl/src/main/java/com/bytechef/platform/scheduler/constant/QuartzTriggerSchedulerConstants.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2025 ByteChef
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.bytechef.platform.scheduler.constant;
+
+/**
+ * @author Ivica Cardic
+ */
+public final class QuartzTriggerSchedulerConstants {
+
+    public static final String CONNECTION_ID = "connectionId";
+    public static final String DYNAMIC_WEBHOOK_TRIGGER_REFRESH = "DynamicWebhookTriggerRefresh";
+    public static final String ONE_TIME_TASK = "OneTimeTask";
+    public static final String POLLING_TRIGGER = "PollingTrigger";
+    public static final String SCHEDULE_TRIGGER = "ScheduleTrigger";
+
+    private QuartzTriggerSchedulerConstants() {
+    }
+}

--- a/server/libs/platform/platform-scheduler/platform-scheduler-impl/src/main/java/com/bytechef/platform/scheduler/job/DynamicWebhookTriggerRefreshJob.java
+++ b/server/libs/platform/platform-scheduler/platform-scheduler-impl/src/main/java/com/bytechef/platform/scheduler/job/DynamicWebhookTriggerRefreshJob.java
@@ -16,6 +16,9 @@
 
 package com.bytechef.platform.scheduler.job;
 
+import static com.bytechef.platform.scheduler.constant.QuartzTriggerSchedulerConstants.CONNECTION_ID;
+import static com.bytechef.platform.scheduler.constant.QuartzTriggerSchedulerConstants.DYNAMIC_WEBHOOK_TRIGGER_REFRESH;
+
 import com.bytechef.atlas.configuration.domain.Workflow;
 import com.bytechef.atlas.configuration.service.WorkflowService;
 import com.bytechef.commons.util.OptionalUtils;
@@ -55,7 +58,7 @@ public class DynamicWebhookTriggerRefreshJob implements Job {
         JobDataMap jobDataMap = context.getMergedJobDataMap();
 
         String workflowExecutionId = jobDataMap.getString("workflowExecutionId");
-        Long connectionId = jobDataMap.getLong("connectionID");
+        Long connectionId = (Long) jobDataMap.get(CONNECTION_ID);
 
         Instant webhookExpirationDate = refreshDynamicWebhookTrigger(
             WorkflowExecutionId.parse(workflowExecutionId), connectionId);
@@ -63,7 +66,7 @@ public class DynamicWebhookTriggerRefreshJob implements Job {
         if (webhookExpirationDate != null) {
             Scheduler scheduler = context.getScheduler();
             try {
-                TriggerKey triggerKey = TriggerKey.triggerKey(workflowExecutionId, "DynamicWebhookTriggerRefresh");
+                TriggerKey triggerKey = TriggerKey.triggerKey(workflowExecutionId, DYNAMIC_WEBHOOK_TRIGGER_REFRESH);
 
                 scheduler.rescheduleJob(
                     triggerKey,

--- a/server/libs/platform/platform-scheduler/platform-scheduler-impl/src/test/java/com/bytechef/platform/scheduler/QuartzIntTest.java
+++ b/server/libs/platform/platform-scheduler/platform-scheduler-impl/src/test/java/com/bytechef/platform/scheduler/QuartzIntTest.java
@@ -16,6 +16,9 @@
 
 package com.bytechef.platform.scheduler;
 
+import static com.bytechef.platform.scheduler.constant.QuartzTriggerSchedulerConstants.CONNECTION_ID;
+import static com.bytechef.platform.scheduler.constant.QuartzTriggerSchedulerConstants.DYNAMIC_WEBHOOK_TRIGGER_REFRESH;
+
 import com.bytechef.config.ApplicationProperties;
 import com.bytechef.platform.constant.PlatformType;
 import com.bytechef.platform.scheduler.config.QuartzJdbcTestConfiguration;
@@ -175,8 +178,8 @@ public class QuartzIntTest {
         quartzTriggerScheduler.scheduleDynamicWebhookTriggerRefresh(
             webhookExpirationDate, componentName, componentVersion, workflowExecutionId, connectionId);
 
-        JobKey jobKey = JobKey.jobKey(workflowExecutionId.toString(), "ScheduleTrigger");
-        TriggerKey triggerKey = TriggerKey.triggerKey(workflowExecutionId.toString(), "ScheduleTrigger");
+        JobKey jobKey = JobKey.jobKey(workflowExecutionId.toString(), DYNAMIC_WEBHOOK_TRIGGER_REFRESH);
+        TriggerKey triggerKey = TriggerKey.triggerKey(workflowExecutionId.toString(), DYNAMIC_WEBHOOK_TRIGGER_REFRESH);
 
         // Then: Verify JobDataMap and trigger are loaded correctly
         // THIS WILL FAIL in Quartz 2.5.1 with PostgreSQL
@@ -190,7 +193,7 @@ public class QuartzIntTest {
         Assertions.assertEquals(workflowExecutionId.toString(),
             jobDataMap.getString("workflowExecutionId"), "WorkflowExecutionId should be in JobDataMap");
         Assertions.assertEquals(
-            connectionId, jobDataMap.getLong("connectionId"), "ConnectionId should be in JobDataMap");
+            connectionId, jobDataMap.get(CONNECTION_ID), "ConnectionId should be in JobDataMap");
 
         // Retrieve SimpleTrigger - THIS FAILS in Quartz 2.5.1
         Trigger retrievedTrigger = scheduler.getTrigger(triggerKey);

--- a/server/libs/platform/platform-scheduler/platform-scheduler-impl/src/test/java/com/bytechef/platform/scheduler/QuartzTriggerSchedulerIntTest.java
+++ b/server/libs/platform/platform-scheduler/platform-scheduler-impl/src/test/java/com/bytechef/platform/scheduler/QuartzTriggerSchedulerIntTest.java
@@ -16,6 +16,10 @@
 
 package com.bytechef.platform.scheduler;
 
+import static com.bytechef.platform.scheduler.constant.QuartzTriggerSchedulerConstants.CONNECTION_ID;
+import static com.bytechef.platform.scheduler.constant.QuartzTriggerSchedulerConstants.DYNAMIC_WEBHOOK_TRIGGER_REFRESH;
+import static com.bytechef.platform.scheduler.constant.QuartzTriggerSchedulerConstants.SCHEDULE_TRIGGER;
+
 import com.bytechef.config.ApplicationProperties;
 import com.bytechef.platform.constant.PlatformType;
 import com.bytechef.platform.scheduler.config.QuartzTriggerSchedulerTestConfiguration;
@@ -50,8 +54,6 @@ import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Primary;
 
 /**
- * Integration test for QuartzTriggerScheduler
- *
  * @author Ivica Cardic
  */
 @ExtendWith(ObjectMapperSetupExtension.class)
@@ -92,8 +94,8 @@ public class QuartzTriggerSchedulerIntTest {
             webhookExpirationDate, componentName, componentVersion, workflowExecutionId, connectionId);
 
         // Then
-        JobKey jobKey = JobKey.jobKey(workflowExecutionId.toString(), "ScheduleTrigger");
-        TriggerKey triggerKey = TriggerKey.triggerKey(workflowExecutionId.toString(), "ScheduleTrigger");
+        JobKey jobKey = JobKey.jobKey(workflowExecutionId.toString(), DYNAMIC_WEBHOOK_TRIGGER_REFRESH);
+        TriggerKey triggerKey = TriggerKey.triggerKey(workflowExecutionId.toString(), DYNAMIC_WEBHOOK_TRIGGER_REFRESH);
 
         // Verify job was created
         Assertions.assertTrue(scheduler.checkExists(jobKey));
@@ -105,7 +107,7 @@ public class QuartzTriggerSchedulerIntTest {
         JobDataMap jobDataMap = jobDetail.getJobDataMap();
 
         Assertions.assertEquals(workflowExecutionId.toString(), jobDataMap.getString("workflowExecutionId"));
-        Assertions.assertEquals(connectionId, jobDataMap.getLong("connectionId"));
+        Assertions.assertEquals(connectionId, jobDataMap.get(CONNECTION_ID));
 
         // Verify trigger timing
         Trigger trigger = scheduler.getTrigger(triggerKey);
@@ -224,6 +226,64 @@ public class QuartzTriggerSchedulerIntTest {
     }
 
     @Test
+    public void testScheduleDynamicWebhookTriggerRefreshWithoutConnection() throws Exception {
+        // Given
+        WorkflowExecutionId workflowExecutionId = WorkflowExecutionId.of(
+            PlatformType.AUTOMATION, 321L, "test-webhook-workflow-without-connection", "testTrigger");
+        Instant webhookExpirationDate = LocalDateTime.now()
+            .plus(Duration.ofMinutes(5))
+            .toInstant(ZoneOffset.UTC);
+
+        // When
+        quartzTriggerScheduler.scheduleDynamicWebhookTriggerRefresh(
+            webhookExpirationDate, "testComponent", 1, workflowExecutionId, null);
+
+        // Then
+        JobKey jobKey = JobKey.jobKey(workflowExecutionId.toString(), DYNAMIC_WEBHOOK_TRIGGER_REFRESH);
+
+        JobDetail jobDetail = scheduler.getJobDetail(jobKey);
+
+        Assertions.assertNotNull(jobDetail);
+
+        JobDataMap jobDataMap = jobDetail.getJobDataMap();
+
+        Assertions.assertEquals(workflowExecutionId.toString(), jobDataMap.getString("workflowExecutionId"));
+        Assertions.assertNull(jobDataMap.get(CONNECTION_ID));
+
+        // Clean up
+        scheduler.deleteJob(jobKey);
+    }
+
+    @Test
+    public void testScheduleDynamicWebhookTriggerRefreshDoesNotEvictScheduleTrigger() throws Exception {
+        // Given
+        WorkflowExecutionId workflowExecutionId = WorkflowExecutionId.of(
+            PlatformType.AUTOMATION, 654L, "test-webhook-and-schedule-workflow", "testTrigger");
+        Instant webhookExpirationDate = LocalDateTime.now()
+            .plus(Duration.ofMinutes(5))
+            .toInstant(ZoneOffset.UTC);
+        ZoneId zoneId = ZoneId.systemDefault();
+
+        quartzTriggerScheduler.scheduleScheduleTrigger(
+            "0 0 12 * * ?", zoneId.getId(), Map.of("test", "data"), workflowExecutionId);
+
+        // When
+        quartzTriggerScheduler.scheduleDynamicWebhookTriggerRefresh(
+            webhookExpirationDate, "testComponent", 1, workflowExecutionId, 456L);
+
+        // Then - the two paths use distinct groups, so neither evicts the other
+        JobKey scheduleTriggerJobKey = JobKey.jobKey(workflowExecutionId.toString(), SCHEDULE_TRIGGER);
+        JobKey refreshJobKey = JobKey.jobKey(workflowExecutionId.toString(), DYNAMIC_WEBHOOK_TRIGGER_REFRESH);
+
+        Assertions.assertTrue(scheduler.checkExists(scheduleTriggerJobKey));
+        Assertions.assertTrue(scheduler.checkExists(refreshJobKey));
+
+        // Clean up
+        scheduler.deleteJob(scheduleTriggerJobKey);
+        scheduler.deleteJob(refreshJobKey);
+    }
+
+    @Test
     public void testCancelDynamicWebhookTriggerRefresh() throws Exception {
         // Given
         WorkflowExecutionId workflowExecutionId = WorkflowExecutionId.of(
@@ -236,24 +296,17 @@ public class QuartzTriggerSchedulerIntTest {
         quartzTriggerScheduler.scheduleDynamicWebhookTriggerRefresh(
             webhookExpirationDate, "testComponent", 1, workflowExecutionId, 123L);
 
-        JobKey scheduledJobKey = JobKey.jobKey(workflowExecutionId.toString(), "ScheduleTrigger");
-        JobKey cancelJobKey = JobKey.jobKey(workflowExecutionId.toString(), "DynamicWebhookTriggerRefresh");
+        JobKey jobKey = JobKey.jobKey(workflowExecutionId.toString(), DYNAMIC_WEBHOOK_TRIGGER_REFRESH);
+        TriggerKey triggerKey = TriggerKey.triggerKey(workflowExecutionId.toString(), DYNAMIC_WEBHOOK_TRIGGER_REFRESH);
 
-        // Verify job was created with "ScheduleTrigger" group
-        Assertions.assertTrue(scheduler.checkExists(scheduledJobKey));
-        // Verify the cancel job key doesn't exist (this reveals the bug in the existing code)
-        Assertions.assertFalse(scheduler.checkExists(cancelJobKey));
+        Assertions.assertTrue(scheduler.checkExists(jobKey));
 
-        // When - This will try to cancel using "DynamicWebhookTriggerRefresh" group
+        // When
         quartzTriggerScheduler.cancelDynamicWebhookTriggerRefresh(workflowExecutionId.toString());
 
-        // Then - The scheduled job should still exist because the cancel used wrong group
-        // This test demonstrates the bug in the existing code
-        Assertions.assertTrue(scheduler.checkExists(scheduledJobKey));
-        Assertions.assertFalse(scheduler.checkExists(cancelJobKey));
-
-        // Clean up manually
-        scheduler.deleteJob(scheduledJobKey);
+        // Then
+        Assertions.assertFalse(scheduler.checkExists(jobKey));
+        Assertions.assertFalse(scheduler.checkExists(triggerKey));
     }
 
     @Test

--- a/server/libs/platform/platform-scheduler/platform-scheduler-impl/src/test/java/com/bytechef/platform/scheduler/job/DynamicWebhookTriggerRefreshJobTest.java
+++ b/server/libs/platform/platform-scheduler/platform-scheduler-impl/src/test/java/com/bytechef/platform/scheduler/job/DynamicWebhookTriggerRefreshJobTest.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2025 ByteChef
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.bytechef.platform.scheduler.job;
+
+import static com.bytechef.platform.scheduler.constant.QuartzTriggerSchedulerConstants.CONNECTION_ID;
+import static com.bytechef.platform.scheduler.constant.QuartzTriggerSchedulerConstants.DYNAMIC_WEBHOOK_TRIGGER_REFRESH;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.bytechef.atlas.configuration.domain.Workflow;
+import com.bytechef.atlas.configuration.domain.Workflow.Format;
+import com.bytechef.atlas.configuration.service.WorkflowService;
+import com.bytechef.component.definition.TriggerDefinition.WebhookEnableOutput;
+import com.bytechef.platform.component.facade.TriggerDefinitionFacade;
+import com.bytechef.platform.constant.PlatformType;
+import com.bytechef.platform.workflow.WorkflowExecutionId;
+import com.bytechef.platform.workflow.execution.accessor.JobPrincipalAccessor;
+import com.bytechef.platform.workflow.execution.accessor.JobPrincipalAccessorRegistry;
+import com.bytechef.platform.workflow.execution.service.TriggerStateService;
+import com.bytechef.test.extension.ObjectMapperSetupExtension;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.quartz.JobDataMap;
+import org.quartz.JobExecutionContext;
+import org.quartz.Scheduler;
+import org.quartz.Trigger;
+import org.quartz.TriggerKey;
+
+/**
+ * @author Ivica Cardic
+ */
+@ExtendWith(ObjectMapperSetupExtension.class)
+public class DynamicWebhookTriggerRefreshJobTest {
+
+    private static final String WORKFLOW_ID = "workflow1";
+    private static final Map<String, ?> WEBHOOK_PARAMETERS = Map.of("subscriptionId", "subscription-1");
+
+    private final JobPrincipalAccessor jobPrincipalAccessor = mock(JobPrincipalAccessor.class);
+    private final JobPrincipalAccessorRegistry jobPrincipalAccessorRegistry = mock(JobPrincipalAccessorRegistry.class);
+    private final JobExecutionContext jobExecutionContext = mock(JobExecutionContext.class);
+    private final Scheduler scheduler = mock(Scheduler.class);
+    private final TriggerDefinitionFacade triggerDefinitionFacade = mock(TriggerDefinitionFacade.class);
+    private final TriggerStateService triggerStateService = mock(TriggerStateService.class);
+    private final WorkflowService workflowService = mock(WorkflowService.class);
+
+    private final WorkflowExecutionId workflowExecutionId = WorkflowExecutionId.of(
+        PlatformType.AUTOMATION, 123L, "test-webhook-workflow", "testTrigger");
+
+    private DynamicWebhookTriggerRefreshJob dynamicWebhookTriggerRefreshJob;
+
+    @BeforeEach
+    public void setUp() {
+        dynamicWebhookTriggerRefreshJob = new DynamicWebhookTriggerRefreshJob();
+
+        dynamicWebhookTriggerRefreshJob.setPrincipalAccessorRegistry(jobPrincipalAccessorRegistry);
+        dynamicWebhookTriggerRefreshJob.setRemoteTriggerDefinitionFacade(triggerDefinitionFacade);
+        dynamicWebhookTriggerRefreshJob.setTriggerStateService(triggerStateService);
+        dynamicWebhookTriggerRefreshJob.setWorkflowService(workflowService);
+
+        Workflow workflow = new Workflow(
+            WORKFLOW_ID,
+            """
+                {
+                    "triggers": [
+                        {
+                            "name": "testTrigger",
+                            "type": "testComponent/v1/testTriggerOperation"
+                        }
+                    ]
+                }
+                """,
+            Format.JSON);
+
+        when(jobPrincipalAccessorRegistry.getJobPrincipalAccessor(any())).thenReturn(jobPrincipalAccessor);
+        when(jobPrincipalAccessor.getWorkflowId(anyLong(), anyString())).thenReturn(WORKFLOW_ID);
+        when(workflowService.getWorkflow(WORKFLOW_ID)).thenReturn(workflow);
+        when(triggerStateService.<WebhookEnableOutput>fetchValue(any()))
+            .thenReturn(Optional.of(new WebhookEnableOutput(WEBHOOK_PARAMETERS, null)));
+        when(jobExecutionContext.getScheduler()).thenReturn(scheduler);
+    }
+
+    @Test
+    public void testExecuteRefreshesAndRequeuesUsingTheSameTriggerKey() throws Exception {
+        // Given
+        Instant webhookExpirationDate = Instant.now()
+            .plus(1, ChronoUnit.HOURS);
+
+        when(triggerDefinitionFacade.executeDynamicWebhookRefresh(
+            "testComponent", 1, "testTriggerOperation", WEBHOOK_PARAMETERS, 456L))
+                .thenReturn(new WebhookEnableOutput(WEBHOOK_PARAMETERS, webhookExpirationDate));
+
+        when(jobExecutionContext.getMergedJobDataMap()).thenReturn(jobDataMap(456L));
+
+        // When
+        dynamicWebhookTriggerRefreshJob.execute(jobExecutionContext);
+
+        // Then
+        ArgumentCaptor<TriggerKey> triggerKeyArgumentCaptor = ArgumentCaptor.forClass(TriggerKey.class);
+        ArgumentCaptor<Trigger> triggerArgumentCaptor = ArgumentCaptor.forClass(Trigger.class);
+
+        verify(scheduler).rescheduleJob(triggerKeyArgumentCaptor.capture(), triggerArgumentCaptor.capture());
+
+        TriggerKey triggerKey = triggerKeyArgumentCaptor.getValue();
+
+        Assertions.assertEquals(workflowExecutionId.toString(), triggerKey.getName());
+        Assertions.assertEquals(DYNAMIC_WEBHOOK_TRIGGER_REFRESH, triggerKey.getGroup());
+
+        Trigger trigger = triggerArgumentCaptor.getValue();
+
+        Assertions.assertEquals(Date.from(webhookExpirationDate), trigger.getStartTime());
+
+        verify(triggerStateService).save(any(), any());
+    }
+
+    @Test
+    public void testExecuteWithoutConnection() throws Exception {
+        // Given
+        when(triggerDefinitionFacade.executeDynamicWebhookRefresh(
+            eq("testComponent"), eq(1), eq("testTriggerOperation"), any(), isNull()))
+                .thenReturn(new WebhookEnableOutput(WEBHOOK_PARAMETERS, Instant.now()
+                    .plus(1, ChronoUnit.HOURS)));
+
+        when(jobExecutionContext.getMergedJobDataMap()).thenReturn(jobDataMap(null));
+
+        // When
+        dynamicWebhookTriggerRefreshJob.execute(jobExecutionContext);
+
+        // Then
+        verify(triggerDefinitionFacade).executeDynamicWebhookRefresh(
+            eq("testComponent"), eq(1), eq("testTriggerOperation"), any(), isNull());
+        verify(scheduler).rescheduleJob(any(), any());
+    }
+
+    @Test
+    public void testExecuteWithoutWebhookExpirationDate() throws Exception {
+        // Given
+        when(triggerDefinitionFacade.executeDynamicWebhookRefresh(
+            "testComponent", 1, "testTriggerOperation", WEBHOOK_PARAMETERS, 456L))
+                .thenReturn(new WebhookEnableOutput(WEBHOOK_PARAMETERS, null));
+
+        when(jobExecutionContext.getMergedJobDataMap()).thenReturn(jobDataMap(456L));
+
+        // When
+        dynamicWebhookTriggerRefreshJob.execute(jobExecutionContext);
+
+        // Then
+        verify(scheduler, never()).rescheduleJob(any(), any());
+    }
+
+    private JobDataMap jobDataMap(Long connectionId) {
+        JobDataMap jobDataMap = new JobDataMap();
+
+        jobDataMap.put("workflowExecutionId", workflowExecutionId.toString());
+        jobDataMap.put(CONNECTION_ID, connectionId);
+
+        return jobDataMap;
+    }
+}

--- a/server/libs/platform/platform-scheduler/platform-scheduler-impl/src/test/java/com/bytechef/platform/scheduler/workflow/contributor/TestWorkflowReservedWordContributor.java
+++ b/server/libs/platform/platform-scheduler/platform-scheduler-impl/src/test/java/com/bytechef/platform/scheduler/workflow/contributor/TestWorkflowReservedWordContributor.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2025 ByteChef
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.bytechef.platform.scheduler.workflow.contributor;
+
+import com.bytechef.atlas.configuration.workflow.contributor.WorkflowReservedWordContributor;
+import java.util.List;
+
+/**
+ * @author Ivica Cardic
+ */
+public class TestWorkflowReservedWordContributor implements WorkflowReservedWordContributor {
+
+    @Override
+    public List<String> getReservedWords() {
+        return List.of("triggers");
+    }
+}

--- a/server/libs/platform/platform-scheduler/platform-scheduler-impl/src/test/resources/META-INF/services/com.bytechef.atlas.configuration.workflow.contributor.WorkflowReservedWordContributor
+++ b/server/libs/platform/platform-scheduler/platform-scheduler-impl/src/test/resources/META-INF/services/com.bytechef.atlas.configuration.workflow.contributor.WorkflowReservedWordContributor
@@ -1,0 +1,1 @@
+com.bytechef.platform.scheduler.workflow.contributor.TestWorkflowReservedWordContributor


### PR DESCRIPTION
Fixes the dynamic-webhook trigger refresh under the Quartz provider, reported in bytechefhq/bytechef#5651.

## The problem

The refresh path carried three identity strings that were never wired together:

| | Written as | Read as |
| --- | --- | --- |
| Job group | `ScheduleTrigger` | `DynamicWebhookTriggerRefresh` (cancel) |
| Connection id | `connectionId` | `connectionID` |
| Reschedule key | `ScheduleTrigger` | `DynamicWebhookTriggerRefresh` (in-job) |

Quartz's `StringKeyDirtyFlagMap.getLong` turns the missing data key into a `ClassCastException`, so the job threw on **every** fire before reaching the refresh call. The trigger is a one-shot `startAt(...)`, so Quartz then dropped it. Net effect: a webhook subscription with an expiry (Microsoft Graph, Google push channels) was never renewed, and disabling a workflow never removed the refresh job.

## A fourth defect, not in the issue

`connectionId` is genuinely nullable — `ProjectDeploymentFacadeImpl.getConnectionId` ends in `.orElse(null)`, the facade parameter is annotated `@Nullable`, and `STATIC_WEBHOOK` shares the enable branch. `getLong` throws for a null value too, so renaming the key alone would have left connection-less triggers broken. The read now goes through `get()` + cast.

## The fix

A new `QuartzTriggerSchedulerConstants` holds the group names and the `connectionId` key, so the writer, the cancel lookup and the in-job reschedule cannot drift apart again. It mirrors the EE `AwsTriggerSchedulerConstants` pattern. Scheduling into its own group also ends the key collision with `scheduleScheduleTrigger`, which used the identical `JobKey`.

Also renamed `deleteJob`'s `pollingTrigger` parameter to `jobGroup` — its log line was this bug's only symptom and it named the wrong thing.

## Tests

`QuartzTriggerSchedulerIntTest` previously *asserted* the broken behaviour, with a comment saying so, which kept the suite green and would have resisted this fix. It now asserts that cancel actually removes the job.

Reverting either source file while keeping the tests turns **8 tests red** (3 unit + 5 integration):

- `DynamicWebhookTriggerRefreshJobTest` — all three fail with `ClassCastException: Identified object is not a Long.`
- `QuartzTriggerSchedulerIntTest` — schedule, cancel, no-connection, and no-eviction cases
- `QuartzIntTest.testDynamicWebhookTriggerJobDataMap`

With the fix: `check` 11 tests / 0 failures (3 pre-existing `@Disabled`), `testIntegration` 12 tests / 0 failures.

New `DynamicWebhookTriggerRefreshJobTest` executes the job against a stubbed `TriggerDefinitionFacade` and asserts the second trigger is queued at the returned expiration date, plus the no-connection and no-expiration-date cases. A test-only `WorkflowReservedWordContributor` supplies the `triggers` keyword, which in production is contributed by `platform-configuration-service` (not on this module's classpath) — the same pattern `atlas-configuration-api` already uses.

## Note for reviewers

The job group change means refresh jobs written by the old code sit in the `ScheduleTrigger` group in `qrtz_job_details`. They are non-durable one-shot jobs that Quartz drops after firing, so they self-clean rather than accumulating — but any still-pending one will fire once after upgrade and then not re-queue, and `cancel` will not find it. Given those jobs never worked, no migration is included; happy to add one if preferred.

The EE AWS provider is unaffected — it carries the ids in its own delimited message string and its group names already agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)