### PR TITLE
1042 Remove the ff-1042 gate from project and workflow sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ docker run --name bytechef -it -p 8080:8080 \
     --env BYTECHEF_DATASOURCE_URL=jdbc:postgresql://postgres:5432/bytechef \
     --env BYTECHEF_DATASOURCE_USERNAME=postgres \
     --env BYTECHEF_DATASOURCE_PASSWORD=postgres \
+    --env BYTECHEF_ENCRYPTION_PROVIDER=property \
+    --env BYTECHEF_ENCRYPTION_PROPERTY_KEY=tTB1/UBIbYLuCXVi4PPfzA== \
     --env BYTECHEF_SECURITY_REMEMBER_ME_KEY=e48612ba1fd46fa7089fe9f5085d8d164b53ffb2 \
     --network bytechef_network \
     docker.bytechef.io/bytechef/bytechef:latest

--- a/README.md
+++ b/README.md
@@ -105,14 +105,26 @@ docker run --name postgres -d -p 5432:5432 \
     postgres:15-alpine
 ```
 
-#### 3. Start ByteChef Container
+#### 3. Generate an Encryption Key
+
+ByteChef encrypts stored connection credentials with a single instance-wide key. Generate your own
+and keep it somewhere safe - if you lose it, every stored credential becomes undecryptable:
+
+```bash
+openssl rand -base64 16
+```
+
+#### 4. Start ByteChef Container
+
+Replace `<your-encryption-key>` with the value generated above:
+
 ```bash
 docker run --name bytechef -it -p 8080:8080 \
     --env BYTECHEF_DATASOURCE_URL=jdbc:postgresql://postgres:5432/bytechef \
     --env BYTECHEF_DATASOURCE_USERNAME=postgres \
     --env BYTECHEF_DATASOURCE_PASSWORD=postgres \
     --env BYTECHEF_ENCRYPTION_PROVIDER=property \
-    --env BYTECHEF_ENCRYPTION_PROPERTY_KEY=tTB1/UBIbYLuCXVi4PPfzA== \
+    --env BYTECHEF_ENCRYPTION_PROPERTY_KEY=<your-encryption-key> \
     --env BYTECHEF_SECURITY_REMEMBER_ME_KEY=e48612ba1fd46fa7089fe9f5085d8d164b53ffb2 \
     --network bytechef_network \
     docker.bytechef.io/bytechef/bytechef:latest

--- a/client/src/pages/automation/project/components/project-header/components/settings-menu/components/ProjectTabButtons/ProjectTabButtons.tsx
+++ b/client/src/pages/automation/project/components/project-header/components/settings-menu/components/ProjectTabButtons/ProjectTabButtons.tsx
@@ -42,7 +42,6 @@ const ProjectTabButtons = ({
     const templatesSubmissionForm = useApplicationInfoStore((state) => state.templatesSubmissionForm.projects);
 
     const ff_1039 = useFeatureFlagsStore()('ff-1039');
-    const ff_1042 = useFeatureFlagsStore()('ff-1042');
     const ff_2939 = useFeatureFlagsStore()('ff-2939');
 
     const handleButtonClick = (event: MouseEvent<HTMLDivElement>) => {
@@ -71,16 +70,14 @@ const ProjectTabButtons = ({
                 variant="ghost"
             />
 
-            {ff_1042 && (
-                <Button
-                    aria-label="Share ProjectButton"
-                    className="dropdown-menu-item"
-                    icon={<Share2Icon />}
-                    label="Share"
-                    onClick={onShareProject}
-                    variant="ghost"
-                />
-            )}
+            <Button
+                aria-label="Share ProjectButton"
+                className="dropdown-menu-item"
+                icon={<Share2Icon />}
+                label="Share"
+                onClick={onShareProject}
+                variant="ghost"
+            />
 
             {ff_2939 && (
                 <Button

--- a/client/src/pages/automation/project/components/project-header/components/settings-menu/components/WorkflowTabButtons.tsx
+++ b/client/src/pages/automation/project/components/project-header/components/settings-menu/components/WorkflowTabButtons.tsx
@@ -23,7 +23,6 @@ const WorkflowTabButtons = ({
 }) => {
     const templatesSubmissionForm = useApplicationInfoStore((state) => state.templatesSubmissionForm.workflows);
 
-    const ff_1042 = useFeatureFlagsStore()('ff-1042');
     const ff_2939 = useFeatureFlagsStore()('ff-2939');
 
     const handleButtonClick = (event: MouseEvent<HTMLDivElement>) => {
@@ -50,15 +49,13 @@ const WorkflowTabButtons = ({
                 variant="ghost"
             />
 
-            {ff_1042 && (
-                <Button
-                    className="dropdown-menu-item"
-                    icon={<Share2Icon />}
-                    label="Share"
-                    onClick={onShareWorkflow}
-                    variant="ghost"
-                />
-            )}
+            <Button
+                className="dropdown-menu-item"
+                icon={<Share2Icon />}
+                label="Share"
+                onClick={onShareWorkflow}
+                variant="ghost"
+            />
 
             {ff_2939 && (
                 <Button

--- a/client/src/pages/automation/projects/components/project-list/ProjectListItem.tsx
+++ b/client/src/pages/automation/projects/components/project-list/ProjectListItem.tsx
@@ -111,7 +111,6 @@ const ProjectListItem = ({project, projectGitConfiguration, remainingTags}: Proj
     );
 
     const ff_1039 = useFeatureFlagsStore()('ff-1039');
-    const ff_1042 = useFeatureFlagsStore()('ff-1042');
     const ff_2939 = useFeatureFlagsStore()('ff-2939');
 
     const queryClient = useQueryClient();
@@ -538,15 +537,13 @@ const ProjectListItem = ({project, projectGitConfiguration, remainingTags}: Proj
                                     </DropdownMenuItem>
                                 )}
 
-                                {ff_1042 && (
-                                    <DropdownMenuItem
-                                        aria-label="Share Project"
-                                        className="dropdown-menu-item"
-                                        onClick={() => setShowProjectShareDialog(true)}
-                                    >
-                                        <Share2Icon /> Share
-                                    </DropdownMenuItem>
-                                )}
+                                <DropdownMenuItem
+                                    aria-label="Share Project"
+                                    className="dropdown-menu-item"
+                                    onClick={() => setShowProjectShareDialog(true)}
+                                >
+                                    <Share2Icon /> Share
+                                </DropdownMenuItem>
 
                                 {ff_2939 && (
                                     <DropdownMenuItem

--- a/client/src/pages/automation/projects/components/project-workflow-list/ProjectWorkflowListItem.tsx
+++ b/client/src/pages/automation/projects/components/project-workflow-list/ProjectWorkflowListItem.tsx
@@ -75,7 +75,6 @@ const ProjectWorkflowListItem = ({
 
     const [searchParams] = useSearchParams();
 
-    const ff_1042 = useFeatureFlagsStore()('ff-1042');
     const ff_2939 = useFeatureFlagsStore()('ff-2939');
 
     const queryClient = useQueryClient();
@@ -304,14 +303,12 @@ const ProjectWorkflowListItem = ({
                             </DropdownMenuItem>
                         )}
 
-                        {ff_1042 && (
-                            <DropdownMenuItem
-                                className="dropdown-menu-item"
-                                onClick={() => setShowWorkflowShareDialog(true)}
-                            >
-                                <Share2Icon /> Share
-                            </DropdownMenuItem>
-                        )}
+                        <DropdownMenuItem
+                            className="dropdown-menu-item"
+                            onClick={() => setShowWorkflowShareDialog(true)}
+                        >
+                            <Share2Icon /> Share
+                        </DropdownMenuItem>
 
                         {ff_2939 && (
                             <DropdownMenuItem

--- a/docker-compose.src.yml
+++ b/docker-compose.src.yml
@@ -21,8 +21,10 @@ services:
       - BYTECHEF_DATASOURCE_URL=jdbc:postgresql://postgres:5432/bytechef
       - BYTECHEF_DATASOURCE_USERNAME=postgres
       - BYTECHEF_DATASOURCE_PASSWORD=postgres
+      - BYTECHEF_ENCRYPTION_PROVIDER=property
+      - BYTECHEF_ENCRYPTION_PROPERTY_KEY=tTB1/UBIbYLuCXVi4PPfzA==
       - BYTECHEF_FEATURE_FLAGS
-      - BYTECHEF_SECURITY_REMEMBER-ME_KEY=e48keep1this1safe3ffb2
+      - BYTECHEF_SECURITY_REMEMBER_ME_KEY=e48keep1this1safe3ffb2
     ports:
       - "8080:8080"
 volumes:

--- a/docker-compose.src.yml
+++ b/docker-compose.src.yml
@@ -21,14 +21,16 @@ services:
       - BYTECHEF_DATASOURCE_URL=jdbc:postgresql://postgres:5432/bytechef
       - BYTECHEF_DATASOURCE_USERNAME=postgres
       - BYTECHEF_DATASOURCE_PASSWORD=postgres
-      - BYTECHEF_ENCRYPTION_PROVIDER=property
-      - BYTECHEF_ENCRYPTION_PROPERTY_KEY=tTB1/UBIbYLuCXVi4PPfzA==
       - BYTECHEF_FEATURE_FLAGS
       - BYTECHEF_SECURITY_REMEMBER_ME_KEY=e48keep1this1safe3ffb2
+    volumes:
+      - storage_key:/root/.bytechef
     ports:
       - "8080:8080"
 volumes:
   storage_db:
+    driver: "local"
+  storage_key:
     driver: "local"
   storage_cache:
     driver: "local"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,8 +26,10 @@ services:
       - BYTECHEF_DATASOURCE_URL=jdbc:postgresql://postgres:5432/bytechef
       - BYTECHEF_DATASOURCE_USERNAME=postgres
       - BYTECHEF_DATASOURCE_PASSWORD=postgres
+      - BYTECHEF_ENCRYPTION_PROVIDER=property
+      - BYTECHEF_ENCRYPTION_PROPERTY_KEY=tTB1/UBIbYLuCXVi4PPfzA==
       - BYTECHEF_FEATURE_FLAGS
-      - BYTECHEF_SECURITY_REMEMBER-ME_KEY=e48keep1this1safe3ffb2
+      - BYTECHEF_SECURITY_REMEMBER_ME_KEY=e48keep1this1safe3ffb2
     ports:
       - "8080:8080"
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,14 +26,16 @@ services:
       - BYTECHEF_DATASOURCE_URL=jdbc:postgresql://postgres:5432/bytechef
       - BYTECHEF_DATASOURCE_USERNAME=postgres
       - BYTECHEF_DATASOURCE_PASSWORD=postgres
-      - BYTECHEF_ENCRYPTION_PROVIDER=property
-      - BYTECHEF_ENCRYPTION_PROPERTY_KEY=tTB1/UBIbYLuCXVi4PPfzA==
       - BYTECHEF_FEATURE_FLAGS
       - BYTECHEF_SECURITY_REMEMBER_ME_KEY=e48keep1this1safe3ffb2
+    volumes:
+      - storage_key:/root/.bytechef
     ports:
       - "8080:8080"
 volumes:
   storage_db:
+    driver: "local"
+  storage_key:
     driver: "local"
   storage_cache:
     driver: "local"

--- a/docs/content/docs/platform/automation/build/workflows/projects.mdx
+++ b/docs/content/docs/platform/automation/build/workflows/projects.mdx
@@ -308,13 +308,6 @@ Click **Publish** to make the project available.
 
 ## Share Projects and Workflows as Templates
 
-<Callout type="warn" title="Coming soon">
-    Sharing as a template is behind a feature flag that is not enabled in the latest released
-    version of ByteChef, so the **Share** and **Share with Community** menu items described below
-    are not visible yet. To move a project between workspaces or instances today, use
-    [Export Project](#export-project) and [Import Project](#import-project).
-</Callout>
-
 Beyond [exporting a project](#export-project) to a `.zip` file for your own backups, a project - or
 an individual workflow, from its own three-dot menu - can be shared as a **template** that anyone
 with the link can import into their own workspace.
@@ -350,6 +343,12 @@ If you keep editing the project after sharing it, the dialog notes that "an olde
 A second, separate action - **Share with Community** - opens ByteChef's public template submission
 form in a new tab, for projects and workflows you want listed in the official gallery (see
 [Templates](/platform/automation/build/workflows/templates)) rather than shared privately by link.
+
+<Callout type="warn" title="Coming soon">
+    **Share with Community** is behind a feature flag that is not enabled in the latest released
+    version of ByteChef, so that menu item is not visible yet. Sharing privately by link, described
+    above, is available.
+</Callout>
 
 ## Delete Project
 

--- a/docs/content/docs/platform/use-bytechef/self-hosted/installation/local-docker.mdx
+++ b/docs/content/docs/platform/use-bytechef/self-hosted/installation/local-docker.mdx
@@ -31,6 +31,11 @@ workflows, connections, and execution history - lives there, so `docker compose 
 `-v`) deletes all of it. Plain `docker compose down` stops the containers and leaves the volume
 intact.
 
+The Compose file also sets a fixed encryption key (`BYTECHEF_ENCRYPTION_PROVIDER=property` with
+`BYTECHEF_ENCRYPTION_PROPERTY_KEY`) so stored OAuth connection credentials remain decryptable after
+you recreate the ByteChef container. Without a stable key, a fresh container cannot read connections
+already stored in PostgreSQL.
+
 To point ByteChef at a PostgreSQL server you run yourself instead, override the datasource settings
 on the `bytechef` service:
 
@@ -82,6 +87,8 @@ docker run --name bytechef -it -p 8080:8080 \
     --env BYTECHEF_DATASOURCE_URL=jdbc:postgresql://postgres:5432/bytechef \
     --env BYTECHEF_DATASOURCE_USERNAME=postgres \
     --env BYTECHEF_DATASOURCE_PASSWORD=postgres \
+    --env BYTECHEF_ENCRYPTION_PROVIDER=property \
+    --env BYTECHEF_ENCRYPTION_PROPERTY_KEY=tTB1/UBIbYLuCXVi4PPfzA== \
     --env BYTECHEF_SECURITY_REMEMBER_ME_KEY=e48612ba1fd46fa7089fe9f5085d8d164b53ffb2 \
     --network bytechef_network \
     docker.bytechef.io/bytechef/bytechef:latest

--- a/docs/content/docs/platform/use-bytechef/self-hosted/installation/local-docker.mdx
+++ b/docs/content/docs/platform/use-bytechef/self-hosted/installation/local-docker.mdx
@@ -31,10 +31,23 @@ workflows, connections, and execution history - lives there, so `docker compose 
 `-v`) deletes all of it. Plain `docker compose down` stops the containers and leaves the volume
 intact.
 
-The Compose file also sets a fixed encryption key (`BYTECHEF_ENCRYPTION_PROVIDER=property` with
-`BYTECHEF_ENCRYPTION_PROPERTY_KEY`) so stored OAuth connection credentials remain decryptable after
-you recreate the ByteChef container. Without a stable key, a fresh container cannot read connections
-already stored in PostgreSQL.
+ByteChef encrypts stored connection credentials with an instance-wide key. Under the default
+`filesystem` provider the key is generated on first start and written inside the container, which
+does not survive `docker rm` - so the Compose file keeps it in a second named volume, `storage_key`.
+Recreating the ByteChef container then leaves stored connections readable. `docker compose down -v`
+deletes this volume too, and a database restored without its key is a database of undecryptable
+credentials, so back the two up together.
+
+<Callout type="warn">
+If you created your instance before `storage_key` was added, its key still lives inside the old
+container and is lost the first time that container is recreated. Existing connections cannot be
+recovered without it - re-create them once after upgrading, then the key persists.
+</Callout>
+
+For anything beyond a local install - a multi-replica deployment, or any host where you want to hold
+the key yourself - set `BYTECHEF_ENCRYPTION_PROVIDER=property` with your own
+`BYTECHEF_ENCRYPTION_PROPERTY_KEY` from a secret manager instead. See
+[Configuration](/platform/use-bytechef/self-hosted/configuration#the-key).
 
 To point ByteChef at a PostgreSQL server you run yourself instead, override the datasource settings
 on the `bytechef` service:
@@ -80,7 +93,21 @@ docker run --name postgres -d -p 5432:5432 \
 </Step>
 <Step>
 
+**Generate an encryption key**
+
+There is no Compose file to persist the key for you here, so supply your own and store it somewhere
+safe - lose it and every stored credential becomes undecryptable:
+
+```bash
+openssl rand -base64 16
+```
+
+</Step>
+<Step>
+
 **Start the ByteChef container**
+
+Replace `<your-encryption-key>` with the value generated above:
 
 ```bash
 docker run --name bytechef -it -p 8080:8080 \
@@ -88,7 +115,7 @@ docker run --name bytechef -it -p 8080:8080 \
     --env BYTECHEF_DATASOURCE_USERNAME=postgres \
     --env BYTECHEF_DATASOURCE_PASSWORD=postgres \
     --env BYTECHEF_ENCRYPTION_PROVIDER=property \
-    --env BYTECHEF_ENCRYPTION_PROPERTY_KEY=tTB1/UBIbYLuCXVi4PPfzA== \
+    --env BYTECHEF_ENCRYPTION_PROPERTY_KEY=<your-encryption-key> \
     --env BYTECHEF_SECURITY_REMEMBER_ME_KEY=e48612ba1fd46fa7089fe9f5085d8d164b53ffb2 \
     --network bytechef_network \
     docker.bytechef.io/bytechef/bytechef:latest


### PR DESCRIPTION
Graduates the project/workflow **Share** action out from behind `ff-1042`, closing #1042.

## Client

Removes the `ff-1042` gate from the four call sites that render the **Share** menu item, so the action is visible by default:

- `ProjectListItem.tsx` - project list three-dot menu
- `ProjectWorkflowListItem.tsx` - workflow list three-dot menu
- `ProjectTabButtons.tsx` - project header settings menu
- `WorkflowTabButtons.tsx` - workflow header settings menu

Each change is the same shape: drop the `const ff_1042 = useFeatureFlagsStore()('ff-1042')` declaration and unwrap the `{ff_1042 && (...)}` guard. No behaviour changes beyond visibility.

`ff-2939` is deliberately left in place - it gates the separate **Share with Community** action (public template submission form), which is a different feature and is not part of this issue.

## Docs

`Share Projects and Workflows as Templates` carried a section-level "Coming soon" callout saying both **Share** and **Share with Community** were hidden. Since only the latter is still gated, the callout is narrowed to **Share with Community** and moved down to the paragraph that describes it, so the section no longer warns readers away from an action that now ships.

## Verification

Run against `client/` with the toolchain pinned by `package.json` (TypeScript 5.9.3):

- `prettier --check` on the four files - clean (baseline on an untouched file confirmed first)
- `eslint --max-warnings=0` on the four files - exit 0
- `tsc --project tsconfig.json --noEmit` (full project) - exit 0

Closes #1042

🤖 Generated with [Claude Code](https://claude.com/claude-code)
