### PR TITLE
5666 client - Sync the cached project workflow version after every node parameter save

### DIFF
--- a/client/src/pages/automation/project/hooks/tests/useProject.test.tsx
+++ b/client/src/pages/automation/project/hooks/tests/useProject.test.tsx
@@ -1,0 +1,127 @@
+import {Workflow} from '@/shared/middleware/automation/configuration';
+import {
+    useDeleteClusterElementParameterMutation,
+    useDeleteWorkflowNodeParameterMutation,
+    useUpdateClusterElementParameterMutation,
+    useUpdateWorkflowNodeParameterMutation,
+} from '@/shared/mutations/platform/workflowNodeParameters.mutations';
+import useUpdatePlatformWorkflowMutation from '@/shared/mutations/platform/workflows.mutations';
+import {ProjectWorkflowKeys} from '@/shared/queries/automation/projectWorkflows.queries';
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
+import {act, renderHook} from '@testing-library/react';
+import {ReactNode} from 'react';
+import {afterEach, describe, expect, it, vi} from 'vitest';
+
+import {useProject} from '../useProject';
+
+const PROJECT_ID = 7;
+
+vi.mock('react-router-dom', () => ({
+    useNavigate: () => vi.fn(),
+    useParams: () => ({projectId: String(PROJECT_ID), projectWorkflowId: '3'}),
+    useSearchParams: () => [new URLSearchParams(''), vi.fn()],
+}));
+
+vi.mock('@/shared/queries/automation/projectWorkflows.queries', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('@/shared/queries/automation/projectWorkflows.queries')>()),
+    useGetProjectWorkflowQuery: () => ({data: undefined, isLoading: false}),
+    useGetProjectWorkflowsQuery: () => ({data: undefined}),
+}));
+
+vi.mock('@/shared/queries/automation/projectCategories.queries', () => ({
+    useGetProjectCategoriesQuery: () => ({data: undefined}),
+}));
+
+vi.mock('@/shared/queries/automation/projectTags.queries', () => ({
+    useGetProjectTagsQuery: () => ({data: undefined}),
+}));
+
+vi.mock('@/shared/mutations/platform/workflowNodeParameters.mutations', () => ({
+    useDeleteClusterElementParameterMutation: vi.fn(() => ({})),
+    useDeleteWorkflowNodeParameterMutation: vi.fn(() => ({})),
+    useUpdateClusterElementParameterMutation: vi.fn(() => ({})),
+    useUpdateWorkflowNodeParameterMutation: vi.fn(() => ({})),
+}));
+
+vi.mock('@/shared/mutations/platform/workflows.mutations', () => ({
+    default: vi.fn(() => ({})),
+}));
+
+const PARAMETER_MUTATION_VARIABLES = {
+    environmentId: 1,
+    id: 'workflow-b',
+    workflowNodeName: 'logger_1',
+};
+
+interface ParameterMutationOptionsI {
+    onSuccess?: (result: {version?: number}, variables: typeof PARAMETER_MUTATION_VARIABLES) => void;
+}
+
+type ParameterMutationHookType = (options?: ParameterMutationOptionsI) => unknown;
+
+const parameterMutationHooks: [string, ParameterMutationHookType][] = [
+    ['useDeleteWorkflowNodeParameterMutation', useDeleteWorkflowNodeParameterMutation],
+    ['useDeleteClusterElementParameterMutation', useDeleteClusterElementParameterMutation],
+    ['useUpdateWorkflowNodeParameterMutation', useUpdateWorkflowNodeParameterMutation],
+    ['useUpdateClusterElementParameterMutation', useUpdateClusterElementParameterMutation],
+];
+
+function renderUseProjectWithCachedWorkflows() {
+    const queryClient = new QueryClient();
+
+    queryClient.setQueryData(ProjectWorkflowKeys.projectWorkflows(PROJECT_ID), [
+        {id: 'workflow-a', version: 1},
+        {id: 'workflow-b', version: 1},
+    ]);
+
+    const wrapper = ({children}: {children: ReactNode}) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    renderHook(() => useProject(), {wrapper});
+
+    return queryClient;
+}
+
+function getCachedProjectWorkflows(queryClient: QueryClient) {
+    return queryClient.getQueryData<Workflow[]>(ProjectWorkflowKeys.projectWorkflows(PROJECT_ID));
+}
+
+describe('useProject', () => {
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it.each(parameterMutationHooks)(
+        'syncs the cached project workflow version after %s succeeds',
+        (_name, useParameterMutation) => {
+            const queryClient = renderUseProjectWithCachedWorkflows();
+
+            const mutationOptions = vi.mocked(useParameterMutation).mock.calls[0][0];
+
+            act(() => {
+                mutationOptions?.onSuccess?.({version: 4}, PARAMETER_MUTATION_VARIABLES);
+            });
+
+            expect(getCachedProjectWorkflows(queryClient)).toEqual([
+                {id: 'workflow-a', version: 1},
+                {id: 'workflow-b', version: 4},
+            ]);
+        }
+    );
+
+    it('syncs the cached project workflow version after the workflow editor save succeeds', () => {
+        const queryClient = renderUseProjectWithCachedWorkflows();
+
+        const editorMutationOptions = vi.mocked(useUpdatePlatformWorkflowMutation).mock.calls[0][0];
+
+        act(() => {
+            editorMutationOptions.onSuccess?.({id: 'workflow-b', version: 4} as Workflow);
+        });
+
+        expect(getCachedProjectWorkflows(queryClient)).toEqual([
+            {id: 'workflow-a', version: 1},
+            {id: 'workflow-b', version: 4},
+        ]);
+    });
+});

--- a/client/src/pages/automation/project/hooks/useProject.ts
+++ b/client/src/pages/automation/project/hooks/useProject.ts
@@ -1,4 +1,5 @@
 import useProjectsLeftSidebarStore from '@/pages/automation/project/stores/useProjectsLeftSidebarStore';
+import updateCachedProjectWorkflowVersion from '@/pages/automation/project/utils/updateCachedProjectWorkflowVersion';
 import {Type} from '@/pages/automation/projects/Projects';
 import {useWorkspaceStore} from '@/pages/automation/stores/useWorkspaceStore';
 import {RequestI} from '@/pages/platform/workflow-editor/providers/workflowEditorProvider';
@@ -11,7 +12,6 @@ import useWorkflowEditorStore from '@/pages/platform/workflow-editor/stores/useW
 import useWorkflowNodeDetailsPanelStore from '@/pages/platform/workflow-editor/stores/useWorkflowNodeDetailsPanelStore';
 import useWorkflowTestChatStore from '@/pages/platform/workflow-editor/stores/useWorkflowTestChatStore';
 import useCopilotPanelStore from '@/shared/components/copilot/stores/useCopilotPanelStore';
-import {Workflow} from '@/shared/middleware/automation/configuration';
 import {useUpdateWorkflowMutation} from '@/shared/mutations/automation/workflows.mutations';
 import {
     useDeleteClusterElementParameterMutation,
@@ -114,24 +114,31 @@ export const useProject = () => {
 
     const queryClient = useQueryClient();
 
-    const deleteWorkflowNodeParameterMutation = useDeleteWorkflowNodeParameterMutation();
+    const deleteWorkflowNodeParameterMutation = useDeleteWorkflowNodeParameterMutation({
+        onSuccess: (result, variables) =>
+            updateCachedProjectWorkflowVersion(queryClient, {
+                projectId: +projectId!,
+                version: result.version,
+                workflowId: variables.id,
+            }),
+    });
 
-    const deleteClusterElementParameterMutation = useDeleteClusterElementParameterMutation();
+    const deleteClusterElementParameterMutation = useDeleteClusterElementParameterMutation({
+        onSuccess: (result, variables) =>
+            updateCachedProjectWorkflowVersion(queryClient, {
+                projectId: +projectId!,
+                version: result.version,
+                workflowId: variables.id,
+            }),
+    });
 
     const updateWorkflowEditorMutation = useUpdatePlatformWorkflowMutation({
-        // Keep the cached project workflow list in sync with the version bumped by the save, so consumers relying on
-        // it, such as the Publish button, do not read a stale version.
-        onSuccess: (updatedWorkflow) => {
-            queryClient.setQueryData<Workflow[]>(
-                ProjectWorkflowKeys.projectWorkflows(+projectId!),
-                (projectWorkflows) =>
-                    projectWorkflows?.map((projectWorkflow) =>
-                        projectWorkflow.id === updatedWorkflow.id
-                            ? {...projectWorkflow, version: updatedWorkflow.version}
-                            : projectWorkflow
-                    )
-            );
-        },
+        onSuccess: (updatedWorkflow) =>
+            updateCachedProjectWorkflowVersion(queryClient, {
+                projectId: +projectId!,
+                version: updatedWorkflow.version,
+                workflowId: updatedWorkflow.id,
+            }),
         useUpdateWorkflowMutation,
         workflowId: workflow.id!,
         workflowKeys: WorkflowKeys,
@@ -155,7 +162,13 @@ export const useProject = () => {
     });
 
     const updateWorkflowNodeParameterMutation = useUpdateWorkflowNodeParameterMutation({
-        onSuccess: (_result, variables) => {
+        onSuccess: (result, variables) => {
+            updateCachedProjectWorkflowVersion(queryClient, {
+                projectId: +projectId!,
+                version: result.version,
+                workflowId: variables.id,
+            });
+
             queryClient.invalidateQueries({
                 queryKey: WorkflowNodeDescriptionKeys.workflowNodeDescription({
                     environmentId: variables.environmentId,
@@ -178,7 +191,14 @@ export const useProject = () => {
         },
     });
 
-    const updateClusterElementParameterMutation = useUpdateClusterElementParameterMutation();
+    const updateClusterElementParameterMutation = useUpdateClusterElementParameterMutation({
+        onSuccess: (result, variables) =>
+            updateCachedProjectWorkflowVersion(queryClient, {
+                projectId: +projectId!,
+                version: result.version,
+                workflowId: variables.id,
+            }),
+    });
 
     const cancelWorkflowQueries = () => {
         const queryKey = ProjectWorkflowKeys.projectWorkflows(+projectId!);

--- a/client/src/pages/automation/project/utils/updateCachedProjectWorkflowVersion.test.ts
+++ b/client/src/pages/automation/project/utils/updateCachedProjectWorkflowVersion.test.ts
@@ -1,0 +1,66 @@
+import {Workflow} from '@/shared/middleware/automation/configuration';
+import {ProjectWorkflowKeys} from '@/shared/queries/automation/projectWorkflows.queries';
+import {QueryClient} from '@tanstack/react-query';
+import {describe, expect, it} from 'vitest';
+
+import updateCachedProjectWorkflowVersion from './updateCachedProjectWorkflowVersion';
+
+const PROJECT_ID = 7;
+
+const cachedProjectWorkflows: Workflow[] = [
+    {id: 'workflow-a', version: 1} as Workflow,
+    {id: 'workflow-b', version: 1} as Workflow,
+];
+
+function createQueryClientWithCachedWorkflows() {
+    const queryClient = new QueryClient();
+
+    queryClient.setQueryData(ProjectWorkflowKeys.projectWorkflows(PROJECT_ID), cachedProjectWorkflows);
+
+    return queryClient;
+}
+
+describe('updateCachedProjectWorkflowVersion', () => {
+    it('bumps the cached version of the saved workflow and leaves the other workflows untouched', () => {
+        const queryClient = createQueryClientWithCachedWorkflows();
+
+        updateCachedProjectWorkflowVersion(queryClient, {projectId: PROJECT_ID, version: 3, workflowId: 'workflow-b'});
+
+        expect(queryClient.getQueryData<Workflow[]>(ProjectWorkflowKeys.projectWorkflows(PROJECT_ID))).toEqual([
+            {id: 'workflow-a', version: 1},
+            {id: 'workflow-b', version: 3},
+        ]);
+    });
+
+    it('keeps the cache untouched when the response carries no version', () => {
+        const queryClient = createQueryClientWithCachedWorkflows();
+
+        updateCachedProjectWorkflowVersion(queryClient, {
+            projectId: PROJECT_ID,
+            version: undefined,
+            workflowId: 'workflow-b',
+        });
+
+        expect(queryClient.getQueryData<Workflow[]>(ProjectWorkflowKeys.projectWorkflows(PROJECT_ID))).toEqual(
+            cachedProjectWorkflows
+        );
+    });
+
+    it('keeps the cache untouched when the saved workflow id is unknown', () => {
+        const queryClient = createQueryClientWithCachedWorkflows();
+
+        updateCachedProjectWorkflowVersion(queryClient, {projectId: PROJECT_ID, version: 3, workflowId: undefined});
+
+        expect(queryClient.getQueryData<Workflow[]>(ProjectWorkflowKeys.projectWorkflows(PROJECT_ID))).toEqual(
+            cachedProjectWorkflows
+        );
+    });
+
+    it('does not seed a project workflow list query when none has been fetched yet', () => {
+        const queryClient = new QueryClient();
+
+        updateCachedProjectWorkflowVersion(queryClient, {projectId: PROJECT_ID, version: 3, workflowId: 'workflow-b'});
+
+        expect(queryClient.getQueryState(ProjectWorkflowKeys.projectWorkflows(PROJECT_ID))).toBeUndefined();
+    });
+});

--- a/client/src/pages/automation/project/utils/updateCachedProjectWorkflowVersion.ts
+++ b/client/src/pages/automation/project/utils/updateCachedProjectWorkflowVersion.ts
@@ -1,0 +1,29 @@
+import {Workflow} from '@/shared/middleware/automation/configuration';
+import {ProjectWorkflowKeys} from '@/shared/queries/automation/projectWorkflows.queries';
+import {QueryClient} from '@tanstack/react-query';
+
+interface UpdateCachedProjectWorkflowVersionI {
+    projectId: number;
+    version: number | undefined;
+    workflowId: string | undefined;
+}
+
+export default function updateCachedProjectWorkflowVersion(
+    queryClient: QueryClient,
+    {projectId, version, workflowId}: UpdateCachedProjectWorkflowVersionI
+) {
+    const queryKey = ProjectWorkflowKeys.projectWorkflows(projectId);
+
+    const projectWorkflows = queryClient.getQueryData<Workflow[]>(queryKey);
+
+    if (!workflowId || version === undefined || !projectWorkflows) {
+        return;
+    }
+
+    queryClient.setQueryData<Workflow[]>(
+        queryKey,
+        projectWorkflows.map((projectWorkflow) =>
+            projectWorkflow.id === workflowId ? {...projectWorkflow, version} : projectWorkflow
+        )
+    );
+}


### PR DESCRIPTION
Closes #5666

## Problem

After editing a node property, the project header's **Publish** button stays disabled until the page is refreshed. Structural edits (add/remove node) enable it correctly.

## Root cause

`useProjectHeader` computes `hasUnpublishedChanges` from the cached project workflow list, treating any workflow with `version > 1` as edited since the last publish (#4124). Property saves go through the `WorkflowNodeParameter` endpoints, which bump the workflow's `@Version` on the server and return it. `saveProperty` wrote that version into the Zustand workflow store, but only the structural editor mutation in `useProject` patched the React Query list, so the header kept reading `version: 1`.

## Fix

- New `updateCachedProjectWorkflowVersion` helper patches the cached list entry for a workflow with the version returned by a save. It is a no-op when the list is not fetched yet or the response carries no version.
- `useProject` calls it from every version-bumping mutation: update/delete workflow node parameter, update/delete cluster element parameter, and the structural editor mutation (replacing its inline copy of the same logic).

## Tests

- Unit tests for the helper: version bump, sibling workflows untouched, response without version, unfetched cache.
- `eslint`, `tsc --noEmit`, and the related suites under `pages/automation/project`, `workflowNodeParameters.mutations`, and `saveProperty` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)