### PR TITLE
5594 Show the component version a node uses, and list only the latest version of each component

### DIFF
--- a/client/src/pages/platform/workflow-editor/components/WorkflowNodeDetailsPanel.tsx
+++ b/client/src/pages/platform/workflow-editor/components/WorkflowNodeDetailsPanel.tsx
@@ -17,12 +17,13 @@ import {
 } from '@/shared/middleware/platform/configuration';
 import {UpdateWorkflowMutationType} from '@/shared/types';
 import {ChevronDownIcon, ExternalLinkIcon, InfoIcon, XIcon} from 'lucide-react';
-import {ReactNode} from 'react';
+import {ReactNode, useMemo} from 'react';
 import InlineSVG from 'react-inlinesvg';
 import {Link} from 'react-router-dom';
 import {twMerge} from 'tailwind-merge';
 
 import {getClusterElementsLabel} from '../../cluster-element-editor/utils/clusterElementsUtils';
+import getAvailableComponentVersions from '../utils/getAvailableComponentVersions';
 import getNodeOperationDescription from '../utils/getNodeOperationDescription';
 import {DescriptionTabSkeleton, FieldsetSkeleton, PropertiesTabSkeleton} from './WorkflowEditorSkeletons';
 import useWorkflowNodeDetailsPanel from './hooks/useWorkflowNodeDetailsPanel';
@@ -51,6 +52,7 @@ const WorkflowNodeDetailsPanel = ({
         activeDisplayConditionsQuery,
         activeTab,
         awaitingFirstSave,
+        componentDefinitionVersions,
         currentActionDefinition,
         currentComponentDefinition,
         currentNode,
@@ -68,6 +70,7 @@ const WorkflowNodeDetailsPanel = ({
         getNodeVersion,
         handleOperationSelectChange,
         handlePanelClose,
+        handleVersionSelectChange,
         nodeDefinition,
         nodeTabs,
         operationDataMissing,
@@ -85,6 +88,13 @@ const WorkflowNodeDetailsPanel = ({
         updateWorkflowMutation,
         workflowNodeOutputs,
     });
+
+    const nodeVersion = getNodeVersion(currentWorkflowNode);
+
+    const availableVersions = useMemo(
+        () => getAvailableComponentVersions({componentDefinitionVersions, nodeVersion}),
+        [componentDefinitionVersions, nodeVersion]
+    );
 
     if (!(panelOpen ?? workflowNodeDetailsPanelOpen)) {
         return <></>;
@@ -368,13 +378,20 @@ const WorkflowNodeDetailsPanel = ({
                         </main>
 
                         <footer className="z-50 mt-auto flex items-center justify-between bg-background px-4 py-2">
-                            <Select defaultValue={getNodeVersion(currentWorkflowNode)}>
-                                <SelectTrigger className="w-auto border-none shadow-none">
+                            <Select onValueChange={handleVersionSelectChange} value={nodeVersion}>
+                                <SelectTrigger
+                                    aria-label="Component version"
+                                    className="w-auto border-none shadow-none"
+                                >
                                     <SelectValue placeholder="Choose version..." />
                                 </SelectTrigger>
 
                                 <SelectContent>
-                                    <SelectItem value="1">v1</SelectItem>
+                                    {availableVersions.map((version) => (
+                                        <SelectItem key={version} value={String(version)}>
+                                            v{version}
+                                        </SelectItem>
+                                    ))}
                                 </SelectContent>
                             </Select>
 

--- a/client/src/pages/platform/workflow-editor/components/hooks/useWorkflowNodeDetailsPanel.ts
+++ b/client/src/pages/platform/workflow-editor/components/hooks/useWorkflowNodeDetailsPanel.ts
@@ -35,16 +35,15 @@ import {
     ClusterElementDefinitionKeys,
     useGetClusterElementDefinitionQuery,
 } from '@/shared/queries/platform/clusterElementDefinitions.queries';
-import {useGetComponentDefinitionQuery} from '@/shared/queries/platform/componentDefinitions.queries';
+import {
+    useGetComponentDefinitionQuery,
+    useGetComponentDefinitionVersionsQuery,
+} from '@/shared/queries/platform/componentDefinitions.queries';
 import {useGetTaskDispatcherDefinitionQuery} from '@/shared/queries/platform/taskDispatcherDefinitions.queries';
 import {
     TriggerDefinitionKeys,
     useGetTriggerDefinitionQuery,
 } from '@/shared/queries/platform/triggerDefinitions.queries';
-import {
-    ClusterElementDynamicPropertyKeys,
-    WorkflowNodeDynamicPropertyKeys,
-} from '@/shared/queries/platform/workflowNodeDynamicProperties.queries';
 import {WorkflowNodeOptionKeys} from '@/shared/queries/platform/workflowNodeOptions.queries';
 import {WorkflowNodeOutputKeys} from '@/shared/queries/platform/workflowNodeOutputs.queries';
 import {
@@ -76,9 +75,11 @@ import {
 import useWorkflowDataStore from '../../stores/useWorkflowDataStore';
 import useWorkflowEditorStore from '../../stores/useWorkflowEditorStore';
 import useWorkflowNodeDetailsPanelStore from '../../stores/useWorkflowNodeDetailsPanelStore';
+import changeComponentVersion from '../../utils/changeComponentVersion';
 import getDataPillsFromProperties from '../../utils/getDataPillsFromProperties';
 import getOutputSchemaFromWorkflowNodeOutput from '../../utils/getOutputSchemaFromWorkflowNodeOutput';
 import getParametersWithDefaultValues from '../../utils/getParametersWithDefaultValues';
+import invalidateOperationQueries from '../../utils/invalidateOperationQueries';
 import saveClusterElementFieldChange from '../../utils/saveClusterElementFieldChange';
 import saveTaskDispatcherSubtaskFieldChange from '../../utils/saveTaskDispatcherSubtaskFieldChange';
 import saveWorkflowDefinition from '../../utils/saveWorkflowDefinition';
@@ -188,6 +189,11 @@ export default function useWorkflowNodeDetailsPanel({
         !!currentNode && !currentNode.taskDispatcher
     );
 
+    const {data: componentDefinitionVersions} = useGetComponentDefinitionVersionsQuery(
+        {componentName: currentNode?.componentName || ''},
+        !!currentNode?.componentName && !currentNode.taskDispatcher
+    );
+
     const {data: workflowTestConfigurationConnections} = useGetWorkflowTestConfigurationConnectionsQuery(
         {
             environmentId: currentEnvironmentId,
@@ -252,14 +258,14 @@ export default function useWorkflowNodeDetailsPanel({
     );
 
     const fetchClusterElementDefinition = useCallback(
-        async (operationName?: string) => {
+        async (operationName?: string, componentVersion?: number) => {
             const clusterElementDefinitionRequest: GetComponentClusterElementDefinitionRequest = {
                 clusterElementName: operationName ?? currentOperationName ?? currentNode?.operationName,
                 clusterElementType: currentNode?.clusterElementType
                     ? convertNameToSnakeCase(currentNode.clusterElementType)
                     : undefined,
                 componentName: currentComponentDefinition?.name as string,
-                componentVersion: currentComponentDefinition?.version as number,
+                componentVersion: componentVersion ?? (currentComponentDefinition?.version as number),
             };
 
             const clusterElementDefinition = await queryClient.fetchQuery({
@@ -290,11 +296,11 @@ export default function useWorkflowNodeDetailsPanel({
     );
 
     const fetchActionDefinition = useCallback(
-        async (operationName?: string) => {
+        async (operationName?: string, componentVersion?: number) => {
             const actionDefinitionRequest: GetComponentActionDefinitionRequest = {
                 actionName: operationName ?? currentOperationName ?? currentNode?.operationName,
                 componentName: currentComponentDefinition?.name as string,
-                componentVersion: currentComponentDefinition?.version as number,
+                componentVersion: componentVersion ?? (currentComponentDefinition?.version as number),
             };
 
             const actionDefinition = await queryClient.fetchQuery({
@@ -321,10 +327,10 @@ export default function useWorkflowNodeDetailsPanel({
     );
 
     const fetchTriggerDefinition = useCallback(
-        async (operationName?: string) => {
+        async (operationName?: string, componentVersion?: number) => {
             const triggerDefinitionRequest: GetComponentTriggerDefinitionRequest = {
                 componentName: currentComponentDefinition?.name as string,
-                componentVersion: currentComponentDefinition?.version as number,
+                componentVersion: componentVersion ?? (currentComponentDefinition?.version as number),
                 triggerName: operationName ?? currentOperationName ?? currentNode?.operationName,
             };
 
@@ -988,21 +994,7 @@ export default function useWorkflowNodeDetailsPanel({
                 workflowNodeName: currentNode!.name,
             });
 
-            queryClient.invalidateQueries({
-                queryKey: WorkflowNodeDynamicPropertyKeys.workflowNodeDynamicProperties,
-            });
-
-            queryClient.invalidateQueries({
-                queryKey: ClusterElementDynamicPropertyKeys.clusterElementDynamicProperties,
-            });
-
-            queryClient.invalidateQueries({
-                queryKey: WorkflowNodeOptionKeys.workflowNodeOptions,
-            });
-
-            queryClient.invalidateQueries({
-                queryKey: WorkflowNodeOptionKeys.clusterElementNodeOptions,
-            });
+            invalidateOperationQueries(queryClient);
 
             const {componentName, description, label, workflowNodeName} = currentNode;
 
@@ -1092,6 +1084,43 @@ export default function useWorkflowNodeDetailsPanel({
             currentNodeIndex,
             setCurrentNode,
             setOperationChangeInProgress,
+        ]
+    );
+
+    const handleVersionSelectChange = useCallback(
+        async (newComponentVersionValue: string) => {
+            if (!currentComponentDefinition) {
+                return;
+            }
+
+            await changeComponentVersion({
+                currentComponentDefinition,
+                currentNodeIndex,
+                currentOperationName,
+                deleteWorkflowNodeTestOutputMutation,
+                environmentId: currentEnvironmentId,
+                fetchActionDefinition,
+                fetchClusterElementDefinition,
+                fetchTriggerDefinition,
+                newComponentVersion: Number(newComponentVersionValue),
+                queryClient,
+                setCurrentOperationName,
+                updateWorkflowMutation,
+                workflowId: workflow.id!,
+            });
+        },
+        [
+            currentComponentDefinition,
+            currentEnvironmentId,
+            currentNodeIndex,
+            currentOperationName,
+            deleteWorkflowNodeTestOutputMutation,
+            fetchActionDefinition,
+            fetchClusterElementDefinition,
+            fetchTriggerDefinition,
+            queryClient,
+            updateWorkflowMutation,
+            workflow.id,
         ]
     );
 
@@ -1454,6 +1483,7 @@ export default function useWorkflowNodeDetailsPanel({
         activeDisplayConditionsQuery,
         activeTab,
         awaitingFirstSave,
+        componentDefinitionVersions,
         currentActionDefinition,
         currentComponentDefinition,
         currentNode,
@@ -1471,6 +1501,7 @@ export default function useWorkflowNodeDetailsPanel({
         getNodeVersion,
         handleOperationSelectChange,
         handlePanelClose,
+        handleVersionSelectChange,
         nodeDefinition,
         nodeTabs,
         operationDataMissing,

--- a/client/src/pages/platform/workflow-editor/tests/WorkflowNodeDetailsPanelVersionSelect.test.tsx
+++ b/client/src/pages/platform/workflow-editor/tests/WorkflowNodeDetailsPanelVersionSelect.test.tsx
@@ -1,0 +1,163 @@
+import {fireEvent, render, screen, waitFor} from '@/shared/util/test-utils';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+
+import WorkflowNodeDetailsPanel from '../components/WorkflowNodeDetailsPanel';
+
+const mockHandleVersionSelectChange = vi.fn();
+const mockUseWorkflowNodeDetailsPanel = vi.fn();
+
+vi.mock('@/pages/platform/workflow-editor/components/hooks/useWorkflowNodeDetailsPanel', () => ({
+    default: () => mockUseWorkflowNodeDetailsPanel(),
+}));
+
+vi.mock('@/pages/platform/workflow-editor/components/CurrentOperationSelect', () => ({
+    default: () => <div>CurrentOperationSelect</div>,
+}));
+
+vi.mock('@/pages/platform/workflow-editor/components/node-details-tabs/DescriptionTab', () => ({
+    default: () => <div>DescriptionTab</div>,
+}));
+
+vi.mock('@/pages/platform/workflow-editor/components/node-details-tabs/connection-tab/ConnectionTab', () => ({
+    default: () => <div>ConnectionTab</div>,
+}));
+
+vi.mock('@/pages/platform/workflow-editor/components/node-details-tabs/output-tab/OutputTab', () => ({
+    default: () => <div>OutputTab</div>,
+}));
+
+vi.mock('@/pages/platform/workflow-editor/components/properties/Properties', () => ({
+    default: () => <div>Properties</div>,
+}));
+
+vi.mock('@/shared/components/copilot/hooks/useCopilotLayoutShifted', () => ({
+    default: () => false,
+}));
+
+const buildHookReturnValue = ({
+    componentDefinitionVersions,
+    nodeVersion,
+}: {
+    componentDefinitionVersions?: Array<{name: string; version: number}>;
+    nodeVersion: string;
+}) => ({
+    activeDisplayConditionsQuery: undefined,
+    activeTab: 'description',
+    componentDefinitionVersions,
+    currentActionDefinition: undefined,
+    currentComponentDefinition: {name: 'test', version: Number(nodeVersion)},
+    currentNode: {componentName: 'test', label: 'Test', name: 'test_1', workflowNodeName: 'test_1'},
+    currentOperationName: 'get',
+    currentOperationProperties: [],
+    currentTaskDispatcherDefinition: undefined,
+    currentTriggerDefinition: undefined,
+    currentWorkflowNode: {name: 'test', title: 'Test', version: Number(nodeVersion)},
+    currentWorkflowNodeConnections: [],
+    currentWorkflowNodeOperations: [],
+    errors: [],
+    errorsAccordionOpen: false,
+    errorsLoading: false,
+    filteredClusterElementOperations: undefined,
+    getNodeVersion: () => nodeVersion,
+    handleOperationSelectChange: vi.fn(),
+    handlePanelClose: vi.fn(),
+    handleVersionSelectChange: mockHandleVersionSelectChange,
+    nodeDefinition: {name: 'test', title: 'Test'},
+    nodeTabs: [{label: 'Description', name: 'description'}],
+    operationDataMissing: false,
+    outputDefined: false,
+    outputFunctionDefined: false,
+    rootClusterElementNodeData: undefined,
+    setActiveTab: vi.fn(),
+    setErrorsAccordionOpen: vi.fn(),
+    tabDataExists: true,
+    workflow: {id: 'workflow-1'},
+    workflowNodeDetailsPanelOpen: true,
+    workflowTestConfigurationConnections: [],
+});
+
+const renderPanel = () =>
+    render(
+        <WorkflowNodeDetailsPanel
+            previousComponentDefinitions={[]}
+            updateWorkflowMutation={{} as never}
+            workflowNodeOutputs={[]}
+        />
+    );
+
+describe('WorkflowNodeDetailsPanel version select', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('should show the version the node uses when it is not the first version', () => {
+        mockUseWorkflowNodeDetailsPanel.mockReturnValue(
+            buildHookReturnValue({
+                componentDefinitionVersions: [
+                    {name: 'test', version: 1},
+                    {name: 'test', version: 2},
+                ],
+                nodeVersion: '2',
+            })
+        );
+
+        renderPanel();
+
+        expect(screen.getByRole('combobox', {name: 'Component version'})).toHaveTextContent('v2');
+    });
+
+    it('should offer every registered version of the component', async () => {
+        mockUseWorkflowNodeDetailsPanel.mockReturnValue(
+            buildHookReturnValue({
+                componentDefinitionVersions: [
+                    {name: 'test', version: 1},
+                    {name: 'test', version: 2},
+                ],
+                nodeVersion: '2',
+            })
+        );
+
+        renderPanel();
+
+        fireEvent.click(screen.getByRole('combobox', {name: 'Component version'}));
+
+        await waitFor(() => {
+            expect(screen.getByRole('option', {name: 'v1'})).toBeInTheDocument();
+            expect(screen.getByRole('option', {name: 'v2'})).toBeInTheDocument();
+        });
+    });
+
+    it('should report the picked version to the version change handler', async () => {
+        mockUseWorkflowNodeDetailsPanel.mockReturnValue(
+            buildHookReturnValue({
+                componentDefinitionVersions: [
+                    {name: 'test', version: 1},
+                    {name: 'test', version: 2},
+                ],
+                nodeVersion: '2',
+            })
+        );
+
+        renderPanel();
+
+        fireEvent.click(screen.getByRole('combobox', {name: 'Component version'}));
+
+        await waitFor(() => {
+            expect(screen.getByRole('option', {name: 'v1'})).toBeInTheDocument();
+        });
+
+        fireEvent.click(screen.getByRole('option', {name: 'v1'}));
+
+        expect(mockHandleVersionSelectChange).toHaveBeenCalledWith('1');
+    });
+
+    it('should still show the version the node uses before the versions are fetched', () => {
+        mockUseWorkflowNodeDetailsPanel.mockReturnValue(
+            buildHookReturnValue({componentDefinitionVersions: undefined, nodeVersion: '3'})
+        );
+
+        renderPanel();
+
+        expect(screen.getByRole('combobox', {name: 'Component version'})).toHaveTextContent('v3');
+    });
+});

--- a/client/src/pages/platform/workflow-editor/utils/changeComponentVersion.test.ts
+++ b/client/src/pages/platform/workflow-editor/utils/changeComponentVersion.test.ts
@@ -1,0 +1,261 @@
+import {ComponentDefinition} from '@/shared/middleware/platform/configuration';
+import {NodeDataType} from '@/shared/types';
+import {QueryClient} from '@tanstack/react-query';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+
+import changeComponentVersion from './changeComponentVersion';
+import saveClusterElementFieldChange from './saveClusterElementFieldChange';
+import saveTaskDispatcherSubtaskFieldChange from './saveTaskDispatcherSubtaskFieldChange';
+import saveWorkflowDefinition from './saveWorkflowDefinition';
+
+const mockGetComponentDefinition = vi.fn();
+const mockSetCurrentNode = vi.fn();
+const mockSetOperationChangeInProgress = vi.fn();
+
+let mockCurrentNode: NodeDataType | undefined;
+
+vi.mock('../stores/useWorkflowNodeDetailsPanelStore', () => ({
+    default: {
+        getState: () => ({
+            currentNode: mockCurrentNode,
+            setCurrentNode: mockSetCurrentNode,
+            setOperationChangeInProgress: mockSetOperationChangeInProgress,
+        }),
+    },
+}));
+
+vi.mock('@/shared/middleware/platform/configuration', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('@/shared/middleware/platform/configuration')>()),
+    ComponentDefinitionApi: class {
+        getComponentDefinition = mockGetComponentDefinition;
+    },
+}));
+
+vi.mock('./saveWorkflowDefinition', () => ({default: vi.fn()}));
+vi.mock('./invalidateOperationQueries', () => ({default: vi.fn()}));
+vi.mock('./saveClusterElementFieldChange', () => ({default: vi.fn()}));
+vi.mock('./saveTaskDispatcherSubtaskFieldChange', () => ({default: vi.fn()}));
+
+const versionOneDefinition = {name: 'slack', version: 1} as ComponentDefinition;
+
+const versionTwoDefinition = {
+    actions: [{name: 'sendMessage'}, {name: 'sendDirectMessage'}],
+    clusterElements: [{name: 'sendMessage', type: 'MODEL'}],
+    name: 'slack',
+    triggers: [{name: 'newMessage'}],
+    version: 2,
+} as ComponentDefinition;
+
+const sendMessageDefinition = {
+    name: 'sendMessage',
+    properties: [
+        {name: 'channel', type: 'STRING'},
+        {defaultValue: 'markdown', name: 'format', type: 'STRING'},
+    ],
+} as never;
+
+const buildNode = (overrides: Partial<NodeDataType> = {}): NodeDataType => ({
+    componentName: 'slack',
+    label: 'Send message',
+    metadata: {ui: {nodePosition: {x: 10, y: 20}}},
+    name: 'slack_1',
+    operationName: 'sendMessage',
+    parameters: {channel: '#general'},
+    type: 'slack/v1/sendMessage',
+    version: 1,
+    workflowNodeName: 'slack_1',
+    ...overrides,
+});
+
+const buildQueryClient = (
+    fetchQuery = vi.fn(({queryFn}: {queryFn: () => Promise<ComponentDefinition>}) => queryFn())
+) => ({fetchQuery, invalidateQueries: vi.fn()}) as unknown as QueryClient;
+
+const buildDependencies = (overrides: Record<string, unknown> = {}) => ({
+    currentComponentDefinition: versionOneDefinition,
+    currentOperationName: 'sendMessage',
+    deleteWorkflowNodeTestOutputMutation: {mutateAsync: vi.fn().mockResolvedValue(undefined)},
+    environmentId: 1,
+    fetchActionDefinition: vi.fn().mockResolvedValue(sendMessageDefinition),
+    fetchClusterElementDefinition: vi.fn().mockResolvedValue(sendMessageDefinition),
+    fetchTriggerDefinition: vi.fn().mockResolvedValue(sendMessageDefinition),
+    newComponentVersion: 2,
+    queryClient: buildQueryClient(),
+    setCurrentOperationName: vi.fn(),
+    updateWorkflowMutation: {} as never,
+    workflowId: 'workflow-1',
+    ...overrides,
+});
+
+describe('changeComponentVersion', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+
+        mockCurrentNode = buildNode();
+
+        mockGetComponentDefinition.mockResolvedValue(versionTwoDefinition);
+
+        vi.mocked(saveWorkflowDefinition).mockImplementation(async ({onSuccess}) => onSuccess?.());
+    });
+
+    it('should do nothing when the node already uses the picked version', async () => {
+        const dependencies = buildDependencies({newComponentVersion: 1});
+
+        await changeComponentVersion(dependencies);
+
+        expect(dependencies.queryClient.fetchQuery).not.toHaveBeenCalled();
+        expect(mockSetOperationChangeInProgress).not.toHaveBeenCalled();
+    });
+
+    it('should do nothing when the picked version is not a number', async () => {
+        const dependencies = buildDependencies({newComponentVersion: Number('not a version')});
+
+        await changeComponentVersion(dependencies);
+
+        expect(dependencies.queryClient.fetchQuery).not.toHaveBeenCalled();
+    });
+
+    it('should do nothing when no node is open in the panel', async () => {
+        mockCurrentNode = undefined;
+
+        const dependencies = buildDependencies();
+
+        await changeComponentVersion(dependencies);
+
+        expect(dependencies.queryClient.fetchQuery).not.toHaveBeenCalled();
+    });
+
+    it('should write the picked version into the node type and version', async () => {
+        await changeComponentVersion(buildDependencies());
+
+        expect(vi.mocked(saveWorkflowDefinition).mock.calls[0][0].nodeData).toMatchObject({
+            operationName: 'sendMessage',
+            type: 'slack/v2/sendMessage',
+            version: 2,
+        });
+
+        expect(mockSetCurrentNode).toHaveBeenCalledWith(
+            expect.objectContaining({type: 'slack/v2/sendMessage', version: 2})
+        );
+    });
+
+    it('should carry configured parameters over and seed the defaults of new properties', async () => {
+        await changeComponentVersion(buildDependencies());
+
+        expect(vi.mocked(saveWorkflowDefinition).mock.calls[0][0].nodeData?.parameters).toEqual({
+            channel: '#general',
+            format: 'markdown',
+        });
+    });
+
+    it('should keep the position of the node', async () => {
+        await changeComponentVersion(buildDependencies());
+
+        expect(vi.mocked(saveWorkflowDefinition).mock.calls[0][0].nodeData?.metadata).toEqual({
+            ui: {nodePosition: {x: 10, y: 20}},
+        });
+    });
+
+    it('should clear the in-progress flag once the workflow is saved', async () => {
+        await changeComponentVersion(buildDependencies());
+
+        expect(mockSetOperationChangeInProgress).toHaveBeenNthCalledWith(1, true);
+        expect(mockSetOperationChangeInProgress).toHaveBeenLastCalledWith(false);
+    });
+
+    it('should fall back to the first action when the picked version dropped the current one', async () => {
+        const dependencies = buildDependencies({currentOperationName: 'removedAction'});
+
+        await changeComponentVersion(dependencies);
+
+        expect(dependencies.fetchActionDefinition).toHaveBeenCalledWith('sendMessage', 2);
+        expect(dependencies.setCurrentOperationName).toHaveBeenCalledWith('sendMessage');
+    });
+
+    it('should resolve a trigger node against the triggers of the picked version', async () => {
+        mockCurrentNode = buildNode({operationName: 'newMessage', trigger: true});
+
+        const dependencies = buildDependencies({currentOperationName: 'newMessage'});
+
+        await changeComponentVersion(dependencies);
+
+        expect(dependencies.fetchTriggerDefinition).toHaveBeenCalledWith('newMessage', 2);
+        expect(dependencies.fetchActionDefinition).not.toHaveBeenCalled();
+    });
+
+    it('should route a cluster element through the cluster element save path', async () => {
+        mockCurrentNode = buildNode({clusterElementType: 'model'});
+
+        const dependencies = buildDependencies();
+
+        await changeComponentVersion(dependencies);
+
+        expect(dependencies.fetchClusterElementDefinition).toHaveBeenCalledWith('sendMessage', 2);
+        expect(vi.mocked(saveClusterElementFieldChange).mock.calls[0][0]).toMatchObject({
+            currentComponentDefinition: versionTwoDefinition,
+            fieldUpdate: {field: 'operation', value: 'sendMessage'},
+            parameters: {channel: '#general', format: 'markdown'},
+        });
+        expect(saveWorkflowDefinition).not.toHaveBeenCalled();
+    });
+
+    it('should route a task dispatcher subtask through the subtask save path', async () => {
+        mockCurrentNode = buildNode({conditionData: {conditionCase: 'caseTrue', conditionId: 'condition_1', index: 0}});
+
+        await changeComponentVersion(buildDependencies());
+
+        expect(vi.mocked(saveTaskDispatcherSubtaskFieldChange).mock.calls[0][0]).toMatchObject({
+            currentComponentDefinition: versionTwoDefinition,
+            parameters: {channel: '#general', format: 'markdown'},
+        });
+        expect(saveWorkflowDefinition).not.toHaveBeenCalled();
+    });
+
+    it('should clear the in-progress flag when the picked version has no usable operation', async () => {
+        mockGetComponentDefinition.mockResolvedValue({name: 'slack', version: 2});
+
+        await changeComponentVersion(buildDependencies());
+
+        expect(mockSetOperationChangeInProgress).toHaveBeenLastCalledWith(false);
+        expect(saveWorkflowDefinition).not.toHaveBeenCalled();
+    });
+
+    it('should clear the in-progress flag when the operation definition cannot be resolved', async () => {
+        const dependencies = buildDependencies({fetchActionDefinition: vi.fn().mockResolvedValue(undefined)});
+
+        await changeComponentVersion(dependencies);
+
+        expect(mockSetOperationChangeInProgress).toHaveBeenLastCalledWith(false);
+        expect(saveWorkflowDefinition).not.toHaveBeenCalled();
+    });
+
+    it('should clear the in-progress flag when the component definition cannot be fetched', async () => {
+        mockGetComponentDefinition.mockRejectedValue(new Error('network down'));
+
+        await changeComponentVersion(buildDependencies());
+
+        expect(mockSetOperationChangeInProgress).toHaveBeenLastCalledWith(false);
+        expect(saveWorkflowDefinition).not.toHaveBeenCalled();
+    });
+
+    it('should clear the in-progress flag when the test output cannot be deleted', async () => {
+        const dependencies = buildDependencies({
+            deleteWorkflowNodeTestOutputMutation: {
+                mutateAsync: vi.fn().mockRejectedValue(new Error('request failed')),
+            },
+        });
+
+        await changeComponentVersion(dependencies);
+
+        expect(mockSetOperationChangeInProgress).toHaveBeenLastCalledWith(false);
+        expect(saveWorkflowDefinition).not.toHaveBeenCalled();
+    });
+
+    it('should clear the in-progress flag when saving the workflow fails', async () => {
+        vi.mocked(saveWorkflowDefinition).mockRejectedValue(new Error('save failed'));
+
+        await changeComponentVersion(buildDependencies());
+
+        expect(mockSetOperationChangeInProgress).toHaveBeenLastCalledWith(false);
+    });
+});

--- a/client/src/pages/platform/workflow-editor/utils/changeComponentVersion.ts
+++ b/client/src/pages/platform/workflow-editor/utils/changeComponentVersion.ts
@@ -1,0 +1,228 @@
+import {TASK_DISPATCHER_DATA_KEY_MAP} from '@/shared/constants';
+import {
+    ActionDefinition,
+    ClusterElementDefinition,
+    ComponentDefinition,
+    ComponentDefinitionApi,
+    TriggerDefinition,
+} from '@/shared/middleware/platform/configuration';
+import {ComponentDefinitionKeys} from '@/shared/queries/platform/componentDefinitions.queries';
+import {DEFINITION_STALE_TIME} from '@/shared/queries/queryConstants';
+import {NodeDataType, PropertyAllType, UpdateWorkflowMutationType} from '@/shared/types';
+import {QueryClient} from '@tanstack/react-query';
+
+import useWorkflowNodeDetailsPanelStore from '../stores/useWorkflowNodeDetailsPanelStore';
+import getParametersForVersionChange from './getParametersForVersionChange';
+import invalidateOperationQueries from './invalidateOperationQueries';
+import resolveOperationNameForVersion from './resolveOperationNameForVersion';
+import saveClusterElementFieldChange from './saveClusterElementFieldChange';
+import saveTaskDispatcherSubtaskFieldChange from './saveTaskDispatcherSubtaskFieldChange';
+import saveWorkflowDefinition from './saveWorkflowDefinition';
+
+type OperationDefinitionType = ActionDefinition | ClusterElementDefinition | TriggerDefinition;
+
+interface DeleteWorkflowNodeTestOutputMutationI {
+    mutateAsync: (variables: {environmentId: number; id: string; workflowNodeName: string}) => Promise<unknown>;
+}
+
+interface ChangeComponentVersionProps {
+    currentComponentDefinition: ComponentDefinition;
+    currentNodeIndex?: number;
+    currentOperationName: string;
+    deleteWorkflowNodeTestOutputMutation: DeleteWorkflowNodeTestOutputMutationI;
+    environmentId: number;
+    fetchActionDefinition: (operationName: string, componentVersion: number) => Promise<OperationDefinitionType>;
+    fetchClusterElementDefinition: (
+        operationName: string,
+        componentVersion: number
+    ) => Promise<OperationDefinitionType>;
+    fetchTriggerDefinition: (operationName: string, componentVersion: number) => Promise<OperationDefinitionType>;
+    newComponentVersion: number;
+    queryClient: QueryClient;
+    setCurrentOperationName: (operationName: string) => void;
+    updateWorkflowMutation: UpdateWorkflowMutationType;
+    workflowId: string;
+}
+
+/**
+ * Moves the node open in the details panel to another version of its component.
+ *
+ * The operation is kept when the target version still declares it, otherwise the first operation of the same kind
+ * is used, and the parameters are carried over for the properties that version still declares.
+ */
+export default async function changeComponentVersion({
+    currentComponentDefinition,
+    currentNodeIndex,
+    currentOperationName,
+    deleteWorkflowNodeTestOutputMutation,
+    environmentId,
+    fetchActionDefinition,
+    fetchClusterElementDefinition,
+    fetchTriggerDefinition,
+    newComponentVersion,
+    queryClient,
+    setCurrentOperationName,
+    updateWorkflowMutation,
+    workflowId,
+}: ChangeComponentVersionProps): Promise<void> {
+    const {currentNode, setCurrentNode, setOperationChangeInProgress} = useWorkflowNodeDetailsPanelStore.getState();
+
+    if (!currentNode || !Number.isInteger(newComponentVersion)) {
+        return;
+    }
+
+    if (currentComponentDefinition.version === newComponentVersion) {
+        return;
+    }
+
+    setOperationChangeInProgress(true);
+
+    try {
+        const componentDefinitionRequest = {
+            componentName: currentComponentDefinition.name,
+            componentVersion: newComponentVersion,
+        };
+
+        const newComponentDefinition = await queryClient.fetchQuery({
+            queryFn: () => new ComponentDefinitionApi().getComponentDefinition(componentDefinitionRequest),
+            queryKey: ComponentDefinitionKeys.componentDefinition(componentDefinitionRequest),
+            staleTime: DEFINITION_STALE_TIME,
+        });
+
+        const newOperationName = resolveOperationNameForVersion({
+            clusterElementType: currentNode.clusterElementType,
+            componentDefinition: newComponentDefinition,
+            currentOperationName,
+            trigger: currentNode.trigger,
+        });
+
+        if (!newOperationName) {
+            console.error(
+                `${currentComponentDefinition.name} v${newComponentVersion} has no operation the node could use`
+            );
+
+            setOperationChangeInProgress(false);
+
+            return;
+        }
+
+        const isClusterElement = !!currentNode.clusterElementType;
+
+        let newOperationDefinition: OperationDefinitionType;
+
+        if (currentNode.trigger && !isClusterElement) {
+            newOperationDefinition = await fetchTriggerDefinition(newOperationName, newComponentVersion);
+        } else if (isClusterElement) {
+            newOperationDefinition = await fetchClusterElementDefinition(newOperationName, newComponentVersion);
+        } else {
+            newOperationDefinition = await fetchActionDefinition(newOperationName, newComponentVersion);
+        }
+
+        if (!newOperationDefinition) {
+            console.error(`newOperationDefinition not found for: ${newOperationName}`);
+
+            setOperationChangeInProgress(false);
+
+            return;
+        }
+
+        const newOperationProperties = (newOperationDefinition.properties ?? []) as Array<PropertyAllType>;
+
+        const newParameters = getParametersForVersionChange({
+            currentParameters: currentNode.parameters,
+            properties: newOperationProperties,
+        });
+
+        setCurrentOperationName(newOperationName);
+
+        await deleteWorkflowNodeTestOutputMutation.mutateAsync({
+            environmentId,
+            id: workflowId,
+            workflowNodeName: currentNode.name,
+        });
+
+        invalidateOperationQueries(queryClient);
+
+        const isTaskDispatcherSubtask = Object.values(TASK_DISPATCHER_DATA_KEY_MAP).some(
+            (dataKey) => dataKey !== undefined && currentNode[dataKey as keyof NodeDataType] !== undefined
+        );
+
+        if (isTaskDispatcherSubtask) {
+            saveTaskDispatcherSubtaskFieldChange({
+                currentComponentDefinition: newComponentDefinition,
+                currentNodeIndex: currentNodeIndex ?? 0,
+                currentOperationProperties: newOperationProperties,
+                fieldUpdate: {
+                    field: 'operation',
+                    value: newOperationName,
+                },
+                parameters: newParameters,
+                updateWorkflowMutation,
+            });
+
+            return;
+        }
+
+        if (isClusterElement) {
+            saveClusterElementFieldChange({
+                currentComponentDefinition: newComponentDefinition,
+                currentOperationProperties: newOperationProperties,
+                fieldUpdate: {
+                    field: 'operation',
+                    value: newOperationName,
+                },
+                parameters: newParameters,
+                updateWorkflowMutation,
+            });
+
+            return;
+        }
+
+        const {componentName, description, label, workflowNodeName} = currentNode;
+
+        const newNodeType = `${componentName}/v${newComponentVersion}/${newOperationName}`;
+
+        const newNodeMetadata = {
+            ui: {
+                nodePosition: currentNode.metadata?.ui?.nodePosition,
+            },
+        };
+
+        await saveWorkflowDefinition({
+            nodeData: {
+                componentName,
+                description,
+                label,
+                metadata: newNodeMetadata,
+                name: workflowNodeName,
+                operationName: newOperationName,
+                parameters: newParameters,
+                trigger: currentNode.trigger,
+                type: newNodeType,
+                version: newComponentVersion,
+                workflowNodeName,
+            },
+            onSuccess: () => {
+                setCurrentNode({
+                    ...currentNode,
+                    componentName,
+                    displayConditions: {},
+                    metadata: newNodeMetadata,
+                    name: workflowNodeName,
+                    operationName: newOperationName,
+                    parameters: newParameters,
+                    type: newNodeType,
+                    version: newComponentVersion,
+                    workflowNodeName,
+                });
+
+                setOperationChangeInProgress(false);
+            },
+            updateWorkflowMutation,
+        });
+    } catch (error) {
+        console.error(`Failed to change ${currentComponentDefinition.name} to v${newComponentVersion}`, error);
+
+        setOperationChangeInProgress(false);
+    }
+}

--- a/client/src/pages/platform/workflow-editor/utils/clusterElementsFieldChangeUtils.test.ts
+++ b/client/src/pages/platform/workflow-editor/utils/clusterElementsFieldChangeUtils.test.ts
@@ -1,0 +1,57 @@
+import {ComponentDefinition} from '@/shared/middleware/platform/configuration';
+import {ClusterElementsType} from '@/shared/types';
+import {describe, expect, it} from 'vitest';
+
+import {updateNestedClusterElementField} from './clusterElementsFieldChangeUtils';
+
+const currentComponentDefinition = {name: 'openAi', version: 2} as ComponentDefinition;
+
+const currentOperationProperties = [{defaultValue: 'default', name: 'model', type: 'STRING'}] as never;
+
+describe('updateNestedClusterElementField', () => {
+    it('should apply the parameters override to a directly nested cluster element', () => {
+        const clusterElements: ClusterElementsType = {
+            model: {name: 'openAiModel', parameters: {model: 'gpt-4'}, type: 'openAi/v1/model'},
+        };
+
+        const updatedClusterElements = updateNestedClusterElementField({
+            clusterElements,
+            currentComponentDefinition,
+            currentOperationProperties,
+            elementName: 'openAiModel',
+            fieldUpdate: {field: 'operation', value: 'model'},
+            parameters: {model: 'gpt-4'},
+        });
+
+        expect((updatedClusterElements.model as {parameters: unknown}).parameters).toEqual({model: 'gpt-4'});
+    });
+
+    it('should apply the parameters override to a cluster element nested inside another cluster root', () => {
+        const clusterElements: ClusterElementsType = {
+            tools: [
+                {
+                    clusterElements: {
+                        model: {name: 'openAiModel', parameters: {model: 'gpt-4'}, type: 'openAi/v1/model'},
+                    },
+                    name: 'nestedAgent',
+                    type: 'aiAgent/v1/agent',
+                },
+            ],
+        };
+
+        const updatedClusterElements = updateNestedClusterElementField({
+            clusterElements,
+            currentComponentDefinition,
+            currentOperationProperties,
+            elementName: 'openAiModel',
+            fieldUpdate: {field: 'operation', value: 'model'},
+            parameters: {model: 'gpt-4'},
+        });
+
+        const nestedAgent = (
+            updatedClusterElements.tools as unknown as Array<{clusterElements: {model: {parameters: unknown}}}>
+        )[0];
+
+        expect(nestedAgent.clusterElements.model.parameters).toEqual({model: 'gpt-4'});
+    });
+});

--- a/client/src/pages/platform/workflow-editor/utils/clusterElementsFieldChangeUtils.ts
+++ b/client/src/pages/platform/workflow-editor/utils/clusterElementsFieldChangeUtils.ts
@@ -14,6 +14,7 @@ interface CreateUpdatedElementProps {
     currentOperationProperties?: Array<PropertyAllType>;
     element: ClusterElementItemType | NodeDataType;
     fieldUpdate: FieldUpdateType;
+    parameters?: NonNullable<NodeDataType['parameters']>;
 }
 
 export function createUpdatedElement({
@@ -21,6 +22,7 @@ export function createUpdatedElement({
     currentOperationProperties,
     element,
     fieldUpdate,
+    parameters,
 }: CreateUpdatedElementProps) {
     switch (fieldUpdate.field) {
         case 'operation':
@@ -35,9 +37,11 @@ export function createUpdatedElement({
                     },
                 },
                 operationName: fieldUpdate.value,
-                parameters: getParametersWithDefaultValues({
-                    properties: currentOperationProperties as Array<PropertyAllType>,
-                }),
+                parameters:
+                    parameters ??
+                    getParametersWithDefaultValues({
+                        properties: currentOperationProperties as Array<PropertyAllType>,
+                    }),
                 type: `${currentComponentDefinition.name}/v${currentComponentDefinition.version}/${fieldUpdate.value}`,
             };
         case 'label':
@@ -60,6 +64,7 @@ interface UpdateClusterRootElementFieldProps {
     currentOperationProperties?: Array<PropertyAllType>;
     fieldUpdate: FieldUpdateType;
     mainRootElement: NodeDataType;
+    parameters?: NonNullable<NodeDataType['parameters']>;
 }
 
 export function updateClusterRootElementField({
@@ -67,12 +72,14 @@ export function updateClusterRootElementField({
     currentOperationProperties,
     fieldUpdate,
     mainRootElement,
+    parameters,
 }: UpdateClusterRootElementFieldProps): NodeDataType {
     const updatedElementData = createUpdatedElement({
         currentComponentDefinition,
         currentOperationProperties,
         element: mainRootElement,
         fieldUpdate,
+        parameters,
     });
 
     return {
@@ -90,6 +97,7 @@ interface UpdateNestedClusterElementFieldProps {
     currentOperationProperties?: Array<PropertyAllType>;
     elementName: string;
     fieldUpdate: FieldUpdateType;
+    parameters?: NonNullable<NodeDataType['parameters']>;
 }
 
 export function updateNestedClusterElementField({
@@ -98,6 +106,7 @@ export function updateNestedClusterElementField({
     currentOperationProperties,
     elementName,
     fieldUpdate,
+    parameters,
 }: UpdateNestedClusterElementFieldProps): ClusterElementsType {
     if (!clusterElements || Object.keys(clusterElements).length === 0) {
         return clusterElements;
@@ -112,6 +121,7 @@ export function updateNestedClusterElementField({
                 currentOperationProperties,
                 element,
                 fieldUpdate,
+                parameters,
             }) as ClusterElementItemType;
         }
 
@@ -125,6 +135,7 @@ export function updateNestedClusterElementField({
                     currentOperationProperties,
                     elementName,
                     fieldUpdate,
+                    parameters,
                 }),
             };
         }

--- a/client/src/pages/platform/workflow-editor/utils/getAvailableComponentVersions.test.ts
+++ b/client/src/pages/platform/workflow-editor/utils/getAvailableComponentVersions.test.ts
@@ -1,0 +1,48 @@
+import {ComponentDefinitionBasic} from '@/shared/middleware/platform/configuration';
+import {describe, expect, it} from 'vitest';
+
+import getAvailableComponentVersions from './getAvailableComponentVersions';
+
+const componentDefinitionVersion = (version: number) => ({name: 'test', version}) as ComponentDefinitionBasic;
+
+describe('getAvailableComponentVersions', () => {
+    it('should list every registered version in ascending order', () => {
+        expect(
+            getAvailableComponentVersions({
+                componentDefinitionVersions: [componentDefinitionVersion(2), componentDefinitionVersion(1)],
+                nodeVersion: '2',
+            })
+        ).toEqual([1, 2]);
+    });
+
+    it('should include the version of the node when the versions have not been fetched yet', () => {
+        expect(getAvailableComponentVersions({componentDefinitionVersions: undefined, nodeVersion: '2'})).toEqual([2]);
+    });
+
+    it('should include the version of the node when it is no longer registered', () => {
+        expect(
+            getAvailableComponentVersions({
+                componentDefinitionVersions: [componentDefinitionVersion(3)],
+                nodeVersion: '1',
+            })
+        ).toEqual([1, 3]);
+    });
+
+    it('should not repeat the version of the node', () => {
+        expect(
+            getAvailableComponentVersions({
+                componentDefinitionVersions: [componentDefinitionVersion(1), componentDefinitionVersion(2)],
+                nodeVersion: '1',
+            })
+        ).toEqual([1, 2]);
+    });
+
+    it('should ignore a node version that is not a number', () => {
+        expect(
+            getAvailableComponentVersions({
+                componentDefinitionVersions: [componentDefinitionVersion(1)],
+                nodeVersion: '',
+            })
+        ).toEqual([1]);
+    });
+});

--- a/client/src/pages/platform/workflow-editor/utils/getAvailableComponentVersions.ts
+++ b/client/src/pages/platform/workflow-editor/utils/getAvailableComponentVersions.ts
@@ -1,0 +1,17 @@
+import {ComponentDefinitionBasic} from '@/shared/middleware/platform/configuration';
+
+export default function getAvailableComponentVersions({
+    componentDefinitionVersions,
+    nodeVersion,
+}: {
+    componentDefinitionVersions?: Array<ComponentDefinitionBasic>;
+    nodeVersion: string;
+}): Array<number> {
+    const versions = new Set((componentDefinitionVersions ?? []).map(({version}) => version));
+
+    if (nodeVersion !== '' && !Number.isNaN(Number(nodeVersion))) {
+        versions.add(Number(nodeVersion));
+    }
+
+    return Array.from(versions).sort((firstVersion, secondVersion) => firstVersion - secondVersion);
+}

--- a/client/src/pages/platform/workflow-editor/utils/getParametersForVersionChange.test.ts
+++ b/client/src/pages/platform/workflow-editor/utils/getParametersForVersionChange.test.ts
@@ -1,0 +1,102 @@
+import {PropertyAllType} from '@/shared/types';
+import {describe, expect, it} from 'vitest';
+
+import getParametersForVersionChange from './getParametersForVersionChange';
+
+const stringProperty = (name: string, defaultValue?: string): PropertyAllType =>
+    ({defaultValue, name, type: 'STRING'}) as PropertyAllType;
+
+describe('getParametersForVersionChange', () => {
+    it('should keep values of properties that still exist in the new version', () => {
+        expect(
+            getParametersForVersionChange({
+                currentParameters: {message: 'hello', recipient: 'someone'},
+                properties: [stringProperty('message'), stringProperty('recipient')],
+            })
+        ).toEqual({message: 'hello', recipient: 'someone'});
+    });
+
+    it('should drop values of properties removed in the new version', () => {
+        expect(
+            getParametersForVersionChange({
+                currentParameters: {message: 'hello', removedProperty: 'stale'},
+                properties: [stringProperty('message')],
+            })
+        ).toEqual({message: 'hello'});
+    });
+
+    it('should fill in default values for properties added in the new version', () => {
+        expect(
+            getParametersForVersionChange({
+                currentParameters: {message: 'hello'},
+                properties: [stringProperty('message'), stringProperty('format', 'markdown')],
+            })
+        ).toEqual({format: 'markdown', message: 'hello'});
+    });
+
+    it('should prefer the configured value over the default value of the new version', () => {
+        expect(
+            getParametersForVersionChange({
+                currentParameters: {format: 'plain'},
+                properties: [stringProperty('format', 'markdown')],
+            })
+        ).toEqual({format: 'plain'});
+    });
+
+    it('should keep a falsy configured value instead of falling back to the default value', () => {
+        expect(
+            getParametersForVersionChange({
+                currentParameters: {enabled: false, retries: 0},
+                properties: [
+                    {defaultValue: true, name: 'enabled', type: 'BOOLEAN'} as unknown as PropertyAllType,
+                    {defaultValue: 3, name: 'retries', type: 'INTEGER'} as unknown as PropertyAllType,
+                ],
+            })
+        ).toEqual({enabled: false, retries: 0});
+    });
+
+    it('should merge nested object properties recursively', () => {
+        expect(
+            getParametersForVersionChange({
+                currentParameters: {options: {removedOption: 'stale', timeout: 30}},
+                properties: [
+                    {
+                        name: 'options',
+                        properties: [
+                            {name: 'timeout', type: 'INTEGER'},
+                            {defaultValue: 'json', name: 'responseType', type: 'STRING'},
+                        ],
+                        type: 'OBJECT',
+                    } as PropertyAllType,
+                ],
+            })
+        ).toEqual({options: {responseType: 'json', timeout: 30}});
+    });
+
+    it('should keep array values as they are', () => {
+        expect(
+            getParametersForVersionChange({
+                currentParameters: {tags: ['first', 'second']},
+                properties: [{items: [{type: 'STRING'}], name: 'tags', type: 'ARRAY'} as PropertyAllType],
+            })
+        ).toEqual({tags: ['first', 'second']});
+    });
+
+    it('should return only default values when there are no configured parameters', () => {
+        expect(
+            getParametersForVersionChange({
+                currentParameters: undefined,
+                properties: [stringProperty('format', 'markdown')],
+            })
+        ).toEqual({format: 'markdown'});
+    });
+
+    it('should return an empty object when the new version has no properties', () => {
+        expect(
+            getParametersForVersionChange({
+                currentParameters: {message: 'hello'},
+                properties: [],
+            })
+        ).toEqual({});
+    });
+});

--- a/client/src/pages/platform/workflow-editor/utils/getParametersForVersionChange.ts
+++ b/client/src/pages/platform/workflow-editor/utils/getParametersForVersionChange.ts
@@ -1,0 +1,44 @@
+import {PropertyAllType} from '@/shared/types';
+
+import getParametersWithDefaultValues from './getParametersWithDefaultValues';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type ParametersType = {[key: string]: any};
+
+const isPlainObject = (value: unknown): value is ParametersType =>
+    typeof value === 'object' && value !== null && !Array.isArray(value);
+
+export default function getParametersForVersionChange({
+    currentParameters,
+    properties,
+}: {
+    currentParameters?: ParametersType;
+    properties: Array<PropertyAllType>;
+}): ParametersType {
+    const parameters = getParametersWithDefaultValues({data: {}, properties}) as ParametersType;
+
+    if (!currentParameters) {
+        return parameters;
+    }
+
+    properties.forEach((property) => {
+        if (!property.name || !(property.name in currentParameters)) {
+            return;
+        }
+
+        const currentValue = currentParameters[property.name];
+
+        if (property.properties?.length && isPlainObject(currentValue)) {
+            parameters[property.name] = getParametersForVersionChange({
+                currentParameters: currentValue,
+                properties: property.properties as Array<PropertyAllType>,
+            });
+
+            return;
+        }
+
+        parameters[property.name] = currentValue;
+    });
+
+    return parameters;
+}

--- a/client/src/pages/platform/workflow-editor/utils/invalidateOperationQueries.test.ts
+++ b/client/src/pages/platform/workflow-editor/utils/invalidateOperationQueries.test.ts
@@ -1,0 +1,24 @@
+import {
+    ClusterElementDynamicPropertyKeys,
+    WorkflowNodeDynamicPropertyKeys,
+} from '@/shared/queries/platform/workflowNodeDynamicProperties.queries';
+import {WorkflowNodeOptionKeys} from '@/shared/queries/platform/workflowNodeOptions.queries';
+import {QueryClient} from '@tanstack/react-query';
+import {describe, expect, it, vi} from 'vitest';
+
+import invalidateOperationQueries from './invalidateOperationQueries';
+
+describe('invalidateOperationQueries', () => {
+    it('should invalidate the dynamic properties and options of both plain nodes and cluster elements', () => {
+        const invalidateQueries = vi.fn();
+
+        invalidateOperationQueries({invalidateQueries} as unknown as QueryClient);
+
+        expect(invalidateQueries.mock.calls.map(([{queryKey}]) => queryKey)).toEqual([
+            WorkflowNodeDynamicPropertyKeys.workflowNodeDynamicProperties,
+            ClusterElementDynamicPropertyKeys.clusterElementDynamicProperties,
+            WorkflowNodeOptionKeys.workflowNodeOptions,
+            WorkflowNodeOptionKeys.clusterElementNodeOptions,
+        ]);
+    });
+});

--- a/client/src/pages/platform/workflow-editor/utils/invalidateOperationQueries.ts
+++ b/client/src/pages/platform/workflow-editor/utils/invalidateOperationQueries.ts
@@ -1,0 +1,24 @@
+import {
+    ClusterElementDynamicPropertyKeys,
+    WorkflowNodeDynamicPropertyKeys,
+} from '@/shared/queries/platform/workflowNodeDynamicProperties.queries';
+import {WorkflowNodeOptionKeys} from '@/shared/queries/platform/workflowNodeOptions.queries';
+import {QueryClient} from '@tanstack/react-query';
+
+export default function invalidateOperationQueries(queryClient: QueryClient): void {
+    queryClient.invalidateQueries({
+        queryKey: WorkflowNodeDynamicPropertyKeys.workflowNodeDynamicProperties,
+    });
+
+    queryClient.invalidateQueries({
+        queryKey: ClusterElementDynamicPropertyKeys.clusterElementDynamicProperties,
+    });
+
+    queryClient.invalidateQueries({
+        queryKey: WorkflowNodeOptionKeys.workflowNodeOptions,
+    });
+
+    queryClient.invalidateQueries({
+        queryKey: WorkflowNodeOptionKeys.clusterElementNodeOptions,
+    });
+}

--- a/client/src/pages/platform/workflow-editor/utils/resolveOperationNameForVersion.test.ts
+++ b/client/src/pages/platform/workflow-editor/utils/resolveOperationNameForVersion.test.ts
@@ -1,0 +1,74 @@
+import {ComponentDefinition} from '@/shared/middleware/platform/configuration';
+import {describe, expect, it} from 'vitest';
+
+import resolveOperationNameForVersion from './resolveOperationNameForVersion';
+
+const componentDefinition = {
+    actions: [{name: 'getMessage'}, {name: 'sendMessage'}],
+    clusterElements: [
+        {name: 'openAiModel', type: 'MODEL'},
+        {name: 'openAiEmbedding', type: 'EMBEDDING'},
+    ],
+    name: 'test',
+    triggers: [{name: 'newMessage'}, {name: 'newReaction'}],
+    version: 2,
+} as unknown as ComponentDefinition;
+
+describe('resolveOperationNameForVersion', () => {
+    it('should keep the current action when the new version still declares it', () => {
+        expect(
+            resolveOperationNameForVersion({
+                componentDefinition,
+                currentOperationName: 'sendMessage',
+            })
+        ).toBe('sendMessage');
+    });
+
+    it('should fall back to the first action when the new version dropped the current one', () => {
+        expect(
+            resolveOperationNameForVersion({
+                componentDefinition,
+                currentOperationName: 'removedAction',
+            })
+        ).toBe('getMessage');
+    });
+
+    it('should resolve against triggers for a trigger node', () => {
+        expect(
+            resolveOperationNameForVersion({
+                componentDefinition,
+                currentOperationName: 'newReaction',
+                trigger: true,
+            })
+        ).toBe('newReaction');
+    });
+
+    it('should fall back to the first trigger when the new version dropped the current one', () => {
+        expect(
+            resolveOperationNameForVersion({
+                componentDefinition,
+                currentOperationName: 'sendMessage',
+                trigger: true,
+            })
+        ).toBe('newMessage');
+    });
+
+    it('should resolve against cluster elements of the matching type', () => {
+        expect(
+            resolveOperationNameForVersion({
+                clusterElementType: 'model',
+                componentDefinition,
+                currentOperationName: 'removedElement',
+            })
+        ).toBe('openAiModel');
+    });
+
+    it('should return undefined when the new version declares no matching operations', () => {
+        expect(
+            resolveOperationNameForVersion({
+                componentDefinition: {name: 'test', version: 2} as ComponentDefinition,
+                currentOperationName: 'sendMessage',
+            })
+        ).toBeUndefined();
+    });
+});

--- a/client/src/pages/platform/workflow-editor/utils/resolveOperationNameForVersion.ts
+++ b/client/src/pages/platform/workflow-editor/utils/resolveOperationNameForVersion.ts
@@ -1,0 +1,35 @@
+import {ComponentDefinition} from '@/shared/middleware/platform/configuration';
+
+import {convertNameToSnakeCase} from '../../cluster-element-editor/utils/clusterElementsUtils';
+
+export default function resolveOperationNameForVersion({
+    clusterElementType,
+    componentDefinition,
+    currentOperationName,
+    trigger,
+}: {
+    clusterElementType?: string;
+    componentDefinition: ComponentDefinition;
+    currentOperationName?: string;
+    trigger?: boolean;
+}): string | undefined {
+    let operations: Array<{name?: string}>;
+
+    if (clusterElementType) {
+        const snakeCaseClusterElementType = convertNameToSnakeCase(clusterElementType);
+
+        operations = (componentDefinition.clusterElements ?? []).filter(
+            (clusterElement) => clusterElement.type === snakeCaseClusterElementType
+        );
+    } else if (trigger) {
+        operations = componentDefinition.triggers ?? [];
+    } else {
+        operations = componentDefinition.actions ?? [];
+    }
+
+    if (currentOperationName && operations.some((operation) => operation.name === currentOperationName)) {
+        return currentOperationName;
+    }
+
+    return operations[0]?.name;
+}

--- a/client/src/pages/platform/workflow-editor/utils/saveClusterElementFieldChange.ts
+++ b/client/src/pages/platform/workflow-editor/utils/saveClusterElementFieldChange.ts
@@ -18,6 +18,7 @@ interface SaveClusterElementFieldChangeProps {
     currentComponentDefinition: ComponentDefinition;
     currentOperationProperties?: Array<PropertyAllType>;
     fieldUpdate: FieldUpdateType;
+    parameters?: NonNullable<NodeDataType['parameters']>;
     updateWorkflowMutation: UpdateWorkflowMutationType;
 }
 
@@ -25,6 +26,7 @@ export default function saveClusterElementFieldChange({
     currentComponentDefinition,
     currentOperationProperties,
     fieldUpdate,
+    parameters,
     updateWorkflowMutation,
 }: SaveClusterElementFieldChangeProps): void {
     const {currentNode, setCurrentNode} = useWorkflowNodeDetailsPanelStore.getState();
@@ -71,6 +73,7 @@ export default function saveClusterElementFieldChange({
                 componentName: rootClusterElementNodeData.componentName,
                 workflowNodeName: rootClusterElementNodeData.workflowNodeName,
             },
+            parameters,
         });
     } else if (
         currentNode.clusterElementType &&
@@ -88,6 +91,7 @@ export default function saveClusterElementFieldChange({
             currentOperationProperties,
             elementName: workflowNodeName,
             fieldUpdate,
+            parameters,
         });
 
         updatedMainRootData = {
@@ -124,10 +128,13 @@ export default function saveClusterElementFieldChange({
                         },
                     },
                     operationName: fieldUpdate.value,
-                    parameters: getParametersWithDefaultValues({
-                        properties: currentOperationProperties as Array<PropertyAllType>,
-                    }),
+                    parameters:
+                        parameters ??
+                        getParametersWithDefaultValues({
+                            properties: currentOperationProperties as Array<PropertyAllType>,
+                        }),
                     type: `${currentComponentDefinition.name}/v${currentComponentDefinition.version}/${fieldUpdate.value}`,
+                    version: currentComponentDefinition.version,
                 };
             } else {
                 commonUpdates[fieldUpdate.field] = fieldUpdate.value;

--- a/client/src/pages/platform/workflow-editor/utils/saveTaskDispatcherSubtaskFieldChange.ts
+++ b/client/src/pages/platform/workflow-editor/utils/saveTaskDispatcherSubtaskFieldChange.ts
@@ -20,6 +20,7 @@ interface SaveTaskDispatcherSubtaskFieldChangeProps {
     currentNodeIndex: number;
     currentOperationProperties?: Array<PropertyAllType>;
     fieldUpdate: FieldUpdateType;
+    parameters?: NonNullable<NodeDataType['parameters']>;
     updateWorkflowMutation: UpdateWorkflowMutationType;
 }
 
@@ -29,6 +30,7 @@ export default function saveTaskDispatcherSubtaskFieldChange(props: SaveTaskDisp
         currentNodeIndex,
         currentOperationProperties,
         fieldUpdate,
+        parameters,
         updateWorkflowMutation,
     } = props;
 
@@ -214,9 +216,11 @@ export default function saveTaskDispatcherSubtaskFieldChange(props: SaveTaskDisp
             case 'operation':
                 updatedTask = {
                     ...parentTaskDispatcherTask,
-                    parameters: getParametersWithDefaultValues({
-                        properties: currentOperationProperties as Array<PropertyAllType>,
-                    }),
+                    parameters:
+                        parameters ??
+                        getParametersWithDefaultValues({
+                            properties: currentOperationProperties as Array<PropertyAllType>,
+                        }),
                     type: `${currentNode.componentName}/v${currentComponentDefinition.version}/${fieldUpdate.value}`,
                 };
                 break;
@@ -257,9 +261,11 @@ export default function saveTaskDispatcherSubtaskFieldChange(props: SaveTaskDisp
                     case 'operation':
                         return {
                             ...subtask,
-                            parameters: getParametersWithDefaultValues({
-                                properties: currentOperationProperties as Array<PropertyAllType>,
-                            }),
+                            parameters:
+                                parameters ??
+                                getParametersWithDefaultValues({
+                                    properties: currentOperationProperties as Array<PropertyAllType>,
+                                }),
                             type: `${currentNode.componentName}/v${currentComponentDefinition.version}/${fieldUpdate.value}`,
                         };
                     case 'label':
@@ -308,10 +314,13 @@ export default function saveTaskDispatcherSubtaskFieldChange(props: SaveTaskDisp
                     displayConditions: {},
                     metadata: {},
                     operationName: fieldUpdate.value as string,
-                    parameters: getParametersWithDefaultValues({
-                        properties: currentOperationProperties as Array<PropertyAllType>,
-                    }),
+                    parameters:
+                        parameters ??
+                        getParametersWithDefaultValues({
+                            properties: currentOperationProperties as Array<PropertyAllType>,
+                        }),
                     type: `${componentName}/v${currentComponentDefinition.version}/${fieldUpdate.value}`,
+                    version: currentComponentDefinition.version,
                 };
             } else if (fieldUpdate.field === 'maxRetries') {
                 commonUpdates.maxRetries = fieldUpdate.value as number;

--- a/client/src/shared/queries/platform/componentDefinitions.queries.test.ts
+++ b/client/src/shared/queries/platform/componentDefinitions.queries.test.ts
@@ -1,0 +1,62 @@
+import {
+    ComponentDefinitionKeys,
+    useGetComponentDefinitionVersionsQuery,
+} from '@/shared/queries/platform/componentDefinitions.queries';
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
+import {renderHook, waitFor} from '@testing-library/react';
+import {type ReactNode, createElement} from 'react';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+
+const mockGetComponentDefinitionVersions = vi.fn();
+
+vi.mock('@/shared/middleware/platform/configuration', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('@/shared/middleware/platform/configuration')>()),
+    ComponentDefinitionApi: class {
+        getComponentDefinitionVersions = mockGetComponentDefinitionVersions;
+    },
+}));
+
+const createWrapper = () => {
+    const queryClient = new QueryClient({defaultOptions: {queries: {retry: false}}});
+
+    return ({children}: {children: ReactNode}) => createElement(QueryClientProvider, {client: queryClient}, children);
+};
+
+describe('useGetComponentDefinitionVersionsQuery', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('should key the versions of a component apart from the component itself', () => {
+        expect(ComponentDefinitionKeys.componentDefinitionVersions({componentName: 'slack'})).toEqual([
+            'componentDefinitions',
+            'slack',
+            'versions',
+        ]);
+    });
+
+    it('should return the versions the component registers', async () => {
+        const versions = [
+            {name: 'slack', version: 1},
+            {name: 'slack', version: 2},
+        ];
+
+        mockGetComponentDefinitionVersions.mockResolvedValue(versions);
+
+        const {result} = renderHook(() => useGetComponentDefinitionVersionsQuery({componentName: 'slack'}), {
+            wrapper: createWrapper(),
+        });
+
+        await waitFor(() => expect(result.current.data).toEqual(versions));
+
+        expect(mockGetComponentDefinitionVersions).toHaveBeenCalledWith({componentName: 'slack'});
+    });
+
+    it('should not fetch while it is disabled', () => {
+        renderHook(() => useGetComponentDefinitionVersionsQuery({componentName: 'slack'}, false), {
+            wrapper: createWrapper(),
+        });
+
+        expect(mockGetComponentDefinitionVersions).not.toHaveBeenCalled();
+    });
+});

--- a/client/src/shared/queries/platform/componentDefinitions.queries.ts
+++ b/client/src/shared/queries/platform/componentDefinitions.queries.ts
@@ -2,7 +2,9 @@
 import {
     ComponentDefinition,
     ComponentDefinitionApi,
+    ComponentDefinitionBasic,
     GetComponentDefinitionRequest,
+    GetComponentDefinitionVersionsRequest,
     GetConnectionComponentDefinitionRequest,
 } from '@/shared/middleware/platform/configuration';
 import {DEFINITION_STALE_TIME} from '@/shared/queries/queryConstants';
@@ -21,6 +23,11 @@ export const ComponentDefinitionKeys = {
         ...ComponentDefinitionKeys.componentDefinitions,
         request.componentName,
         request.componentVersion,
+    ],
+    componentDefinitionVersions: (request: GetComponentDefinitionVersionsRequest) => [
+        ...ComponentDefinitionKeys.componentDefinitions,
+        request.componentName,
+        'versions',
     ],
     componentDefinitions: ['componentDefinitions'] as const,
     connectionComponentDefinition: (request: GetConnectionComponentDefinitionRequest) => [
@@ -50,5 +57,16 @@ export const useGetConnectionComponentDefinitionQuery = (
         queryKey: ComponentDefinitionKeys.connectionComponentDefinition(request),
         queryFn: () => new ComponentDefinitionApi().getConnectionComponentDefinition(request),
         enabled: enabled === undefined ? true : enabled,
+        staleTime: DEFINITION_STALE_TIME,
+    });
+
+export const useGetComponentDefinitionVersionsQuery = (
+    request: GetComponentDefinitionVersionsRequest,
+    enabled?: boolean
+) =>
+    useQuery<Array<ComponentDefinitionBasic>, Error>({
+        queryKey: ComponentDefinitionKeys.componentDefinitionVersions(request),
+        queryFn: () => new ComponentDefinitionApi().getComponentDefinitionVersions(request),
+        enabled: enabled ?? true,
         staleTime: DEFINITION_STALE_TIME,
     });

--- a/server/libs/platform/platform-component/platform-component-service/src/main/java/com/bytechef/platform/component/service/ComponentDefinitionServiceImpl.java
+++ b/server/libs/platform/platform-component/platform-component-service/src/main/java/com/bytechef/platform/component/service/ComponentDefinitionServiceImpl.java
@@ -40,6 +40,7 @@ import com.bytechef.platform.constant.PlatformType;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -170,14 +171,16 @@ public class ComponentDefinitionServiceImpl implements ComponentDefinitionServic
             .findFirst()
             .orElseThrow(() -> new IllegalArgumentException("Unsupported mode type: " + platformType));
 
-        List<ComponentDefinition> components = getComponentDefinitions()
-            .stream()
-            .filter(componentDefinitionFilter::filter)
-            .filter(
-                filter(
-                    actionDefinitions, clusterElementDefinitions, connectionDefinitions, triggerDefinitions, include))
-            .distinct()
-            .toList();
+        List<ComponentDefinition> components = filterLatestVersions(
+            getComponentDefinitions()
+                .stream()
+                .filter(componentDefinitionFilter::filter)
+                .filter(
+                    filter(
+                        actionDefinitions, clusterElementDefinitions, connectionDefinitions, triggerDefinitions,
+                        include))
+                .distinct()
+                .toList());
 
         if (include != null && !include.isEmpty()) {
             components = new ArrayList<>(components);
@@ -197,13 +200,14 @@ public class ComponentDefinitionServiceImpl implements ComponentDefinitionServic
             .findFirst()
             .orElseThrow(() -> new IllegalArgumentException("Unsupported mode type: " + platformType));
 
-        return getComponentDefinitions()
-            .stream()
-            .filter(componentDefinitionFilter::filter)
-            .filter(componentDefinition -> hasMatchingComponent(componentDefinition, lowerCaseQuery) ||
-                hasMatchingAction(componentDefinition.getActions(), lowerCaseQuery) ||
-                hasMatchingTrigger(componentDefinition.getTriggers(), lowerCaseQuery))
-            .toList();
+        return filterLatestVersions(
+            getComponentDefinitions()
+                .stream()
+                .filter(componentDefinitionFilter::filter)
+                .filter(componentDefinition -> hasMatchingComponent(componentDefinition, lowerCaseQuery) ||
+                    hasMatchingAction(componentDefinition.getActions(), lowerCaseQuery) ||
+                    hasMatchingTrigger(componentDefinition.getTriggers(), lowerCaseQuery))
+                .toList());
     }
 
     @Override
@@ -211,6 +215,7 @@ public class ComponentDefinitionServiceImpl implements ComponentDefinitionServic
         return componentDefinitionRegistry.getComponentDefinitions(name)
             .stream()
             .map(ComponentDefinition::new)
+            .sorted(Comparator.comparingInt(ComponentDefinition::getVersion))
             .toList();
     }
 
@@ -273,6 +278,24 @@ public class ComponentDefinitionServiceImpl implements ComponentDefinitionServic
             return include == null && actionDefinitions == null && clusterElementDefinitions == null &&
                 connectionDefinitions == null && triggerDefinitions == null;
         };
+    }
+
+    private static List<ComponentDefinition> filterLatestVersions(List<ComponentDefinition> componentDefinitions) {
+        Map<String, ComponentDefinition> latestComponentDefinitionMap = new LinkedHashMap<>();
+
+        for (ComponentDefinition componentDefinition : componentDefinitions) {
+            latestComponentDefinitionMap.merge(
+                componentDefinition.getName(), componentDefinition,
+                (currentComponentDefinition, candidateComponentDefinition) -> {
+                    if (candidateComponentDefinition.getVersion() > currentComponentDefinition.getVersion()) {
+                        return candidateComponentDefinition;
+                    }
+
+                    return currentComponentDefinition;
+                });
+        }
+
+        return List.copyOf(latestComponentDefinitionMap.values());
     }
 
     private static boolean hasMatchingAction(List<ActionDefinition> actions, String lowerCaseQuery) {

--- a/server/libs/platform/platform-component/platform-component-service/src/test/java/com/bytechef/platform/component/service/ComponentDefinitionServiceTest.java
+++ b/server/libs/platform/platform-component/platform-component-service/src/test/java/com/bytechef/platform/component/service/ComponentDefinitionServiceTest.java
@@ -16,13 +16,36 @@
 
 package com.bytechef.platform.component.service;
 
+import static com.bytechef.component.definition.ComponentDsl.action;
+import static com.bytechef.component.definition.ComponentDsl.component;
+
+import com.bytechef.component.ComponentHandler;
+import com.bytechef.config.ApplicationProperties;
+import com.bytechef.platform.component.ComponentDefinitionRegistry;
+import com.bytechef.platform.component.context.ContextFactory;
+import com.bytechef.platform.component.domain.ComponentDefinition;
+import com.bytechef.platform.component.filter.ComponentDefinitionFilter;
+import com.bytechef.platform.constant.PlatformType;
+import java.util.List;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 /**
  * @author Ivica Cardic
  */
 public class ComponentDefinitionServiceTest {
+
+    private static final ComponentHandler TEST_COMPONENT_V1_HANDLER = () -> component("test")
+        .title("Test")
+        .version(1)
+        .actions(action("get").title("Get"));
+
+    private static final ComponentHandler TEST_COMPONENT_V2_HANDLER = () -> component("test")
+        .title("Test")
+        .version(2)
+        .actions(action("get").title("Get"), action("create").title("Create"));
 
     @Disabled
     @Test
@@ -34,5 +57,71 @@ public class ComponentDefinitionServiceTest {
     @Test
     public void testGetComponentDefinitions() {
         // TODO
+    }
+
+    @Test
+    public void testGetComponentDefinitionsReturnsOnlyLatestVersion() {
+        ComponentDefinitionService componentDefinitionService = createComponentDefinitionService();
+
+        List<ComponentDefinition> componentDefinitions = componentDefinitionService.getComponentDefinitions(
+            true, null, null, null, null, PlatformType.AUTOMATION);
+
+        Assertions.assertThat(componentDefinitions)
+            .filteredOn(componentDefinition -> "test".equals(componentDefinition.getName()))
+            .extracting(ComponentDefinition::getVersion)
+            .containsExactly(2);
+    }
+
+    @Test
+    public void testGetComponentDefinitionsBySearchQueryReturnsOnlyLatestVersion() {
+        ComponentDefinitionService componentDefinitionService = createComponentDefinitionService();
+
+        List<ComponentDefinition> componentDefinitions = componentDefinitionService.getComponentDefinitions(
+            "test", PlatformType.AUTOMATION);
+
+        Assertions.assertThat(componentDefinitions)
+            .filteredOn(componentDefinition -> "test".equals(componentDefinition.getName()))
+            .extracting(ComponentDefinition::getVersion)
+            .containsExactly(2);
+    }
+
+    @Test
+    public void testGetComponentDefinitionVersionsReturnsAllVersionsInAscendingOrder() {
+        ComponentDefinitionService componentDefinitionService = createComponentDefinitionService();
+
+        List<ComponentDefinition> componentDefinitions =
+            componentDefinitionService.getComponentDefinitionVersions("test");
+
+        Assertions.assertThat(componentDefinitions)
+            .extracting(ComponentDefinition::getVersion)
+            .containsExactly(1, 2);
+    }
+
+    private static ComponentDefinitionService createComponentDefinitionService() {
+        ApplicationProperties applicationProperties = new ApplicationProperties();
+        ApplicationProperties.Component component = new ApplicationProperties.Component();
+
+        component.setRegistry(new ApplicationProperties.Component.Registry());
+        applicationProperties.setComponent(component);
+
+        ComponentDefinitionRegistry componentDefinitionRegistry = new ComponentDefinitionRegistry(
+            applicationProperties, List.of(TEST_COMPONENT_V2_HANDLER, TEST_COMPONENT_V1_HANDLER), List::of, List.of());
+
+        return new ComponentDefinitionServiceImpl(
+            List.of(new AllComponentDefinitionFilter()), componentDefinitionRegistry,
+            Mockito.mock(ContextFactory.class));
+    }
+
+    private static class AllComponentDefinitionFilter implements ComponentDefinitionFilter {
+
+        @Override
+        public boolean filter(ComponentDefinition componentDefinition) {
+            return true;
+        }
+
+        @Override
+        public boolean supports(PlatformType type) {
+            return true;
+        }
     }
 }


### PR DESCRIPTION
Fixes #5594

## Problem

Raising a component to v2 left the workflow editor showing the wrong thing, for two independent reasons.

**Backend.** `ComponentDefinitionServiceImpl` built the component listing by flat-mapping the registry's whole `name → version → definition` map, so a component registering both v1 and v2 came back twice. `.distinct()` doesn't collapse them — the two definitions genuinely differ — so the picker rendered the component twice under the same React key and let the stale v1 be placed.

**Frontend.** The version `Select` in the node details panel footer had been a stub since the editor was extracted in `201a46ac953`: a single hardcoded `<SelectItem value="1">v1</SelectItem>` and no `onValueChange`. A node on any other version had no matching item, so Radix fell back to the placeholder, and picking "v1" only moved local Select state — it never touched the workflow.

## Changes

**Server** — the two listing methods (`getComponentDefinitions(...)` and the search variant) keep the highest version per component name, applied *after* the platform and `include` filters so a v2 the filter would reject can't displace a v1 that qualified. `getComponentDefinitionVersions` now returns ascending order instead of relying on `HashMap` iteration.

The de-duplication deliberately stays out of the shared registry method: `getComponentDefinitions()` has ~20 callers, and `getConnectionComponentDefinition` genuinely needs older versions to resolve an old connection version against its component.

**Client** — the selector lists the versions the component registers, shows the one the node uses, and on a change rewrites the node to that version:

- the operation is kept when the target version still declares it, otherwise it falls back to that version's first operation of the same kind;
- parameters are carried over for properties the target version still declares, defaults fill in new properties, and values for removed properties are dropped;
- the node's `version` is written back so the component definition query refetches and the operation list reflects the chosen version;
- cluster elements and task-dispatcher subtasks go through the same path, via an optional `parameters` override threaded into the two existing save helpers.

The trigger also gained an `aria-label`, so it has an accessible name once a version is selected.

## Verification

- `ComponentDefinitionServiceTest` fails on `master` with `Expecting [1, 2] to contain exactly [2]` and passes here. The module's `check` (tests + checkstyle/PMD/SpotBugs) is green.
- `npm run check` is green — 378 files, 4016 tests. The new `WorkflowNodeDetailsPanelVersionSelect` test renders the panel and asserts a v2 node displays **v2**, lists v1 and v2, and reports `'1'` to the change handler; all four cases go red against the old stub.
- New unit tests cover the operation resolution, the parameter carry-over (including that a configured `false`/`0` is not replaced by the new version's default), and the version list.

**Not covered:** no component in this repo declares a version above 1, so the full round trip — handler → server → persisted workflow definition — was not exercised against a running server with a real v2 component. Its parts are unit-tested; the end-to-end path is not.

## Riding along

This branch also carries `5649 Label schedule timezones by standard offset instead of the current one`, cherry-picked from #5664. It is unrelated to this change: `ScheduleComponentHandlerTest` has been red on `master` since Chile's DST transition in early September, and without it the `server` job fails here for a reason that has nothing to do with component versions. Whichever of the two PRs merges second will drop the duplicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
