### PR TITLE
Add a README FAQ and correct the connector, flow-control, trigger and polyglot claims

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,7 +146,7 @@ The `server/ee/` directory contains microservices for distributed deployment:
 - `runtime-job-app/` - Runtime job execution
 
 ### Available Components
-ByteChef includes 180+ built-in components in `server/libs/modules/components/` covering CRM, project management, communication, e-commerce, cloud storage, AI/ML, databases, and custom code execution.
+ByteChef includes 250+ built-in components in `server/libs/modules/components/` covering CRM, project management, communication, e-commerce, cloud storage, AI/ML, databases, and custom code execution.
 
 ## Development Patterns
 

--- a/README.md
+++ b/README.md
@@ -203,3 +203,55 @@ This project is licenced under **Apache 2.0** for the core (everything outside `
 ## Credits
 
 ByteChef started as a fork of [Piper](https://github.com/runabol/piper).
+
+## FAQ
+
+### What is ByteChef?
+
+ByteChef is an open-source platform that unifies AI agent orchestration and automation workflows. It provides a unified interface for integrating multiple AI services and automating complex business processes.
+
+### Key Features
+
+| Feature | Description |
+|---------|-------------|
+| **AI Agent Orchestration** | Coordinate multiple AI agents for complex tasks |
+| **Workflow Automation** | Automate repetitive tasks with AI-powered decision making |
+| **Multi-Platform Integration** | Connect with popular AI services and platforms |
+| **Extensible Architecture** | Add custom tools and integrations easily |
+| **Low-Code Interface** | Build workflows visually without extensive coding |
+
+### How to get started?
+
+1. Check the [Installation Guide](#installation) in the README
+2. Follow the [Quick Start](#quick-start) instructions
+3. Explore the [Examples](#examples) section for common use cases
+4. Join the [Community](#community) for support and discussions
+
+### What integrations are available?
+
+ByteChef integrates with:
+- **AI Services** - OpenAI, Anthropic, AWS Bedrock, and more
+- **Data Sources** - PostgreSQL, MySQL, MongoDB, REST APIs
+- **Business Tools** - Slack, Email, CRM systems
+- **Cloud Platforms** - AWS, GCP, Azure
+
+### Is this project free and open source?
+
+Yes! ByteChef is licensed under an open-source license. You can use it freely for personal and commercial projects. Check the [License](#license) section for details.
+
+### How can I contribute?
+
+1. Fork the repository
+2. Create a feature branch
+3. Make your changes with clear commit messages
+4. Submit a pull request following the project's contribution guidelines
+
+### Where can I get help?
+
+- **Documentation** - Check the README and docs folder
+- **GitHub Issues** - Report bugs or request features
+- **Community Chat** - Join discussions with other users and developers
+
+---
+
+**Made with ❤️ by the ByteChef community**

--- a/README.md
+++ b/README.md
@@ -182,6 +182,50 @@ CRM · marketing · communication · e-commerce · cloud storage · databases ·
 
 ---
 
+## FAQ
+
+### How is this different from n8n, Zapier or Make?
+
+Those are automation tools where AI is a node you call and get an answer back. In ByteChef an agent is a step that owns a loop — it selects tools, executes them, observes the result and decides what to do next — and any workflow can be handed to an agent as a single tool. You get deterministic branching, retries and approvals in the same graph as the non-deterministic part, under one audit trail.
+
+### How is this different from LangChain, LangGraph or CrewAI?
+
+Those are libraries you build an application around: you own deployment, persistence, retries, credential storage and the UI. ByteChef is the running system — durable execution, a visual editor, managed connections, and 180+ connectors that are already agent tools. You can still drop into code where it earns its place; it just isn't the only way in.
+
+### Which LLM providers ship out of the box?
+
+Twelve direct providers — OpenAI, Anthropic, Azure OpenAI, Amazon Bedrock, Google Gemini, Mistral, Groq, DeepSeek, Nvidia, Perplexity, Stability and Ollama — plus three aggregator components (OpenRouter, LiteLLM, NanoGPT) if you would rather route through a gateway.
+
+### How does an agent get its tools?
+
+Every connector is already a tool, and so is any workflow you point the agent at. To let the model supply a value at runtime, put the expression `=fromAi('order_id', 'STRING', {'description': 'The order to refund'})` in the field instead of a literal — that property then becomes part of the tool schema the model sees. It is the same properties panel you would otherwise type into; there is no separate tool definition to write.
+
+### What is available for memory and RAG?
+
+Eight chat-memory backends (built-in, JDBC, Redis, MongoDB, Cassandra, Neo4j, vector-store-backed, in-memory) and fourteen vector stores (pgvector, Pinecone, Qdrant, Weaviate, Milvus, Couchbase, MongoDB Atlas, Neo4j, Redis, Typesense, MariaDB, Oracle, S3, and the built-in knowledge base). Ingestion and chunking are native, and two RAG patterns ship as components: `rag-modular` and `rag-questionanswer`.
+
+### What guardrails are there?
+
+Twelve, attached to an agent the same way tools and memory are: PII, LLM-based PII, jailbreak, NSFW, topical alignment, keywords, secret keys, URLs, text sanitization, custom regex, custom rules, and a violation aggregator that decides what happens when several fire at once.
+
+### Does ByteChef work with MCP?
+
+In both directions. It consumes external MCP servers as a tool source, so remote MCP tools show up alongside connectors in an agent's tool list. It also exposes your own workflows as an MCP server over an API-key-authenticated endpoint, so Claude Desktop, Cursor or Windsurf can call them.
+
+### Do I need the Enterprise Edition?
+
+Only for the rows marked EE in the table above. Everything outside `/ee/` is Apache 2.0 — free to self-host and use commercially, including modified. Code under `/ee/` is covered by the ByteChef Enterprise License and is not; see [License](#license).
+
+### Where do I get help?
+
+- **Docs** — [docs.bytechef.io](https://docs.bytechef.io)
+- **Discord** — [discord.gg/VKvNxHjpYx](https://discord.gg/VKvNxHjpYx)
+- **Issues** — [GitHub Issues](https://github.com/bytechefhq/bytechef/issues), with templates for bugs, features and connector requests
+- **Roadmap** — [project board](https://github.com/orgs/bytechefhq/projects/3)
+- **Email** — [support@bytechef.io](mailto:support@bytechef.io)
+
+---
+
 ## Contributing
 
 If you would like to contribute to the software, read the [contributing guide](https://github.com/bytechefhq/bytechef/blob/master/CONTRIBUTING.md) to get started.
@@ -203,55 +247,3 @@ This project is licenced under **Apache 2.0** for the core (everything outside `
 ## Credits
 
 ByteChef started as a fork of [Piper](https://github.com/runabol/piper).
-
-## FAQ
-
-### What is ByteChef?
-
-ByteChef is an open-source platform that unifies AI agent orchestration and automation workflows. It provides a unified interface for integrating multiple AI services and automating complex business processes.
-
-### Key Features
-
-| Feature | Description |
-|---------|-------------|
-| **AI Agent Orchestration** | Coordinate multiple AI agents for complex tasks |
-| **Workflow Automation** | Automate repetitive tasks with AI-powered decision making |
-| **Multi-Platform Integration** | Connect with popular AI services and platforms |
-| **Extensible Architecture** | Add custom tools and integrations easily |
-| **Low-Code Interface** | Build workflows visually without extensive coding |
-
-### How to get started?
-
-1. Check the [Installation Guide](#installation) in the README
-2. Follow the [Quick Start](#quick-start) instructions
-3. Explore the [Examples](#examples) section for common use cases
-4. Join the [Community](#community) for support and discussions
-
-### What integrations are available?
-
-ByteChef integrates with:
-- **AI Services** - OpenAI, Anthropic, AWS Bedrock, and more
-- **Data Sources** - PostgreSQL, MySQL, MongoDB, REST APIs
-- **Business Tools** - Slack, Email, CRM systems
-- **Cloud Platforms** - AWS, GCP, Azure
-
-### Is this project free and open source?
-
-Yes! ByteChef is licensed under an open-source license. You can use it freely for personal and commercial projects. Check the [License](#license) section for details.
-
-### How can I contribute?
-
-1. Fork the repository
-2. Create a feature branch
-3. Make your changes with clear commit messages
-4. Submit a pull request following the project's contribution guidelines
-
-### Where can I get help?
-
-- **Documentation** - Check the README and docs folder
-- **GitHub Issues** - Report bugs or request features
-- **Community Chat** - Join discussions with other users and developers
-
----
-
-**Made with ❤️ by the ByteChef community**

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Open <http://localhost:8080/login> → **Create Account** → sign in.
 1. **New Project → New Workflow**,
 2. Add a trigger
 3. Add the **AI Agent** component
-4. Pick a **model**, attach **tools** from 200+ connectors, optionally add a **knowledge base** and **guardrails**
+4. Pick a **model**, attach **tools** from 180+ connectors, optionally add a **knowledge base** and **guardrails**
 5. Fill the necessary credentials
 6. Configure each component's parameters in the properties panel
 7. Test your workflow
@@ -136,9 +136,9 @@ Open <http://localhost:8080/login> → **Create Account** → sign in.
 ## Workflow Automation
 
 - **Visual editor** with JSON underneath, Git-friendly
-- **Flow controls** — `condition` · `switch` · `loop` · `each` · `parallel` · `branch` · sub-workflows
-- **Triggers** — webhook · schedule · polling · app-event · manual · form
-- **Polyglot code** — Java · JavaScript · Python · Ruby on GraalVM
+- **Flow controls** — `condition` · `branch` · `loop` · `each` · `map` · `parallel` · `fork-join` · `subflow` · `on-error` · `terminate` · `waitForApproval`
+- **Triggers** — static & dynamic webhooks · polling · app-event listeners · callable, plus schedule and form components
+- **Polyglot code** — JavaScript · Python · Ruby on GraalVM
 - **Durable execution** on the Atlas runtime, Postgres-backed, queue-mode for horizontal scale (memory · Redis · RabbitMQ · Kafka · JMS · AMQP · SQS)
 - **Workflows-as-APIs** — workflows can be an authenticated HTTP endpoint
 - **Git-native** — push from the UI, environments backed by branches
@@ -165,8 +165,8 @@ CRM · marketing · communication · e-commerce · cloud storage · databases ·
 
 | Capability                                                                | CE (Apache 2.0) | EE |
 |---------------------------------------------------------------------------| --- | --- |
-| Visual editor, AI agents, workflows, 200+ connectors                      | ✅ | ✅ |
-| Polyglot code (Java/JS/Python/Ruby)                                       | ✅ | ✅ |
+| Visual editor, AI agents, workflows, 180+ connectors                      | ✅ | ✅ |
+| Polyglot code (JS/Python/Ruby)                                            | ✅ | ✅ |
 | Knowledge bases, vector stores, guardrails, MCP server                    | ✅ | ✅ |
 | Agent skills, agent evaluations                                           | 🚧 in development | 🚧 in development |
 | Self-host (Docker / Kubernetes / Helm)                                    | ✅ | ✅ |

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Open <http://localhost:8080/login> → **Create Account** → sign in.
 1. **New Project → New Workflow**,
 2. Add a trigger
 3. Add the **AI Agent** component
-4. Pick a **model**, attach **tools** from 180+ connectors, optionally add a **knowledge base** and **guardrails**
+4. Pick a **model**, attach **tools** from 250+ connectors, optionally add a **knowledge base** and **guardrails**
 5. Fill the necessary credentials
 6. Configure each component's parameters in the properties panel
 7. Test your workflow
@@ -137,7 +137,7 @@ Open <http://localhost:8080/login> → **Create Account** → sign in.
 
 - **Visual editor** with JSON underneath, Git-friendly
 - **Flow controls** — `condition` · `branch` · `loop` · `each` · `map` · `parallel` · `fork-join` · `subflow` · `on-error` · `terminate` · `waitForApproval`
-- **Triggers** — static & dynamic webhooks · polling · app-event listeners · callable, plus schedule and form components
+- **Triggers** — static & dynamic webhooks · polling · hybrid · app-event listeners · callable, plus schedule and form components
 - **Polyglot code** — JavaScript · Python · Ruby on GraalVM
 - **Durable execution** on the Atlas runtime, Postgres-backed, queue-mode for horizontal scale (memory · Redis · RabbitMQ · Kafka · JMS · AMQP · SQS)
 - **Workflows-as-APIs** — workflows can be an authenticated HTTP endpoint
@@ -155,7 +155,7 @@ Open <http://localhost:8080/login> → **Create Account** → sign in.
 
 ---
 
-## 180+ connectors
+## 250+ connectors
 
 CRM · marketing · communication · e-commerce · cloud storage · databases · AI/ML · helpdesk · finance. Every connector is **also an agent tool, also an MCP tool**. Browse the [full catalog](https://docs.bytechef.io/reference/components).
 
@@ -165,7 +165,7 @@ CRM · marketing · communication · e-commerce · cloud storage · databases ·
 
 | Capability                                                                | CE (Apache 2.0) | EE |
 |---------------------------------------------------------------------------| --- | --- |
-| Visual editor, AI agents, workflows, 180+ connectors                      | ✅ | ✅ |
+| Visual editor, AI agents, workflows, 250+ connectors                      | ✅ | ✅ |
 | Polyglot code (JS/Python/Ruby)                                            | ✅ | ✅ |
 | Knowledge bases, vector stores, guardrails, MCP server                    | ✅ | ✅ |
 | Agent skills, agent evaluations                                           | 🚧 in development | 🚧 in development |
@@ -186,11 +186,11 @@ CRM · marketing · communication · e-commerce · cloud storage · databases ·
 
 ### How is this different from n8n, Zapier or Make?
 
-Those are automation tools where AI is a node you call and get an answer back. In ByteChef an agent is a step that owns a loop — it selects tools, executes them, observes the result and decides what to do next — and any workflow can be handed to an agent as a single tool. You get deterministic branching, retries and approvals in the same graph as the non-deterministic part, under one audit trail.
+Those are automation tools where AI is a node you call and get an answer back. In ByteChef an agent is a step that owns a loop — it selects tools, executes them, observes the result and decides what to do next — and any workflow can be published as an MCP tool for agents to call. You get deterministic branching, retries and approvals in the same graph as the non-deterministic part, under one audit trail.
 
 ### How is this different from LangChain, LangGraph or CrewAI?
 
-Those are libraries you build an application around: you own deployment, persistence, retries, credential storage and the UI. ByteChef is the running system — durable execution, a visual editor, managed connections, and 180+ connectors that are already agent tools. You can still drop into code where it earns its place; it just isn't the only way in.
+Those are libraries you build an application around: you own deployment, persistence, retries, credential storage and the UI. ByteChef is the running system — durable execution, a visual editor, managed connections, and 250+ connectors that are already agent tools. You can still drop into code where it earns its place; it just isn't the only way in.
 
 ### Which LLM providers ship out of the box?
 
@@ -198,7 +198,7 @@ Twelve direct providers — OpenAI, Anthropic, Azure OpenAI, Amazon Bedrock, Goo
 
 ### How does an agent get its tools?
 
-Every connector is already a tool, and so is any workflow you point the agent at. To let the model supply a value at runtime, put the expression `=fromAi('order_id', 'STRING', {'description': 'The order to refund'})` in the field instead of a literal — that property then becomes part of the tool schema the model sees. It is the same properties panel you would otherwise type into; there is no separate tool definition to write.
+Every connector is already a tool, and workflows you expose through the MCP server become tools too. To let the model supply a value at runtime, put the expression `=fromAi('order_id', 'STRING', {'description': 'The order to refund'})` in the field instead of a literal — that property then becomes part of the tool schema the model sees. It is the same properties panel you would otherwise type into; there is no separate tool definition to write.
 
 ### What is available for memory and RAG?
 

--- a/docs/content/docs/developer-guide/architecture.mdx
+++ b/docs/content/docs/developer-guide/architecture.mdx
@@ -43,7 +43,7 @@ flowchart TB
 
     BROKER(["Message broker - memory / Redis / RabbitMQ / Kafka / JMS / SQS"])
 
-    COMP["Component task handlers - 200+ components"]
+    COMP["Component task handlers - 250+ components"]
     SVC(("External services"))
 
     DB[("PostgreSQL")]
@@ -102,7 +102,7 @@ flowchart TB
     subgraph ENGINE["Engine + extensions"]
         ATLAS["atlas - workflow kernel"]
         TD["modules/task-dispatchers - control flow"]
-        COMPS["modules/components - 200+ integrations"]
+        COMPS["modules/components - 250+ integrations"]
     end
 
     subgraph CORE["core"]
@@ -128,7 +128,7 @@ flowchart TB
 |---|---|---|
 | Atlas engine | `server/libs/atlas/` | Generic workflow kernel: definitions, jobs, coordinator, worker, file storage |
 | Task dispatchers | `server/libs/modules/task-dispatchers/` | Control flow: `condition`, `loop`, `each`, `map`, `parallel`, `fork-join`, `branch`, `on-error`, `subflow`, `approval`, `suspend`, `terminate` |
-| Components | `server/libs/modules/components/` | The 200+ integrations built with the Component SDK |
+| Components | `server/libs/modules/components/` | The 250+ integrations built with the Component SDK |
 | Platform | `server/libs/platform/` | Everything that makes Atlas a product: component registry, connections, triggers, webhooks, scheduler, OAuth2, data storage |
 | Automation | `server/libs/automation/` | The workspace/project/deployment domain on top of the platform |
 | Embedded (EE) | `server/ee/libs/embedded/` | The embedded iPaaS domain (integrations, connected users) |


### PR DESCRIPTION
## Summary

- Adds a **FAQ** section to the README covering the questions the rest of the README does not answer: positioning against n8n/Zapier/Make and LangChain/LangGraph/CrewAI, bundled LLM providers, how agents get tools (`=fromAi(...)`), memory and RAG options, guardrails, MCP in both directions, when EE is needed, and where to get help.
- Corrects the **flow control**, **trigger** and **polyglot** lists to match what master actually ships: task dispatchers by their real names (`branch`, `map`, `fork-join`, `subflow`, `on-error`, `terminate`, `waitForApproval`; no `switch`), all six `TriggerType` values, and JS/Python/Ruby only (Java and R actions are commented out in `ScriptComponentHandler`).
- Raises the **connector count** to 250+ everywhere it appears (README, `CLAUDE.md`, architecture guide). Master has 275 component modules in `settings.gradle.kts` and 280 generated reference pages, so both the old 200+ and 180+ figures undersold the catalog.
- Qualifies the workflow-as-tool claim: workflows become agent tools via the MCP server rather than as a direct agent attachment.

Every count in the FAQ (12 direct LLM providers + 3 aggregators, 8 chat-memory backends, 14 vector stores, 12 guardrails, 2 RAG components) was verified against the module tree on master.

## Test plan

- [ ] Docs-only change, no code touched
- [ ] Proofread rendered README on the PR branch
- [ ] Confirm the docs site build picks up the `architecture.mdx` edit

🤖 Generated with [Claude Code](https://claude.com/claude-code)