### PR TITLE
5689 client - Fix the templates page and share dialog layouts and the project template links

### DIFF
--- a/client/src/pages/automation/project/components/ProjectShareDialog.tsx
+++ b/client/src/pages/automation/project/components/ProjectShareDialog.tsx
@@ -5,6 +5,7 @@ import {Alert, AlertDescription} from '@/components/ui/alert';
 import {Dialog, DialogCloseButton, DialogContent, DialogHeader, DialogTitle} from '@/components/ui/dialog';
 import {Label} from '@/components/ui/label';
 import {Textarea} from '@/components/ui/textarea';
+import {TEMPLATE_SHARING_DOCUMENTATION_URL} from '@/shared/constants';
 import {
     useDeleteSharedProjectMutation,
     useExportSharedProjectMutation,
@@ -114,6 +115,8 @@ export function ProjectShareDialog({
         }
     }, [sharedProject, projectUuid]);
 
+    const handleLearnMoreClick = () => window.open(TEMPLATE_SHARING_DOCUMENTATION_URL, '_blank', 'noopener,noreferrer');
+
     return (
         <Dialog onOpenChange={onOpenChange} open={open}>
             <DialogContent className="flex flex-col">
@@ -145,13 +148,18 @@ export function ProjectShareDialog({
                                         time.
                                     </p>
 
-                                    <Button className="h-auto p-0" label="Learn more" variant="link" />
+                                    <Button
+                                        className="h-auto p-0"
+                                        label="Learn more"
+                                        onClick={handleLearnMoreClick}
+                                        variant="link"
+                                    />
                                 </div>
                             )}
 
                             {shareState === 'exported' && (
                                 <>
-                                    <div className="flex items-center justify-between pb-4 font-semibold text-primary">
+                                    <div className="flex w-full items-center justify-between pb-4 font-semibold text-primary">
                                         {sharedProject?.projectVersion === projectVersion ? (
                                             <span className="text-sm font-medium text-primary">
                                                 This project has been exported
@@ -174,8 +182,8 @@ export function ProjectShareDialog({
                                         </p>
                                     )}
 
-                                    <div className="flex items-center gap-2">
-                                        <Input className="text-primary" readOnly value={templateUrl!} />
+                                    <div className="flex w-full items-center gap-2">
+                                        <Input className="grow text-primary" readOnly value={templateUrl!} />
 
                                         {isCopied ? (
                                             <div className="flex items-center text-sm font-medium">
@@ -213,7 +221,12 @@ export function ProjectShareDialog({
                                             link.
                                         </p>
 
-                                        <Button className="h-auto p-0" label="Learn more" variant="link" />
+                                        <Button
+                                            className="h-auto p-0"
+                                            label="Learn more"
+                                            onClick={handleLearnMoreClick}
+                                            variant="link"
+                                        />
                                     </div>
                                 </div>
                             )}
@@ -260,7 +273,13 @@ export function ProjectShareDialog({
                             share, and you may disable and re-enable them at any time.
                         </span>
 
-                        <Button className="h-auto p-0" label="Learn more" size="sm" variant="link" />
+                        <Button
+                            className="h-auto p-0"
+                            label="Learn more"
+                            onClick={handleLearnMoreClick}
+                            size="sm"
+                            variant="link"
+                        />
                     </p>
                 </div>
             </DialogContent>

--- a/client/src/pages/automation/project/components/WorkflowShareDialog.tsx
+++ b/client/src/pages/automation/project/components/WorkflowShareDialog.tsx
@@ -5,6 +5,7 @@ import {Alert, AlertDescription} from '@/components/ui/alert';
 import {Dialog, DialogCloseButton, DialogContent, DialogHeader, DialogTitle} from '@/components/ui/dialog';
 import {Label} from '@/components/ui/label';
 import {Textarea} from '@/components/ui/textarea';
+import {TEMPLATE_SHARING_DOCUMENTATION_URL} from '@/shared/constants';
 import {
     useDeleteSharedWorkflowMutation,
     useExportSharedWorkflowMutation,
@@ -112,6 +113,8 @@ export function WorkflowShareDialog({
         }
     }, [sharedWorkflow, workflowUuid]);
 
+    const handleLearnMoreClick = () => window.open(TEMPLATE_SHARING_DOCUMENTATION_URL, '_blank', 'noopener,noreferrer');
+
     return (
         <Dialog onOpenChange={onOpenChange} open={open}>
             <DialogContent className="flex flex-col">
@@ -143,11 +146,16 @@ export function WorkflowShareDialog({
                                         time.
                                     </p>
 
-                                    <Button className="h-auto p-0" label="Learn more" variant="link" />
+                                    <Button
+                                        className="h-auto p-0"
+                                        label="Learn more"
+                                        onClick={handleLearnMoreClick}
+                                        variant="link"
+                                    />
                                 </div>
                             ) : shareState === 'exported' ? (
                                 <>
-                                    <div className="flex items-center justify-between pb-4 font-semibold text-primary">
+                                    <div className="flex w-full items-center justify-between pb-4 font-semibold text-primary">
                                         {sharedWorkflow?.projectVersion === projectVersion ? (
                                             <span className="text-sm font-medium text-primary">
                                                 This workflow has been exported
@@ -170,8 +178,8 @@ export function WorkflowShareDialog({
                                         </p>
                                     )}
 
-                                    <div className="flex items-center gap-2">
-                                        <Input className="text-primary" readOnly value={templateUrl!} />
+                                    <div className="flex w-full items-center gap-2">
+                                        <Input className="grow text-primary" readOnly value={templateUrl!} />
 
                                         {isCopied ? (
                                             <div className="flex items-center text-sm font-medium">
@@ -207,7 +215,12 @@ export function WorkflowShareDialog({
                                             the link.
                                         </p>
 
-                                        <Button className="h-auto p-0" label="Learn more" variant="link" />
+                                        <Button
+                                            className="h-auto p-0"
+                                            label="Learn more"
+                                            onClick={handleLearnMoreClick}
+                                            variant="link"
+                                        />
                                     </div>
                                 </div>
                             )}
@@ -270,7 +283,13 @@ export function WorkflowShareDialog({
                             share, and you may disable and re-enable them at any time.
                         </span>
 
-                        <Button className="h-auto p-0" label="Learn more" size="sm" variant="link" />
+                        <Button
+                            className="h-auto p-0"
+                            label="Learn more"
+                            onClick={handleLearnMoreClick}
+                            size="sm"
+                            variant="link"
+                        />
                     </p>
                 </div>
             </DialogContent>

--- a/client/src/pages/automation/project/components/projects-sidebar/ProjectsLeftSidebar.test.tsx
+++ b/client/src/pages/automation/project/components/projects-sidebar/ProjectsLeftSidebar.test.tsx
@@ -155,8 +155,10 @@ vi.mock('@tanstack/react-query', async () => {
     };
 });
 
+const mockNavigate = vi.hoisted(() => vi.fn());
+
 vi.mock('react-router-dom', async () => ({
-    useNavigate: () => vi.fn(),
+    useNavigate: () => mockNavigate,
 }));
 
 // Helper to set default mocks per test scenario
@@ -444,5 +446,25 @@ describe('ProjectsLeftSidebar', () => {
         const menuItem = (await screen.findByText('Import n8n Workflow')).closest('[role="menuitem"]');
 
         expect(menuItem).not.toHaveAttribute('aria-disabled');
+    });
+
+    it('opens the template pages with absolute routes', () => {
+        setupQueries({selectedProjectId: 5});
+
+        renderWithProviders(<ProjectsLeftSidebar {...baseProps} projectId={5} />);
+
+        const templateItems = screen
+            .getAllByRole('menuitem')
+            .filter((menuItem) => /From Template/.test(menuItem.textContent ?? ''));
+
+        expect(templateItems).toHaveLength(2);
+
+        fireEvent.click(templateItems[0]);
+
+        expect(mockNavigate).toHaveBeenCalledWith('/automation/projects/templates');
+
+        fireEvent.click(templateItems[1]);
+
+        expect(mockNavigate).toHaveBeenCalledWith('/automation/projects/5/templates');
     });
 });

--- a/client/src/pages/automation/project/components/projects-sidebar/ProjectsLeftSidebar.tsx
+++ b/client/src/pages/automation/project/components/projects-sidebar/ProjectsLeftSidebar.tsx
@@ -193,7 +193,10 @@ const ProjectsLeftSidebar = ({
                                         From Scratch
                                     </DropdownMenuItem>
 
-                                    <DropdownMenuItem className="cursor-pointer" onClick={() => navigate(`templates`)}>
+                                    <DropdownMenuItem
+                                        className="cursor-pointer"
+                                        onClick={() => navigate('/automation/projects/templates')}
+                                    >
                                         <LayoutTemplateIcon className="mr-2 size-4" />
                                         From Template
                                     </DropdownMenuItem>
@@ -247,7 +250,7 @@ const ProjectsLeftSidebar = ({
                         <DropdownMenuContent align="end">
                             <DropdownMenuItem
                                 className="cursor-pointer"
-                                onClick={() => navigate(`./../../../${selectedProjectId}/templates`)}
+                                onClick={() => navigate(`/automation/projects/${selectedProjectId}/templates`)}
                             >
                                 <LayoutTemplateIcon /> From Template
                             </DropdownMenuItem>
@@ -309,7 +312,7 @@ const ProjectsLeftSidebar = ({
                                     />
                                 ))
                             ) : (
-                                <span className="text-sm text-muted-foreground">No workflows found</span>
+                                <span className="w-full py-2 text-sm text-muted-foreground">No workflows found</span>
                             ))}
 
                         {selectedProjectId !== 0 && filteredWorkflowsList.length > 0 ? (
@@ -325,7 +328,7 @@ const ProjectsLeftSidebar = ({
                                 />
                             ))
                         ) : (
-                            <span className="text-sm text-muted-foreground">No workflows found</span>
+                            <span className="w-full py-2 text-sm text-muted-foreground">No workflows found</span>
                         )}
                     </ul>
                 )}

--- a/client/src/pages/automation/project/components/tests/ProjectShareDialog.test.tsx
+++ b/client/src/pages/automation/project/components/tests/ProjectShareDialog.test.tsx
@@ -1,0 +1,69 @@
+import {TEMPLATE_SHARING_DOCUMENTATION_URL} from '@/shared/constants';
+import {fireEvent, render, screen} from '@testing-library/react';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+
+import {ProjectShareDialog} from '../ProjectShareDialog';
+
+const hoisted = vi.hoisted(() => ({
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    shared: undefined as any,
+}));
+
+vi.mock('@/shared/middleware/graphql', () => ({
+    useDeleteSharedProjectMutation: () => ({isPending: false, mutate: vi.fn()}),
+    useExportSharedProjectMutation: () => ({isPending: false, mutate: vi.fn()}),
+    useSharedProjectQuery: () => ({data: {sharedProject: hoisted.shared}, refetch: vi.fn()}),
+}));
+
+describe('ProjectShareDialog', () => {
+    beforeEach(() => {
+        hoisted.shared = undefined;
+
+        vi.spyOn(window, 'open')
+            .mockImplementation(() => null)
+            .mockClear();
+    });
+
+    afterEach(() => {
+        vi.mocked(window.open).mockRestore();
+    });
+
+    const renderDialog = () =>
+        render(
+            <ProjectShareDialog
+                onOpenChange={vi.fn()}
+                open
+                projectId={1}
+                projectUuid="project-uuid"
+                projectVersion={2}
+            />
+        );
+
+    it('opens the documentation from Learn more before anything is shared', () => {
+        renderDialog();
+
+        screen.getAllByText('Learn more').forEach((learnMoreButton) => fireEvent.click(learnMoreButton));
+
+        expect(window.open).toHaveBeenCalledWith(TEMPLATE_SHARING_DOCUMENTATION_URL, '_blank', 'noopener,noreferrer');
+    });
+
+    it('opens the documentation from Learn more while the template is disabled', () => {
+        hoisted.shared = {exported: false};
+
+        renderDialog();
+
+        screen.getAllByText('Learn more').forEach((learnMoreButton) => fireEvent.click(learnMoreButton));
+
+        expect(window.open).toHaveBeenCalledWith(TEMPLATE_SHARING_DOCUMENTATION_URL, '_blank', 'noopener,noreferrer');
+    });
+
+    it('opens the documentation from Learn more when the shared version is stale', () => {
+        hoisted.shared = {exported: true, projectVersion: 1};
+
+        renderDialog();
+
+        screen.getAllByText('Learn more').forEach((learnMoreButton) => fireEvent.click(learnMoreButton));
+
+        expect(window.open).toHaveBeenCalledWith(TEMPLATE_SHARING_DOCUMENTATION_URL, '_blank', 'noopener,noreferrer');
+    });
+});

--- a/client/src/pages/automation/project/components/tests/WorkflowShareDialog.test.tsx
+++ b/client/src/pages/automation/project/components/tests/WorkflowShareDialog.test.tsx
@@ -1,0 +1,69 @@
+import {TEMPLATE_SHARING_DOCUMENTATION_URL} from '@/shared/constants';
+import {fireEvent, render, screen} from '@testing-library/react';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+
+import {WorkflowShareDialog} from '../WorkflowShareDialog';
+
+const hoisted = vi.hoisted(() => ({
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    shared: undefined as any,
+}));
+
+vi.mock('@/shared/middleware/graphql', () => ({
+    useDeleteSharedWorkflowMutation: () => ({isPending: false, mutate: vi.fn()}),
+    useExportSharedWorkflowMutation: () => ({isPending: false, mutate: vi.fn()}),
+    useSharedWorkflowQuery: () => ({data: {sharedWorkflow: hoisted.shared}, refetch: vi.fn()}),
+}));
+
+describe('WorkflowShareDialog', () => {
+    beforeEach(() => {
+        hoisted.shared = undefined;
+
+        vi.spyOn(window, 'open')
+            .mockImplementation(() => null)
+            .mockClear();
+    });
+
+    afterEach(() => {
+        vi.mocked(window.open).mockRestore();
+    });
+
+    const renderDialog = () =>
+        render(
+            <WorkflowShareDialog
+                onOpenChange={vi.fn()}
+                open
+                projectVersion={2}
+                workflowId="workflow-id"
+                workflowUuid="workflow-uuid"
+            />
+        );
+
+    it('opens the documentation from Learn more before anything is shared', () => {
+        renderDialog();
+
+        screen.getAllByText('Learn more').forEach((learnMoreButton) => fireEvent.click(learnMoreButton));
+
+        expect(window.open).toHaveBeenCalledWith(TEMPLATE_SHARING_DOCUMENTATION_URL, '_blank', 'noopener,noreferrer');
+    });
+
+    it('opens the documentation from Learn more while the template is disabled', () => {
+        hoisted.shared = {exported: false};
+
+        renderDialog();
+
+        screen.getAllByText('Learn more').forEach((learnMoreButton) => fireEvent.click(learnMoreButton));
+
+        expect(window.open).toHaveBeenCalledWith(TEMPLATE_SHARING_DOCUMENTATION_URL, '_blank', 'noopener,noreferrer');
+    });
+
+    it('opens the documentation from Learn more when the shared version is stale', () => {
+        hoisted.shared = {exported: true, projectVersion: 1};
+
+        renderDialog();
+
+        screen.getAllByText('Learn more').forEach((learnMoreButton) => fireEvent.click(learnMoreButton));
+
+        expect(window.open).toHaveBeenCalledWith(TEMPLATE_SHARING_DOCUMENTATION_URL, '_blank', 'noopener,noreferrer');
+    });
+});

--- a/client/src/pages/automation/template/components/TemplateLayoutContainer.tsx
+++ b/client/src/pages/automation/template/components/TemplateLayoutContainer.tsx
@@ -22,7 +22,7 @@ const TemplateLayoutContainer = ({
             )}
 
             <div className="flex flex-1 items-center justify-center px-6 py-8">
-                <Card className="w-8/12 overflow-hidden">
+                <Card className="w-8/12 overflow-hidden py-0">
                     <div className="flex h-template-height">{children}</div>
                 </Card>
             </div>

--- a/client/src/pages/automation/template/components/tests/TemplateLayoutContainer.test.tsx
+++ b/client/src/pages/automation/template/components/tests/TemplateLayoutContainer.test.tsx
@@ -1,0 +1,32 @@
+import {render, screen} from '@testing-library/react';
+import {MemoryRouter} from 'react-router-dom';
+import {describe, expect, it} from 'vitest';
+
+import TemplateLayoutContainer from '../TemplateLayoutContainer';
+
+describe('TemplateLayoutContainer', () => {
+    it('renders the content inside the card with the logo link', () => {
+        render(
+            <MemoryRouter>
+                <TemplateLayoutContainer>
+                    <span>template body</span>
+                </TemplateLayoutContainer>
+            </MemoryRouter>
+        );
+
+        expect(screen.getByText('template body')).toBeInTheDocument();
+        expect(screen.getByRole('link')).toHaveAttribute('href', '/');
+    });
+
+    it('omits the logo when opened from inside the app', () => {
+        render(
+            <MemoryRouter>
+                <TemplateLayoutContainer fromInternalFlow>
+                    <span>template body</span>
+                </TemplateLayoutContainer>
+            </MemoryRouter>
+        );
+
+        expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    });
+});

--- a/client/src/pages/automation/templates/components/TemplateCard.tsx
+++ b/client/src/pages/automation/templates/components/TemplateCard.tsx
@@ -27,8 +27,8 @@ export function TemplateCard({authorName, categories, description, icons, templa
 
     return (
         <Link to={templateId}>
-            <Card className="flex min-h-[230px] flex-col transition-all hover:border-primary/20 hover:shadow-lg">
-                <CardHeader>
+            <Card className="flex min-h-[230px] flex-col p-4 transition-all hover:border-primary/20 hover:shadow-lg">
+                <CardHeader className="px-0">
                     <div className="flex items-center justify-end">
                         {categories.map((category, index) => (
                             <Badge
@@ -56,7 +56,7 @@ export function TemplateCard({authorName, categories, description, icons, templa
                     </CardDescription>
                 </CardHeader>
 
-                <CardContent className="flex-1">
+                <CardContent className="flex-1 px-0">
                     <div className="flex size-full items-end">
                         <div className="flex flex-wrap gap-1">
                             {icons.map((icon, index) => (
@@ -74,7 +74,7 @@ export function TemplateCard({authorName, categories, description, icons, templa
                     </div>
                 </CardContent>
 
-                <CardFooter>{authorName}</CardFooter>
+                <CardFooter className="px-0">{authorName}</CardFooter>
             </Card>
         </Link>
     );

--- a/client/src/pages/automation/templates/components/layout-container/TemplatesLayoutContainer.tsx
+++ b/client/src/pages/automation/templates/components/layout-container/TemplatesLayoutContainer.tsx
@@ -11,8 +11,8 @@ interface TemplateImportsProps {
 
 const TemplatesLayoutContainer = ({children, searchPlaceholder, title}: TemplateImportsProps) => {
     return (
-        <div className="size-full">
-            <main className="mx-auto mt-14 flex h-full max-w-7xl flex-col overflow-auto px-4 py-8 sm:px-6 lg:px-8">
+        <div className="flex size-full flex-col">
+            <main className="mx-auto mt-14 flex min-h-0 w-full max-w-7xl flex-1 flex-col overflow-auto px-4 pt-8 pb-4 sm:px-6 sm:pb-6 lg:px-8 lg:pb-8">
                 <div className="mb-8 text-center">
                     <h1 className="mb-10 text-4xl font-bold text-foreground">{title}</h1>
 

--- a/client/src/pages/automation/templates/components/tests/TemplateCard.test.tsx
+++ b/client/src/pages/automation/templates/components/tests/TemplateCard.test.tsx
@@ -1,0 +1,34 @@
+import {TooltipProvider} from '@/components/ui/tooltip';
+import {render, screen} from '@testing-library/react';
+import {MemoryRouter} from 'react-router-dom';
+import {describe, expect, it, vi} from 'vitest';
+
+import {TemplateCard} from '../TemplateCard';
+
+vi.mock('@/components/LazyLoadSVG/LazyLoadSVG', () => ({
+    default: ({src}: {src: string}) => <img alt={src} src={src} />,
+}));
+
+describe('TemplateCard', () => {
+    it('renders the title, description, categories and icons', () => {
+        render(
+            <MemoryRouter>
+                <TooltipProvider>
+                    <TemplateCard
+                        authorName="ByteChef"
+                        categories={['ai']}
+                        description="Classifies incoming mail"
+                        icons={['/gmail.svg', '/openai.svg']}
+                        templateId="ai-email-classifier"
+                        title="AI Email Classifier"
+                    />
+                </TooltipProvider>
+            </MemoryRouter>
+        );
+
+        expect(screen.getByText('AI Email Classifier')).toBeInTheDocument();
+        expect(screen.getByText('Classifies incoming mail')).toBeInTheDocument();
+        expect(screen.getByText('ByteChef')).toBeInTheDocument();
+        expect(screen.getAllByRole('img')).toHaveLength(2);
+    });
+});

--- a/client/src/shared/constants.tsx
+++ b/client/src/shared/constants.tsx
@@ -233,3 +233,5 @@ export const WORKFLOW_NODES_SIDEBAR_WIDTH = 384;
 export const PROJECT_LEFT_SIDEBAR_WIDTH = 355;
 
 export const CANVAS_BACKGROUND_COLOR = '#E2E8F0';
+
+export const TEMPLATE_SHARING_DOCUMENTATION_URL = 'https://docs.bytechef.io';


### PR DESCRIPTION
Closes #5689

- Templates page: keep the scroll container inside its parent so the bottom padding is visible (`mt-14` + `h-full` pushed it off-screen).
- Template card: uniform `p-4` padding; the template detail card drops the default vertical padding above its banner.
- Share dialogs: toggle row and link row fill the width, the link input grows so *Copy link* sits on the right; the six *Learn more* buttons open the documentation.
- Project sidebar: template menu items navigate with absolute routes (`/automation/projects/templates` and `/automation/projects/<id>/templates`) instead of routes relative to the current page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)