### PR TITLE
1042 Remove the ff-1042 gate from project and workflow sharing

### DIFF
--- a/client/src/pages/automation/project/components/project-header/components/settings-menu/components/ProjectTabButtons/ProjectTabButtons.tsx
+++ b/client/src/pages/automation/project/components/project-header/components/settings-menu/components/ProjectTabButtons/ProjectTabButtons.tsx
@@ -42,7 +42,6 @@ const ProjectTabButtons = ({
     const templatesSubmissionForm = useApplicationInfoStore((state) => state.templatesSubmissionForm.projects);
 
     const ff_1039 = useFeatureFlagsStore()('ff-1039');
-    const ff_1042 = useFeatureFlagsStore()('ff-1042');
     const ff_2939 = useFeatureFlagsStore()('ff-2939');
 
     const handleButtonClick = (event: MouseEvent<HTMLDivElement>) => {
@@ -71,16 +70,14 @@ const ProjectTabButtons = ({
                 variant="ghost"
             />
 
-            {ff_1042 && (
-                <Button
-                    aria-label="Share ProjectButton"
-                    className="dropdown-menu-item"
-                    icon={<Share2Icon />}
-                    label="Share"
-                    onClick={onShareProject}
-                    variant="ghost"
-                />
-            )}
+            <Button
+                aria-label="Share ProjectButton"
+                className="dropdown-menu-item"
+                icon={<Share2Icon />}
+                label="Share"
+                onClick={onShareProject}
+                variant="ghost"
+            />
 
             {ff_2939 && (
                 <Button

--- a/client/src/pages/automation/project/components/project-header/components/settings-menu/components/WorkflowTabButtons.tsx
+++ b/client/src/pages/automation/project/components/project-header/components/settings-menu/components/WorkflowTabButtons.tsx
@@ -23,7 +23,6 @@ const WorkflowTabButtons = ({
 }) => {
     const templatesSubmissionForm = useApplicationInfoStore((state) => state.templatesSubmissionForm.workflows);
 
-    const ff_1042 = useFeatureFlagsStore()('ff-1042');
     const ff_2939 = useFeatureFlagsStore()('ff-2939');
 
     const handleButtonClick = (event: MouseEvent<HTMLDivElement>) => {
@@ -50,15 +49,13 @@ const WorkflowTabButtons = ({
                 variant="ghost"
             />
 
-            {ff_1042 && (
-                <Button
-                    className="dropdown-menu-item"
-                    icon={<Share2Icon />}
-                    label="Share"
-                    onClick={onShareWorkflow}
-                    variant="ghost"
-                />
-            )}
+            <Button
+                className="dropdown-menu-item"
+                icon={<Share2Icon />}
+                label="Share"
+                onClick={onShareWorkflow}
+                variant="ghost"
+            />
 
             {ff_2939 && (
                 <Button

--- a/client/src/pages/automation/projects/components/project-list/ProjectListItem.tsx
+++ b/client/src/pages/automation/projects/components/project-list/ProjectListItem.tsx
@@ -111,7 +111,6 @@ const ProjectListItem = ({project, projectGitConfiguration, remainingTags}: Proj
     );
 
     const ff_1039 = useFeatureFlagsStore()('ff-1039');
-    const ff_1042 = useFeatureFlagsStore()('ff-1042');
     const ff_2939 = useFeatureFlagsStore()('ff-2939');
 
     const queryClient = useQueryClient();
@@ -538,15 +537,13 @@ const ProjectListItem = ({project, projectGitConfiguration, remainingTags}: Proj
                                     </DropdownMenuItem>
                                 )}
 
-                                {ff_1042 && (
-                                    <DropdownMenuItem
-                                        aria-label="Share Project"
-                                        className="dropdown-menu-item"
-                                        onClick={() => setShowProjectShareDialog(true)}
-                                    >
-                                        <Share2Icon /> Share
-                                    </DropdownMenuItem>
-                                )}
+                                <DropdownMenuItem
+                                    aria-label="Share Project"
+                                    className="dropdown-menu-item"
+                                    onClick={() => setShowProjectShareDialog(true)}
+                                >
+                                    <Share2Icon /> Share
+                                </DropdownMenuItem>
 
                                 {ff_2939 && (
                                     <DropdownMenuItem

--- a/client/src/pages/automation/projects/components/project-workflow-list/ProjectWorkflowListItem.tsx
+++ b/client/src/pages/automation/projects/components/project-workflow-list/ProjectWorkflowListItem.tsx
@@ -75,7 +75,6 @@ const ProjectWorkflowListItem = ({
 
     const [searchParams] = useSearchParams();
 
-    const ff_1042 = useFeatureFlagsStore()('ff-1042');
     const ff_2939 = useFeatureFlagsStore()('ff-2939');
 
     const queryClient = useQueryClient();
@@ -304,14 +303,12 @@ const ProjectWorkflowListItem = ({
                             </DropdownMenuItem>
                         )}
 
-                        {ff_1042 && (
-                            <DropdownMenuItem
-                                className="dropdown-menu-item"
-                                onClick={() => setShowWorkflowShareDialog(true)}
-                            >
-                                <Share2Icon /> Share
-                            </DropdownMenuItem>
-                        )}
+                        <DropdownMenuItem
+                            className="dropdown-menu-item"
+                            onClick={() => setShowWorkflowShareDialog(true)}
+                        >
+                            <Share2Icon /> Share
+                        </DropdownMenuItem>
 
                         {ff_2939 && (
                             <DropdownMenuItem

--- a/docs/content/docs/platform/automation/build/workflows/projects.mdx
+++ b/docs/content/docs/platform/automation/build/workflows/projects.mdx
@@ -344,12 +344,6 @@ A second, separate action - **Share with Community** - opens ByteChef's public t
 form in a new tab, for projects and workflows you want listed in the official gallery (see
 [Templates](/platform/automation/build/workflows/templates)) rather than shared privately by link.
 
-<Callout type="warn" title="Coming soon">
-    **Share with Community** is behind a feature flag that is not enabled in the latest released
-    version of ByteChef, so that menu item is not visible yet. Sharing privately by link, described
-    above, is available.
-</Callout>
-
 ## Delete Project
 
 <Steps>

--- a/docs/content/docs/platform/automation/build/workflows/projects.mdx
+++ b/docs/content/docs/platform/automation/build/workflows/projects.mdx
@@ -308,13 +308,6 @@ Click **Publish** to make the project available.
 
 ## Share Projects and Workflows as Templates
 
-<Callout type="warn" title="Coming soon">
-    Sharing as a template is behind a feature flag that is not enabled in the latest released
-    version of ByteChef, so the **Share** and **Share with Community** menu items described below
-    are not visible yet. To move a project between workspaces or instances today, use
-    [Export Project](#export-project) and [Import Project](#import-project).
-</Callout>
-
 Beyond [exporting a project](#export-project) to a `.zip` file for your own backups, a project - or
 an individual workflow, from its own three-dot menu - can be shared as a **template** that anyone
 with the link can import into their own workspace.
@@ -350,6 +343,12 @@ If you keep editing the project after sharing it, the dialog notes that "an olde
 A second, separate action - **Share with Community** - opens ByteChef's public template submission
 form in a new tab, for projects and workflows you want listed in the official gallery (see
 [Templates](/platform/automation/build/workflows/templates)) rather than shared privately by link.
+
+<Callout type="warn" title="Coming soon">
+    **Share with Community** is behind a feature flag that is not enabled in the latest released
+    version of ByteChef, so that menu item is not visible yet. Sharing privately by link, described
+    above, is available.
+</Callout>
 
 ## Delete Project
 


### PR DESCRIPTION
Graduates the project/workflow **Share** action out from behind `ff-1042`, closing #1042.

## Client

Removes the `ff-1042` gate from the four call sites that render the **Share** menu item, so the action is visible by default:

- `ProjectListItem.tsx` - project list three-dot menu
- `ProjectWorkflowListItem.tsx` - workflow list three-dot menu
- `ProjectTabButtons.tsx` - project header settings menu
- `WorkflowTabButtons.tsx` - workflow header settings menu

Each change is the same shape: drop the `const ff_1042 = useFeatureFlagsStore()('ff-1042')` declaration and unwrap the `{ff_1042 && (...)}` guard. No behaviour changes beyond visibility.

`ff-2939` is deliberately left in place - it gates the separate **Share with Community** action (public template submission form), which is a different feature and is not part of this issue.

## Docs

`Share Projects and Workflows as Templates` carried a section-level "Coming soon" callout saying both **Share** and **Share with Community** were hidden. Since only the latter is still gated, the callout is narrowed to **Share with Community** and moved down to the paragraph that describes it, so the section no longer warns readers away from an action that now ships.

## Verification

Run against `client/` with the toolchain pinned by `package.json` (TypeScript 5.9.3):

- `prettier --check` on the four files - clean (baseline on an untouched file confirmed first)
- `eslint --max-warnings=0` on the four files - exit 0
- `tsc --project tsconfig.json --noEmit` (full project) - exit 0

Closes #1042

🤖 Generated with [Claude Code](https://claude.com/claude-code)
