### PR TITLE
5659 Reject management MCP requests with 401 when the mcp.server secret is not configured

### DIFF
--- a/server/libs/ai/ai-mcp/ai-mcp-server/src/main/java/com/bytechef/ai/mcp/server/security/web/authentication/ManagementMcpServerApiKeyAuthenticationProvider.java
+++ b/server/libs/ai/ai-mcp/ai-mcp-server/src/main/java/com/bytechef/ai/mcp/server/security/web/authentication/ManagementMcpServerApiKeyAuthenticationProvider.java
@@ -62,7 +62,8 @@ public class ManagementMcpServerApiKeyAuthenticationProvider implements Authenti
         ManagementMcpServerApiKeyAuthenticationToken managementMcpServerApiKeyAuthenticationToken =
             (ManagementMcpServerApiKeyAuthenticationToken) authentication;
 
-        Property property = propertyService.getProperty("mcp.server", Property.Scope.PLATFORM, null);
+        Property property = propertyService.fetchProperty("mcp.server", Property.Scope.PLATFORM, null)
+            .orElseThrow(() -> new BadCredentialsException("MCP server secret key is not configured"));
 
         if (!Objects.equals(
             property.get("secretKey"), managementMcpServerApiKeyAuthenticationToken.getMcpServerSecretKey())) {

--- a/server/libs/ai/ai-mcp/ai-mcp-server/src/test/java/com/bytechef/ai/mcp/server/security/web/authentication/ManagementMcpServerApiKeyAuthenticationProviderTest.java
+++ b/server/libs/ai/ai-mcp/ai-mcp-server/src/test/java/com/bytechef/ai/mcp/server/security/web/authentication/ManagementMcpServerApiKeyAuthenticationProviderTest.java
@@ -26,34 +26,50 @@ import static org.mockito.Mockito.when;
 
 import com.bytechef.platform.configuration.domain.Property;
 import com.bytechef.platform.configuration.service.PropertyService;
+import com.bytechef.platform.security.domain.ApiKey;
+import com.bytechef.platform.security.exception.UserNotActivatedException;
 import com.bytechef.platform.security.service.ApiKeyService;
+import com.bytechef.platform.user.domain.Authority;
+import com.bytechef.platform.user.domain.User;
 import com.bytechef.platform.user.service.AuthorityService;
 import com.bytechef.platform.user.service.UserService;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 
 /**
  * @author Ivica Cardic
  */
+@SuppressFBWarnings("HARD_CODE_PASSWORD")
 class ManagementMcpServerApiKeyAuthenticationProviderTest {
 
+    private static final String AUTH_SECRET_KEY = "api-secret";
+    private static final long AUTHORITY_ID = 1L;
     private static final String MCP_SERVER_SECRET_KEY = "mcp-server-secret";
+    private static final long USER_ID = 7L;
 
     private ApiKeyService apiKeyService;
+    private AuthorityService authorityService;
     private PropertyService propertyService;
     private ManagementMcpServerApiKeyAuthenticationProvider provider;
+    private UserService userService;
 
     @BeforeEach
     void beforeEach() {
         apiKeyService = mock(ApiKeyService.class);
+        authorityService = mock(AuthorityService.class);
         propertyService = mock(PropertyService.class);
+        userService = mock(UserService.class);
 
         provider = new ManagementMcpServerApiKeyAuthenticationProvider(
-            apiKeyService, mock(AuthorityService.class), propertyService, mock(UserService.class));
+            apiKeyService, authorityService, propertyService, userService);
     }
 
     @Test
@@ -88,6 +104,74 @@ class ManagementMcpServerApiKeyAuthenticationProviderTest {
         verifyNoInteractions(apiKeyService);
     }
 
+    @Test
+    void testAuthenticateReturnsUserTokenWhenApiKeyIsValid() {
+        stubMcpServerProperty(MCP_SERVER_SECRET_KEY);
+        stubApiKey();
+        stubUser(true);
+
+        Authority authority = new Authority();
+
+        authority.setId(AUTHORITY_ID);
+        authority.setName("ROLE_ADMIN");
+
+        when(authorityService.fetchAuthority(AUTHORITY_ID)).thenReturn(Optional.of(authority));
+
+        Authentication authentication = provider.authenticate(token(MCP_SERVER_SECRET_KEY, AUTH_SECRET_KEY));
+
+        assertThat(authentication.isAuthenticated()).isTrue();
+        assertThat(authentication.getPrincipal())
+            .isInstanceOfSatisfying(
+                org.springframework.security.core.userdetails.User.class,
+                user -> assertThat(user.getUsername()).isEqualTo("admin"));
+        assertThat(authentication.getAuthorities())
+            .extracting(GrantedAuthority::getAuthority)
+            .containsExactly("ROLE_ADMIN");
+    }
+
+    @Test
+    void testAuthenticateRejectsWhenApiKeyIsInvalid() {
+        stubMcpServerProperty(MCP_SERVER_SECRET_KEY);
+
+        when(apiKeyService.getApiKey(AUTH_SECRET_KEY)).thenThrow(new IllegalArgumentException("unknown"));
+
+        assertThatThrownBy(() -> provider.authenticate(token(MCP_SERVER_SECRET_KEY, AUTH_SECRET_KEY)))
+            .isInstanceOf(BadCredentialsException.class);
+
+        verifyNoInteractions(userService);
+    }
+
+    @Test
+    void testAuthenticateRejectsWhenApiKeyUserDoesNotExist() {
+        stubMcpServerProperty(MCP_SERVER_SECRET_KEY);
+        stubApiKey();
+
+        when(userService.fetchUser(USER_ID)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> provider.authenticate(token(MCP_SERVER_SECRET_KEY, AUTH_SECRET_KEY)))
+            .isInstanceOf(UsernameNotFoundException.class);
+    }
+
+    @Test
+    void testAuthenticateRejectsWhenApiKeyUserIsNotActivated() {
+        stubMcpServerProperty(MCP_SERVER_SECRET_KEY);
+        stubApiKey();
+        stubUser(false);
+
+        assertThatThrownBy(() -> provider.authenticate(token(MCP_SERVER_SECRET_KEY, AUTH_SECRET_KEY)))
+            .isInstanceOf(UserNotActivatedException.class);
+
+        verifyNoInteractions(authorityService);
+    }
+
+    private void stubApiKey() {
+        ApiKey apiKey = new ApiKey();
+
+        apiKey.setUserId(USER_ID);
+
+        when(apiKeyService.getApiKey(AUTH_SECRET_KEY)).thenReturn(apiKey);
+    }
+
     private void stubMcpServerProperty(String secretKey) {
         Property property = new Property();
 
@@ -95,6 +179,18 @@ class ManagementMcpServerApiKeyAuthenticationProviderTest {
 
         when(propertyService.fetchProperty(eq("mcp.server"), eq(Property.Scope.PLATFORM), isNull()))
             .thenReturn(Optional.of(property));
+    }
+
+    private void stubUser(boolean activated) {
+        User user = new User();
+
+        user.setId(USER_ID);
+        user.setLogin("admin");
+        user.setPassword("password");
+        user.setActivated(activated);
+        user.setAuthorityIds(List.of(AUTHORITY_ID));
+
+        when(userService.fetchUser(USER_ID)).thenReturn(Optional.of(user));
     }
 
     private static ManagementMcpServerApiKeyAuthenticationToken token(String mcpServerSecretKey, String authSecretKey) {

--- a/server/libs/ai/ai-mcp/ai-mcp-server/src/test/java/com/bytechef/ai/mcp/server/security/web/authentication/ManagementMcpServerApiKeyAuthenticationProviderTest.java
+++ b/server/libs/ai/ai-mcp/ai-mcp-server/src/test/java/com/bytechef/ai/mcp/server/security/web/authentication/ManagementMcpServerApiKeyAuthenticationProviderTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2025 ByteChef
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.bytechef.ai.mcp.server.security.web.authentication;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.bytechef.platform.configuration.domain.Property;
+import com.bytechef.platform.configuration.service.PropertyService;
+import com.bytechef.platform.security.service.ApiKeyService;
+import com.bytechef.platform.user.service.AuthorityService;
+import com.bytechef.platform.user.service.UserService;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.Authentication;
+
+/**
+ * @author Ivica Cardic
+ */
+class ManagementMcpServerApiKeyAuthenticationProviderTest {
+
+    private static final String MCP_SERVER_SECRET_KEY = "mcp-server-secret";
+
+    private ApiKeyService apiKeyService;
+    private PropertyService propertyService;
+    private ManagementMcpServerApiKeyAuthenticationProvider provider;
+
+    @BeforeEach
+    void beforeEach() {
+        apiKeyService = mock(ApiKeyService.class);
+        propertyService = mock(PropertyService.class);
+
+        provider = new ManagementMcpServerApiKeyAuthenticationProvider(
+            apiKeyService, mock(AuthorityService.class), propertyService, mock(UserService.class));
+    }
+
+    @Test
+    void testAuthenticateRejectsWhenMcpServerPropertyIsMissing() {
+        when(propertyService.fetchProperty(eq("mcp.server"), eq(Property.Scope.PLATFORM), isNull()))
+            .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> provider.authenticate(token(MCP_SERVER_SECRET_KEY, null)))
+            .isInstanceOf(BadCredentialsException.class);
+
+        verifyNoInteractions(apiKeyService);
+    }
+
+    @Test
+    void testAuthenticateRejectsWhenMcpServerSecretKeyDoesNotMatch() {
+        stubMcpServerProperty(MCP_SERVER_SECRET_KEY);
+
+        assertThatThrownBy(() -> provider.authenticate(token("wrong-secret", null)))
+            .isInstanceOf(BadCredentialsException.class);
+
+        verifyNoInteractions(apiKeyService);
+    }
+
+    @Test
+    void testAuthenticateReturnsAuthenticatedTokenWhenOnlyMcpServerSecretKeyMatches() {
+        stubMcpServerProperty(MCP_SERVER_SECRET_KEY);
+
+        Authentication authentication = provider.authenticate(token(MCP_SERVER_SECRET_KEY, null));
+
+        assertThat(authentication.isAuthenticated()).isTrue();
+
+        verifyNoInteractions(apiKeyService);
+    }
+
+    private void stubMcpServerProperty(String secretKey) {
+        Property property = new Property();
+
+        property.setValue(Map.of("secretKey", secretKey));
+
+        when(propertyService.fetchProperty(eq("mcp.server"), eq(Property.Scope.PLATFORM), isNull()))
+            .thenReturn(Optional.of(property));
+    }
+
+    private static ManagementMcpServerApiKeyAuthenticationToken token(String mcpServerSecretKey, String authSecretKey) {
+        return new ManagementMcpServerApiKeyAuthenticationToken(mcpServerSecretKey, authSecretKey, "public");
+    }
+}

--- a/server/libs/platform/platform-security-web/platform-security-web-api/build.gradle.kts
+++ b/server/libs/platform/platform-security-web/platform-security-web-api/build.gradle.kts
@@ -7,4 +7,10 @@ dependencies {
     implementation(project(":server:libs:core:tenant:tenant-api"))
 
     compileOnly("jakarta.servlet:jakarta.servlet-api")
+
+    testImplementation("jakarta.servlet:jakarta.servlet-api")
+    testImplementation("org.assertj:assertj-core")
+    testImplementation("org.junit.jupiter:junit-jupiter")
+    testImplementation("org.mockito:mockito-core")
+    testImplementation("org.springframework:spring-test")
 }

--- a/server/libs/platform/platform-security-web/platform-security-web-api/src/main/java/com/bytechef/platform/security/web/filter/ApiKeyAuthenticationFilter.java
+++ b/server/libs/platform/platform-security-web/platform-security-web-api/src/main/java/com/bytechef/platform/security/web/filter/ApiKeyAuthenticationFilter.java
@@ -94,10 +94,15 @@ public class ApiKeyAuthenticationFilter extends OncePerRequestFilter {
                 TenantContext.runWithTenantId(
                     authentication.getTenantId(),
                     () -> {
-                        Authentication authenticatedAuthentication = authenticationManager.authenticate(authentication);
+                        try {
+                            Authentication authenticatedAuthentication = authenticationManager.authenticate(
+                                authentication);
 
-                        successfulAuthentication(httpServletRequest, httpServletResponse, filterChain,
-                            authenticatedAuthentication);
+                            successfulAuthentication(
+                                httpServletRequest, httpServletResponse, filterChain, authenticatedAuthentication);
+                        } catch (AuthenticationException ex) {
+                            unsuccessfulAuthentication(httpServletRequest, httpServletResponse, ex);
+                        }
                     });
             }
         } catch (AuthenticationException ex) {

--- a/server/libs/platform/platform-security-web/platform-security-web-api/src/test/java/com/bytechef/platform/security/web/filter/ApiKeyAuthenticationFilterTest.java
+++ b/server/libs/platform/platform-security-web/platform-security-web-api/src/test/java/com/bytechef/platform/security/web/filter/ApiKeyAuthenticationFilterTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2025 ByteChef
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.bytechef.platform.security.web.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.bytechef.platform.security.web.authentication.AbstractApiKeyAuthenticationToken;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+
+/**
+ * @author Ivica Cardic
+ */
+class ApiKeyAuthenticationFilterTest {
+
+    private AuthenticationManager authenticationManager;
+    private ApiKeyAuthenticationFilter filter;
+    private MockFilterChain filterChain;
+    private MockHttpServletRequest request;
+    private MockHttpServletResponse response;
+
+    @BeforeEach
+    void beforeEach() {
+        authenticationManager = mock(AuthenticationManager.class);
+
+        filter = new ApiKeyAuthenticationFilter(
+            servletRequest -> true, servletRequest -> new TestApiKeyAuthenticationToken(), authenticationManager);
+        filterChain = new MockFilterChain();
+        request = new MockHttpServletRequest("POST", "/api/management/secret/mcp");
+        response = new MockHttpServletResponse();
+    }
+
+    @Test
+    void testDoFilterRespondsUnauthorizedWhenAuthenticationFails() throws Exception {
+        when(authenticationManager.authenticate(any())).thenThrow(new BadCredentialsException("Invalid secret key"));
+
+        filter.doFilter(request, response, filterChain);
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+        assertThat(filterChain.getRequest()).isNull();
+    }
+
+    @Test
+    void testDoFilterContinuesChainWhenAuthenticationSucceeds() throws Exception {
+        TestApiKeyAuthenticationToken authenticatedToken = new TestApiKeyAuthenticationToken();
+
+        authenticatedToken.setAuthenticated(true);
+
+        when(authenticationManager.authenticate(any())).thenReturn(authenticatedToken);
+
+        filter.doFilter(request, response, filterChain);
+
+        assertThat(filterChain.getRequest()).isSameAs(request);
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
+    }
+
+    @Test
+    void testDoFilterPropagatesNonAuthenticationFailures() {
+        when(authenticationManager.authenticate(any())).thenThrow(new IllegalStateException("Database is down"));
+
+        assertThatThrownBy(() -> filter.doFilter(request, response, filterChain))
+            .isInstanceOf(RuntimeException.class)
+            .hasCauseInstanceOf(IllegalStateException.class);
+        assertThat(filterChain.getRequest()).isNull();
+    }
+
+    private static class TestApiKeyAuthenticationToken extends AbstractApiKeyAuthenticationToken {
+
+        TestApiKeyAuthenticationToken() {
+            super(-1, "public");
+        }
+    }
+}


### PR DESCRIPTION
Closes #5659

## Problem

The `mcp.server` platform property is created lazily by the `managementMcpServerUrl` GraphQL query, i.e. the first time someone opens the Management MCP server settings page. Until then, every request to `/api/management/{secretKey}/mcp` hit `PropertyService.getProperty`, whose `IllegalArgumentException` is not an `AuthenticationException`, and the request failed with a 500 and a full stack trace in the log.

Fixing only the provider was not enough. `ApiKeyAuthenticationFilter` authenticates inside `TenantContext.runWithTenantId`, which wraps every exception in a plain `RuntimeException`, so even a `BadCredentialsException` never reached the filter's `AuthenticationException` handler. Every API key authentication failure across the management, automation, embedded and API platform providers was a 500 instead of a 401.

## Fix

- `ManagementMcpServerApiKeyAuthenticationProvider` uses `fetchProperty` and throws `BadCredentialsException` when the property is absent, the same way it already maps a missing API key.
- `ApiKeyAuthenticationFilter` handles the authentication failure inside the tenant-scoped block, so the failure handler answers 401. Non-authentication exceptions still propagate, so genuine infrastructure failures are not disguised as bad credentials.

## Tests

- `ManagementMcpServerApiKeyAuthenticationProviderTest`: missing property (red before the fix), mismatched secret, server-secret-only happy path, and the API key branch (valid key, invalid key, missing user, unactivated user).
- `ApiKeyAuthenticationFilterTest`: authentication failure answers 401 without invoking the chain (red before the fix with the exact production message), success continues the chain, and a non-authentication exception still propagates.
- Cherry-picks the 5649 schedule timezone fix so `ScheduleComponentHandlerTest` is green on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)