### PR TITLE
3700 Persist the Docker encryption key without publishing a fixed one

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ docker run --name bytechef -it -p 8080:8080 \
     --env BYTECHEF_DATASOURCE_URL=jdbc:postgresql://postgres:5432/bytechef \
     --env BYTECHEF_DATASOURCE_USERNAME=postgres \
     --env BYTECHEF_DATASOURCE_PASSWORD=postgres \
+    --env BYTECHEF_ENCRYPTION_PROVIDER=property \
+    --env BYTECHEF_ENCRYPTION_PROPERTY_KEY=tTB1/UBIbYLuCXVi4PPfzA== \
     --env BYTECHEF_SECURITY_REMEMBER_ME_KEY=e48612ba1fd46fa7089fe9f5085d8d164b53ffb2 \
     --network bytechef_network \
     docker.bytechef.io/bytechef/bytechef:latest

--- a/README.md
+++ b/README.md
@@ -105,27 +105,18 @@ docker run --name postgres -d -p 5432:5432 \
     postgres:15-alpine
 ```
 
-#### 3. Generate an Encryption Key
+#### 3. Start ByteChef Container
 
-ByteChef encrypts stored connection credentials with a single instance-wide key. Generate your own
-and keep it somewhere safe - if you lose it, every stored credential becomes undecryptable:
-
-```bash
-openssl rand -base64 16
-```
-
-#### 4. Start ByteChef Container
-
-Replace `<your-encryption-key>` with the value generated above:
+ByteChef generates the key that encrypts stored connection credentials on first start. Mounting
+`~/.bytechef` keeps that key on the host, so it survives recreating the container:
 
 ```bash
 docker run --name bytechef -it -p 8080:8080 \
     --env BYTECHEF_DATASOURCE_URL=jdbc:postgresql://postgres:5432/bytechef \
     --env BYTECHEF_DATASOURCE_USERNAME=postgres \
     --env BYTECHEF_DATASOURCE_PASSWORD=postgres \
-    --env BYTECHEF_ENCRYPTION_PROVIDER=property \
-    --env BYTECHEF_ENCRYPTION_PROPERTY_KEY=<your-encryption-key> \
     --env BYTECHEF_SECURITY_REMEMBER_ME_KEY=e48612ba1fd46fa7089fe9f5085d8d164b53ffb2 \
+    -v ~/.bytechef:/root/.bytechef \
     --network bytechef_network \
     docker.bytechef.io/bytechef/bytechef:latest
 ```

--- a/README.md
+++ b/README.md
@@ -105,14 +105,26 @@ docker run --name postgres -d -p 5432:5432 \
     postgres:15-alpine
 ```
 
-#### 3. Start ByteChef Container
+#### 3. Generate an Encryption Key
+
+ByteChef encrypts stored connection credentials with a single instance-wide key. Generate your own
+and keep it somewhere safe - if you lose it, every stored credential becomes undecryptable:
+
+```bash
+openssl rand -base64 16
+```
+
+#### 4. Start ByteChef Container
+
+Replace `<your-encryption-key>` with the value generated above:
+
 ```bash
 docker run --name bytechef -it -p 8080:8080 \
     --env BYTECHEF_DATASOURCE_URL=jdbc:postgresql://postgres:5432/bytechef \
     --env BYTECHEF_DATASOURCE_USERNAME=postgres \
     --env BYTECHEF_DATASOURCE_PASSWORD=postgres \
     --env BYTECHEF_ENCRYPTION_PROVIDER=property \
-    --env BYTECHEF_ENCRYPTION_PROPERTY_KEY=tTB1/UBIbYLuCXVi4PPfzA== \
+    --env BYTECHEF_ENCRYPTION_PROPERTY_KEY=<your-encryption-key> \
     --env BYTECHEF_SECURITY_REMEMBER_ME_KEY=e48612ba1fd46fa7089fe9f5085d8d164b53ffb2 \
     --network bytechef_network \
     docker.bytechef.io/bytechef/bytechef:latest

--- a/docker-compose.src.yml
+++ b/docker-compose.src.yml
@@ -21,8 +21,10 @@ services:
       - BYTECHEF_DATASOURCE_URL=jdbc:postgresql://postgres:5432/bytechef
       - BYTECHEF_DATASOURCE_USERNAME=postgres
       - BYTECHEF_DATASOURCE_PASSWORD=postgres
+      - BYTECHEF_ENCRYPTION_PROVIDER=property
+      - BYTECHEF_ENCRYPTION_PROPERTY_KEY=tTB1/UBIbYLuCXVi4PPfzA==
       - BYTECHEF_FEATURE_FLAGS
-      - BYTECHEF_SECURITY_REMEMBER-ME_KEY=e48keep1this1safe3ffb2
+      - BYTECHEF_SECURITY_REMEMBER_ME_KEY=e48keep1this1safe3ffb2
     ports:
       - "8080:8080"
 volumes:

--- a/docker-compose.src.yml
+++ b/docker-compose.src.yml
@@ -21,14 +21,16 @@ services:
       - BYTECHEF_DATASOURCE_URL=jdbc:postgresql://postgres:5432/bytechef
       - BYTECHEF_DATASOURCE_USERNAME=postgres
       - BYTECHEF_DATASOURCE_PASSWORD=postgres
-      - BYTECHEF_ENCRYPTION_PROVIDER=property
-      - BYTECHEF_ENCRYPTION_PROPERTY_KEY=tTB1/UBIbYLuCXVi4PPfzA==
       - BYTECHEF_FEATURE_FLAGS
       - BYTECHEF_SECURITY_REMEMBER_ME_KEY=e48keep1this1safe3ffb2
+    volumes:
+      - storage_key:/root/.bytechef
     ports:
       - "8080:8080"
 volumes:
   storage_db:
+    driver: "local"
+  storage_key:
     driver: "local"
   storage_cache:
     driver: "local"

--- a/docker-compose.src.yml
+++ b/docker-compose.src.yml
@@ -24,13 +24,11 @@ services:
       - BYTECHEF_FEATURE_FLAGS
       - BYTECHEF_SECURITY_REMEMBER_ME_KEY=e48keep1this1safe3ffb2
     volumes:
-      - storage_key:/root/.bytechef
+      - ~/.bytechef:/root/.bytechef
     ports:
       - "8080:8080"
 volumes:
   storage_db:
-    driver: "local"
-  storage_key:
     driver: "local"
   storage_cache:
     driver: "local"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,8 +26,10 @@ services:
       - BYTECHEF_DATASOURCE_URL=jdbc:postgresql://postgres:5432/bytechef
       - BYTECHEF_DATASOURCE_USERNAME=postgres
       - BYTECHEF_DATASOURCE_PASSWORD=postgres
+      - BYTECHEF_ENCRYPTION_PROVIDER=property
+      - BYTECHEF_ENCRYPTION_PROPERTY_KEY=tTB1/UBIbYLuCXVi4PPfzA==
       - BYTECHEF_FEATURE_FLAGS
-      - BYTECHEF_SECURITY_REMEMBER-ME_KEY=e48keep1this1safe3ffb2
+      - BYTECHEF_SECURITY_REMEMBER_ME_KEY=e48keep1this1safe3ffb2
     ports:
       - "8080:8080"
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,13 +29,11 @@ services:
       - BYTECHEF_FEATURE_FLAGS
       - BYTECHEF_SECURITY_REMEMBER_ME_KEY=e48keep1this1safe3ffb2
     volumes:
-      - storage_key:/root/.bytechef
+      - ~/.bytechef:/root/.bytechef
     ports:
       - "8080:8080"
 volumes:
   storage_db:
-    driver: "local"
-  storage_key:
     driver: "local"
   storage_cache:
     driver: "local"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,14 +26,16 @@ services:
       - BYTECHEF_DATASOURCE_URL=jdbc:postgresql://postgres:5432/bytechef
       - BYTECHEF_DATASOURCE_USERNAME=postgres
       - BYTECHEF_DATASOURCE_PASSWORD=postgres
-      - BYTECHEF_ENCRYPTION_PROVIDER=property
-      - BYTECHEF_ENCRYPTION_PROPERTY_KEY=tTB1/UBIbYLuCXVi4PPfzA==
       - BYTECHEF_FEATURE_FLAGS
       - BYTECHEF_SECURITY_REMEMBER_ME_KEY=e48keep1this1safe3ffb2
+    volumes:
+      - storage_key:/root/.bytechef
     ports:
       - "8080:8080"
 volumes:
   storage_db:
+    driver: "local"
+  storage_key:
     driver: "local"
   storage_cache:
     driver: "local"

--- a/docs/content/docs/platform/use-bytechef/self-hosted/installation/local-docker.mdx
+++ b/docs/content/docs/platform/use-bytechef/self-hosted/installation/local-docker.mdx
@@ -31,6 +31,11 @@ workflows, connections, and execution history - lives there, so `docker compose 
 `-v`) deletes all of it. Plain `docker compose down` stops the containers and leaves the volume
 intact.
 
+The Compose file also sets a fixed encryption key (`BYTECHEF_ENCRYPTION_PROVIDER=property` with
+`BYTECHEF_ENCRYPTION_PROPERTY_KEY`) so stored OAuth connection credentials remain decryptable after
+you recreate the ByteChef container. Without a stable key, a fresh container cannot read connections
+already stored in PostgreSQL.
+
 To point ByteChef at a PostgreSQL server you run yourself instead, override the datasource settings
 on the `bytechef` service:
 
@@ -82,6 +87,8 @@ docker run --name bytechef -it -p 8080:8080 \
     --env BYTECHEF_DATASOURCE_URL=jdbc:postgresql://postgres:5432/bytechef \
     --env BYTECHEF_DATASOURCE_USERNAME=postgres \
     --env BYTECHEF_DATASOURCE_PASSWORD=postgres \
+    --env BYTECHEF_ENCRYPTION_PROVIDER=property \
+    --env BYTECHEF_ENCRYPTION_PROPERTY_KEY=tTB1/UBIbYLuCXVi4PPfzA== \
     --env BYTECHEF_SECURITY_REMEMBER_ME_KEY=e48612ba1fd46fa7089fe9f5085d8d164b53ffb2 \
     --network bytechef_network \
     docker.bytechef.io/bytechef/bytechef:latest

--- a/docs/content/docs/platform/use-bytechef/self-hosted/installation/local-docker.mdx
+++ b/docs/content/docs/platform/use-bytechef/self-hosted/installation/local-docker.mdx
@@ -32,22 +32,24 @@ workflows, connections, and execution history - lives there, so `docker compose 
 intact.
 
 ByteChef encrypts stored connection credentials with an instance-wide key. Under the default
-`filesystem` provider the key is generated on first start and written inside the container, which
-does not survive `docker rm` - so the Compose file keeps it in a second named volume, `storage_key`.
-Recreating the ByteChef container then leaves stored connections readable. `docker compose down -v`
-deletes this volume too, and a database restored without its key is a database of undecryptable
-credentials, so back the two up together.
+`filesystem` provider that key is generated on first start and written to `~/.bytechef/key`, so the
+Compose file mounts your `~/.bytechef` directory into the container. Keeping the key on the host
+rather than inside the container has three consequences: it survives recreating the container,
+`docker compose down -v` does not touch it, and a server you run outside Docker uses the very same
+key - the same connections stay readable either way.
+
+Back the key up alongside the database. A database restored without its key is a database of
+undecryptable credentials.
 
 <Callout type="warn">
-If you created your instance before `storage_key` was added, its key still lives inside the old
-container and is lost the first time that container is recreated. Existing connections cannot be
-recovered without it - re-create them once after upgrading, then the key persists.
+An instance created before this mount existed kept its key inside the container, where it is lost
+the first time that container is recreated. Connections stored under it cannot be recovered -
+re-create them once, after which the key persists in `~/.bytechef`.
 </Callout>
 
-For anything beyond a local install - a multi-replica deployment, or any host where you want to hold
-the key yourself - set `BYTECHEF_ENCRYPTION_PROVIDER=property` with your own
-`BYTECHEF_ENCRYPTION_PROPERTY_KEY` from a secret manager instead. See
-[Configuration](/platform/use-bytechef/self-hosted/configuration#the-key).
+For a multi-replica deployment, or any host where you would rather hold the key in a secret manager,
+set `BYTECHEF_ENCRYPTION_PROVIDER=property` with your own `BYTECHEF_ENCRYPTION_PROPERTY_KEY`
+instead. See [Configuration](/platform/use-bytechef/self-hosted/configuration#the-key).
 
 To point ByteChef at a PostgreSQL server you run yourself instead, override the datasource settings
 on the `bytechef` service:
@@ -93,30 +95,18 @@ docker run --name postgres -d -p 5432:5432 \
 </Step>
 <Step>
 
-**Generate an encryption key**
-
-There is no Compose file to persist the key for you here, so supply your own and store it somewhere
-safe - lose it and every stored credential becomes undecryptable:
-
-```bash
-openssl rand -base64 16
-```
-
-</Step>
-<Step>
-
 **Start the ByteChef container**
 
-Replace `<your-encryption-key>` with the value generated above:
+Mount `~/.bytechef` so the generated encryption key stays on the host, exactly as the Compose file
+does:
 
 ```bash
 docker run --name bytechef -it -p 8080:8080 \
     --env BYTECHEF_DATASOURCE_URL=jdbc:postgresql://postgres:5432/bytechef \
     --env BYTECHEF_DATASOURCE_USERNAME=postgres \
     --env BYTECHEF_DATASOURCE_PASSWORD=postgres \
-    --env BYTECHEF_ENCRYPTION_PROVIDER=property \
-    --env BYTECHEF_ENCRYPTION_PROPERTY_KEY=<your-encryption-key> \
     --env BYTECHEF_SECURITY_REMEMBER_ME_KEY=e48612ba1fd46fa7089fe9f5085d8d164b53ffb2 \
+    -v ~/.bytechef:/root/.bytechef \
     --network bytechef_network \
     docker.bytechef.io/bytechef/bytechef:latest
 ```

--- a/docs/content/docs/platform/use-bytechef/self-hosted/installation/local-docker.mdx
+++ b/docs/content/docs/platform/use-bytechef/self-hosted/installation/local-docker.mdx
@@ -31,10 +31,23 @@ workflows, connections, and execution history - lives there, so `docker compose 
 `-v`) deletes all of it. Plain `docker compose down` stops the containers and leaves the volume
 intact.
 
-The Compose file also sets a fixed encryption key (`BYTECHEF_ENCRYPTION_PROVIDER=property` with
-`BYTECHEF_ENCRYPTION_PROPERTY_KEY`) so stored OAuth connection credentials remain decryptable after
-you recreate the ByteChef container. Without a stable key, a fresh container cannot read connections
-already stored in PostgreSQL.
+ByteChef encrypts stored connection credentials with an instance-wide key. Under the default
+`filesystem` provider the key is generated on first start and written inside the container, which
+does not survive `docker rm` - so the Compose file keeps it in a second named volume, `storage_key`.
+Recreating the ByteChef container then leaves stored connections readable. `docker compose down -v`
+deletes this volume too, and a database restored without its key is a database of undecryptable
+credentials, so back the two up together.
+
+<Callout type="warn">
+If you created your instance before `storage_key` was added, its key still lives inside the old
+container and is lost the first time that container is recreated. Existing connections cannot be
+recovered without it - re-create them once after upgrading, then the key persists.
+</Callout>
+
+For anything beyond a local install - a multi-replica deployment, or any host where you want to hold
+the key yourself - set `BYTECHEF_ENCRYPTION_PROVIDER=property` with your own
+`BYTECHEF_ENCRYPTION_PROPERTY_KEY` from a secret manager instead. See
+[Configuration](/platform/use-bytechef/self-hosted/configuration#the-key).
 
 To point ByteChef at a PostgreSQL server you run yourself instead, override the datasource settings
 on the `bytechef` service:
@@ -80,7 +93,21 @@ docker run --name postgres -d -p 5432:5432 \
 </Step>
 <Step>
 
+**Generate an encryption key**
+
+There is no Compose file to persist the key for you here, so supply your own and store it somewhere
+safe - lose it and every stored credential becomes undecryptable:
+
+```bash
+openssl rand -base64 16
+```
+
+</Step>
+<Step>
+
 **Start the ByteChef container**
+
+Replace `<your-encryption-key>` with the value generated above:
 
 ```bash
 docker run --name bytechef -it -p 8080:8080 \
@@ -88,7 +115,7 @@ docker run --name bytechef -it -p 8080:8080 \
     --env BYTECHEF_DATASOURCE_USERNAME=postgres \
     --env BYTECHEF_DATASOURCE_PASSWORD=postgres \
     --env BYTECHEF_ENCRYPTION_PROVIDER=property \
-    --env BYTECHEF_ENCRYPTION_PROPERTY_KEY=tTB1/UBIbYLuCXVi4PPfzA== \
+    --env BYTECHEF_ENCRYPTION_PROPERTY_KEY=<your-encryption-key> \
     --env BYTECHEF_SECURITY_REMEMBER_ME_KEY=e48612ba1fd46fa7089fe9f5085d8d164b53ffb2 \
     --network bytechef_network \
     docker.bytechef.io/bytechef/bytechef:latest


### PR DESCRIPTION
Fixes #3700. Supersedes #5576, whose commit is included here with authorship intact — thanks @anshulgoel22 for the diagnosis and the original fix.

## The problem

`FileSystemEncryptionKey` generates the instance-wide AES key on first start and writes it to `$HOME/.bytechef/key`. The image runs as root with no `USER` directive, so that resolves to `/root/.bytechef/key` — inside the container layer, with no volume behind it. Recreating the container throws the key away while the Postgres volume keeps the credentials encrypted under it, and every connection then fails to decrypt.

## What changed

`docker-compose.yml`, `docker-compose.src.yml` and both manual `docker run` paths now mount `~/.bytechef` into the container:

```yaml
    volumes:
      - ~/.bytechef:/root/.bytechef
```

This is the pattern `server/docker-compose.dev.server.yml` already uses for `server-app`, so the quickstart and the dev stack now handle the key the same way.

Keeping the key on the host rather than in a Docker-managed volume means:

- it survives `docker rm` / container recreation, which is the actual bug
- `docker compose down -v` cannot destroy it
- a server run outside Docker uses the very same key, so connections created either way stay decryptable
- backing it up is `cp ~/.bytechef/key`, not a helper container against `/var/lib/docker/volumes/`

The docs page gains the reasoning, a warning that instances created before this mount lose their key once on the next container recreate, and a pointer to `BYTECHEF_ENCRYPTION_PROVIDER=property` for multi-replica deployments and secret managers.

## Why not a fixed property key

#5576 originally set `BYTECHEF_ENCRYPTION_PROVIDER=property` with a literal key in the Compose file. That literal is this repository's own test fixture — it appears verbatim in 16 committed test files — so every install created by the documented `curl -O … && docker compose up` path would have encrypted its stored credentials under a key published on GitHub. `EncryptionImpl.getSecretKey()` uses the base64-decoded value as raw AES key material with no stretching, so anyone with a copy of the database and the repo could decrypt every OAuth token and API key. It also contradicts the self-hosted configuration guide, which says to store the key in a secret manager and never in source control.

Treating #3700 as a storage problem rather than a configuration one removes the need for any key in source control while keeping the quickstart a single command.

## Verification

- `user.home` inside the image confirmed as `/root` (`USER` empty, Docker defaults root's `HOME` to `/root`), so `/root/.bytechef` is the correct mount target
- Compose expands `~` to the host path; `~` rather than `${HOME}` because `${HOME}` is unset on native Windows
- Bind-mount round trip verified — a container reads the identical key a local run wrote
- `docker compose config -q` passes on both Compose files

## Type of change

- Bug fix (Docker / self-hosted local setup)
- Security fix (no shared encryption key shipped in source control)

🤖 Generated with [Claude Code](https://claude.com/claude-code)