### PR TITLE
5668 Activate the local Spring profile alongside dev and prod

### DIFF
--- a/buildSrc/src/main/kotlin/com.bytechef.java-spring-boot-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/com.bytechef.java-spring-boot-conventions.gradle.kts
@@ -16,7 +16,7 @@ val libs = rootProject.extensions.getByType<VersionCatalogsExtension>().named("l
 var profiles = ""
 
 if (project.hasProperty("prod")) {
-    profiles = "prod"
+    profiles = "prod,local"
 
     if (project.hasProperty("api-docs")) {
         profiles += ",api-docs"
@@ -38,7 +38,7 @@ if (project.hasProperty("prod")) {
         "developmentOnly"("org.springframework.boot:spring-boot-devtools:${libs.findVersion("spring-boot").get()}")
     }
 
-    profiles = "dev"
+    profiles = "dev,local"
 
     configure<org.springframework.boot.gradle.dsl.SpringBootExtension> {
         buildInfo {


### PR DESCRIPTION
Closes #5668

## Summary

- Append `local` to the active Spring profile list in `com.bytechef.java-spring-boot-conventions.gradle.kts` for both the `dev` (`bootRun`) and `prod` (packaged) branches.
- Lets developers keep machine-specific overrides in the already gitignored `application-local.yml` without editing tracked config or passing `--spring.profiles.active` by hand.
- Spring Boot ignores a profile with no matching config file, so builds and images without `application-local.yml` behave as before.

## Test plan

- [ ] `./gradlew -p server/apps/server-app bootRun` with an `application-local.yml` present applies its overrides.
- [ ] Without the file, `bootRun` and `./gradlew -Pprod bootJar` start with the same effective config as today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019wDYtVYtFbD3k4JTUgJnZa