### PR TITLE
Workflow sidebar actions menu, integration list affordances, and workflow editor island fixes

### DIFF
--- a/client/src/ee/pages/embedded/automation-workflow/AutomationWorkflow.tsx
+++ b/client/src/ee/pages/embedded/automation-workflow/AutomationWorkflow.tsx
@@ -183,13 +183,11 @@ const AutomationWorkflow = () => {
                         <ResizableHandle className="bg-muted" />
 
                         <ResizablePanel className="bg-background" defaultSize={0} panelRef={bottomResizablePanelRef}>
-                            {(workflowIsRunning || workflowTestExecution) && (
-                                <WorkflowExecutionsTestOutput
-                                    onCloseClick={handleWorkflowExecutionsTestOutputCloseClick}
-                                    workflowIsRunning={workflowIsRunning}
-                                    workflowTestExecution={workflowTestExecution}
-                                />
-                            )}
+                            <WorkflowExecutionsTestOutput
+                                onCloseClick={handleWorkflowExecutionsTestOutputCloseClick}
+                                workflowIsRunning={workflowIsRunning}
+                                workflowTestExecution={workflowTestExecution}
+                            />
                         </ResizablePanel>
                     </ResizablePanelGroup>
                 </div>

--- a/client/src/ee/pages/embedded/automation-workflow/components/automation-workflow-editor/AutomationWorkflowEditorLeftSidebar.tsx
+++ b/client/src/ee/pages/embedded/automation-workflow/components/automation-workflow-editor/AutomationWorkflowEditorLeftSidebar.tsx
@@ -20,7 +20,7 @@ import {
 } from '@/shared/middleware/graphql';
 import {useQueryClient} from '@tanstack/react-query';
 import {PlusIcon} from 'lucide-react';
-import {useMemo, useRef, useState} from 'react';
+import {useEffect, useMemo, useRef, useState} from 'react';
 import {useNavigate} from 'react-router-dom';
 
 type AutomationWorkflowProjectType = AutomationWorkflowProjectsQuery['automationWorkflowProjects'][number];
@@ -148,6 +148,14 @@ const AutomationWorkflowEditorLeftSidebar = ({currentWorkflowId}: AutomationWork
 
         setShowWorkflowDialog(false);
     };
+
+    useEffect(() => {
+        if (!currentProject) {
+            return;
+        }
+
+        setSelectedProjectId((previousSelectedProjectId) => previousSelectedProjectId || currentProject.id);
+    }, [currentProject]);
 
     return (
         <aside className="flex h-full min-w-[355px] flex-col items-center gap-2 bg-surface-main px-4 pt-3">

--- a/client/src/ee/pages/embedded/automation-workflow/components/automation-workflow-editor/AutomationWorkflowEditorLeftSidebar.tsx
+++ b/client/src/ee/pages/embedded/automation-workflow/components/automation-workflow-editor/AutomationWorkflowEditorLeftSidebar.tsx
@@ -197,13 +197,14 @@ const AutomationWorkflowEditorLeftSidebar = ({currentWorkflowId}: AutomationWork
                     </div>
                 )}
 
-                {!projectsIsLoading && filteredAndSortedWorkflows.length > 0 && (
+                {!projectsIsLoading && selectedProject && filteredAndSortedWorkflows.length > 0 && (
                     <ul className="flex flex-col items-center gap-4">
                         {filteredAndSortedWorkflows.map((workflow) => (
                             <AutomationWorkflowEditorWorkflowsListItem
                                 currentWorkflowId={currentWorkflowId}
                                 key={workflow.workflowUuid}
                                 onWorkflowClick={handleWorkflowClick}
+                                project={selectedProject}
                                 workflow={workflow}
                             />
                         ))}

--- a/client/src/ee/pages/embedded/automation-workflow/components/automation-workflow-editor/components/AutomationWorkflowEditorWorkflowsListItem.tsx
+++ b/client/src/ee/pages/embedded/automation-workflow/components/automation-workflow-editor/components/AutomationWorkflowEditorWorkflowsListItem.tsx
@@ -1,23 +1,35 @@
 import {Tooltip, TooltipContent, TooltipTrigger} from '@/components/ui/tooltip';
+import AutomationWorkflowEditorWorkflowsListItemDropdownMenu from '@/ee/pages/embedded/automation-workflow/components/automation-workflow-editor/components/AutomationWorkflowEditorWorkflowsListItemDropdownMenu';
 import {AutomationWorkflowProjectsQuery} from '@/shared/middleware/graphql';
+import {MouseEvent} from 'react';
 import InlineSVG from 'react-inlinesvg';
 import {twMerge} from 'tailwind-merge';
 
-type AutomationWorkflowProjectWorkflowTemplateType =
-    AutomationWorkflowProjectsQuery['automationWorkflowProjects'][number]['workflowTemplates'][number];
+type AutomationWorkflowProjectType = AutomationWorkflowProjectsQuery['automationWorkflowProjects'][number];
+type AutomationWorkflowProjectWorkflowTemplateType = AutomationWorkflowProjectType['workflowTemplates'][number];
 
 interface AutomationWorkflowEditorWorkflowsListItemProps {
     currentWorkflowId: string;
     onWorkflowClick: (workflowUuid: string) => void;
+    project: AutomationWorkflowProjectType;
     workflow: AutomationWorkflowProjectWorkflowTemplateType;
 }
 
 const AutomationWorkflowEditorWorkflowsListItem = ({
     currentWorkflowId,
     onWorkflowClick,
+    project,
     workflow,
 }: AutomationWorkflowEditorWorkflowsListItemProps) => {
     const editedDate = workflow.lastModifiedDate ? new Date(workflow.lastModifiedDate).toLocaleDateString() : undefined;
+
+    const handleCardClick = (event: MouseEvent<HTMLLIElement>) => {
+        if (!event.currentTarget.contains(event.target as Node)) {
+            return;
+        }
+
+        onWorkflowClick(workflow.workflowUuid);
+    };
 
     return (
         <li
@@ -25,42 +37,50 @@ const AutomationWorkflowEditorWorkflowsListItem = ({
                 'w-80 cursor-pointer self-start rounded-md border border-transparent p-3 hover:bg-background',
                 workflow.workflowUuid === currentWorkflowId && 'border-stroke-brand-primary bg-background'
             )}
-            onClick={() => onWorkflowClick(workflow.workflowUuid)}
+            onClick={handleCardClick}
         >
-            <div className="flex flex-col gap-3 overflow-hidden">
-                {(workflow.triggers.length > 0 || workflow.components.length > 0) && (
-                    <div className="flex flex-wrap gap-2">
-                        {[...workflow.triggers, ...workflow.components].map((item, index) => (
-                            <div
-                                className="flex shrink-0 items-center justify-center rounded-full border bg-background p-1"
-                                key={`${index}-${item.name}`}
-                                title={item.title ?? item.name}
-                            >
-                                {item.icon && <InlineSVG className="size-5 flex-none" src={item.icon} />}
-                            </div>
-                        ))}
-                    </div>
-                )}
-
-                <Tooltip>
-                    <TooltipTrigger asChild>
-                        <div className="flex flex-col gap-1 text-start">
-                            <span className="truncate overflow-hidden text-sm font-medium">{workflow.label}</span>
-
-                            {editedDate && (
-                                <div className="flex gap-1 text-xs text-content-neutral-secondary">
-                                    <span>Edited</span>
-
-                                    <span>{editedDate}</span>
+            <div className="flex items-center justify-between gap-2">
+                <div className="flex min-w-0 flex-col gap-3 overflow-hidden">
+                    {(workflow.triggers.length > 0 || workflow.components.length > 0) && (
+                        <div className="flex flex-wrap gap-2">
+                            {[...workflow.triggers, ...workflow.components].map((item, index) => (
+                                <div
+                                    className="flex shrink-0 items-center justify-center rounded-full border bg-background p-1"
+                                    key={`${index}-${item.name}`}
+                                    title={item.title ?? item.name}
+                                >
+                                    {item.icon && <InlineSVG className="size-5 flex-none" src={item.icon} />}
                                 </div>
-                            )}
+                            ))}
                         </div>
-                    </TooltipTrigger>
-
-                    {workflow.label && workflow.label.length > 40 && (
-                        <TooltipContent className="max-w-96">{workflow.label}</TooltipContent>
                     )}
-                </Tooltip>
+
+                    <Tooltip>
+                        <TooltipTrigger asChild>
+                            <div className="flex flex-col gap-1 text-start">
+                                <span className="truncate overflow-hidden text-sm font-medium">{workflow.label}</span>
+
+                                {editedDate && (
+                                    <div className="flex gap-1 text-xs text-content-neutral-secondary">
+                                        <span>Edited</span>
+
+                                        <span>{editedDate}</span>
+                                    </div>
+                                )}
+                            </div>
+                        </TooltipTrigger>
+
+                        {workflow.label && workflow.label.length > 40 && (
+                            <TooltipContent className="max-w-96">{workflow.label}</TooltipContent>
+                        )}
+                    </Tooltip>
+                </div>
+
+                <AutomationWorkflowEditorWorkflowsListItemDropdownMenu
+                    currentWorkflowId={currentWorkflowId}
+                    project={project}
+                    workflow={workflow}
+                />
             </div>
         </li>
     );

--- a/client/src/ee/pages/embedded/automation-workflow/components/automation-workflow-editor/components/AutomationWorkflowEditorWorkflowsListItem.tsx
+++ b/client/src/ee/pages/embedded/automation-workflow/components/automation-workflow-editor/components/AutomationWorkflowEditorWorkflowsListItem.tsx
@@ -1,8 +1,9 @@
 import {Tooltip, TooltipContent, TooltipTrigger} from '@/components/ui/tooltip';
 import AutomationWorkflowEditorWorkflowsListItemDropdownMenu from '@/ee/pages/embedded/automation-workflow/components/automation-workflow-editor/components/AutomationWorkflowEditorWorkflowsListItemDropdownMenu';
+import {WorkflowComponentIconDefinitionType} from '@/pages/automation/project/components/projects-sidebar/components/WorkflowComponentsIcon';
+import WorkflowComponentsList from '@/shared/components/WorkflowComponentsList';
 import {AutomationWorkflowProjectsQuery} from '@/shared/middleware/graphql';
-import {MouseEvent} from 'react';
-import InlineSVG from 'react-inlinesvg';
+import {MouseEvent, useMemo} from 'react';
 import {twMerge} from 'tailwind-merge';
 
 type AutomationWorkflowProjectType = AutomationWorkflowProjectsQuery['automationWorkflowProjects'][number];
@@ -31,6 +32,27 @@ const AutomationWorkflowEditorWorkflowsListItem = ({
         onWorkflowClick(workflow.workflowUuid);
     };
 
+    const {filteredComponentNames, workflowComponentDefinitions} = useMemo(() => {
+        const componentNames: string[] = [];
+        const componentDefinitions: Record<string, WorkflowComponentIconDefinitionType | undefined> = {};
+
+        [...workflow.triggers, ...workflow.components].forEach((workflowComponent) => {
+            if (componentDefinitions[workflowComponent.name]) {
+                return;
+            }
+
+            componentNames.push(workflowComponent.name);
+
+            componentDefinitions[workflowComponent.name] = {
+                icon: workflowComponent.icon ?? undefined,
+                name: workflowComponent.name,
+                title: workflowComponent.title ?? undefined,
+            };
+        });
+
+        return {filteredComponentNames: componentNames, workflowComponentDefinitions: componentDefinitions};
+    }, [workflow.components, workflow.triggers]);
+
     return (
         <li
             className={twMerge(
@@ -41,19 +63,11 @@ const AutomationWorkflowEditorWorkflowsListItem = ({
         >
             <div className="flex items-center justify-between gap-2">
                 <div className="flex min-w-0 flex-col gap-3 overflow-hidden">
-                    {(workflow.triggers.length > 0 || workflow.components.length > 0) && (
-                        <div className="flex flex-wrap gap-2">
-                            {[...workflow.triggers, ...workflow.components].map((item, index) => (
-                                <div
-                                    className="flex shrink-0 items-center justify-center rounded-full border bg-background p-1"
-                                    key={`${index}-${item.name}`}
-                                    title={item.title ?? item.name}
-                                >
-                                    {item.icon && <InlineSVG className="size-5 flex-none" src={item.icon} />}
-                                </div>
-                            ))}
-                        </div>
-                    )}
+                    <WorkflowComponentsList
+                        filteredComponentNames={filteredComponentNames}
+                        workflowComponentDefinitions={workflowComponentDefinitions}
+                        workflowTaskDispatcherDefinitions={{}}
+                    />
 
                     <Tooltip>
                         <TooltipTrigger asChild>

--- a/client/src/ee/pages/embedded/automation-workflow/components/automation-workflow-editor/components/AutomationWorkflowEditorWorkflowsListItemDropdownMenu.tsx
+++ b/client/src/ee/pages/embedded/automation-workflow/components/automation-workflow-editor/components/AutomationWorkflowEditorWorkflowsListItemDropdownMenu.tsx
@@ -1,0 +1,122 @@
+import {DropdownMenuItem} from '@/components/ui/dropdown-menu';
+import AutomationWorkflowDialog, {
+    AutomationWorkflowFormValuesI,
+} from '@/ee/pages/embedded/automation-workflows/components/automation-workflow-dialog/AutomationWorkflowDialog';
+import WorkflowListItemDropdownMenu from '@/shared/components/workflow/WorkflowListItemDropdownMenu';
+import {
+    AutomationWorkflowProjectsQuery,
+    useDeleteAutomationWorkflowProjectWorkflowMutation,
+    useDuplicateAutomationWorkflowProjectWorkflowMutation,
+    useUpdateAutomationWorkflowProjectWorkflowMutation,
+} from '@/shared/middleware/graphql';
+
+import '@/shared/styles/dropdownMenu.css';
+import {useQueryClient} from '@tanstack/react-query';
+import {CopyIcon} from 'lucide-react';
+import {useState} from 'react';
+import {useNavigate} from 'react-router-dom';
+
+type AutomationWorkflowProjectType = AutomationWorkflowProjectsQuery['automationWorkflowProjects'][number];
+type AutomationWorkflowProjectWorkflowTemplateType = AutomationWorkflowProjectType['workflowTemplates'][number];
+
+interface AutomationWorkflowEditorWorkflowsListItemDropdownMenuProps {
+    currentWorkflowId: string;
+    project: AutomationWorkflowProjectType;
+    workflow: AutomationWorkflowProjectWorkflowTemplateType;
+}
+
+const AutomationWorkflowEditorWorkflowsListItemDropdownMenu = ({
+    currentWorkflowId,
+    project,
+    workflow,
+}: AutomationWorkflowEditorWorkflowsListItemDropdownMenuProps) => {
+    const [showEditWorkflowDialog, setShowEditWorkflowDialog] = useState(false);
+
+    const navigate = useNavigate();
+
+    const queryClient = useQueryClient();
+
+    const deleteWorkflowMutation = useDeleteAutomationWorkflowProjectWorkflowMutation();
+    const duplicateWorkflowMutation = useDuplicateAutomationWorkflowProjectWorkflowMutation();
+    const updateWorkflowMutation = useUpdateAutomationWorkflowProjectWorkflowMutation();
+
+    const invalidateProjects = () => {
+        queryClient.invalidateQueries({queryKey: ['automationWorkflowProjects']});
+    };
+
+    const handleDeleteWorkflowClick = () => {
+        deleteWorkflowMutation.mutate(
+            {workflowUuid: workflow.workflowUuid},
+            {
+                onSuccess: () => {
+                    invalidateProjects();
+
+                    if (workflow.workflowUuid !== currentWorkflowId) {
+                        return;
+                    }
+
+                    const firstRemainingWorkflow = project.workflowTemplates.find(
+                        (workflowTemplate) => workflowTemplate.workflowUuid !== workflow.workflowUuid
+                    );
+
+                    if (firstRemainingWorkflow) {
+                        navigate(`/embedded/automation-workflows/${firstRemainingWorkflow.workflowUuid}/editor`);
+                    } else {
+                        navigate('/embedded/automation-workflows');
+                    }
+                },
+            }
+        );
+    };
+
+    const handleDuplicateWorkflowClick = () => {
+        duplicateWorkflowMutation.mutate(
+            {workflowUuid: workflow.workflowUuid},
+            {
+                onSuccess: () => {
+                    invalidateProjects();
+                },
+            }
+        );
+    };
+
+    const handleEditWorkflowSubmit = (values: AutomationWorkflowFormValuesI) => {
+        updateWorkflowMutation.mutate(
+            {
+                description: values.description || undefined,
+                label: values.label,
+                workflowUuid: workflow.workflowUuid,
+            },
+            {
+                onSuccess: () => {
+                    invalidateProjects();
+
+                    setShowEditWorkflowDialog(false);
+                },
+            }
+        );
+    };
+
+    return (
+        <WorkflowListItemDropdownMenu
+            dialogs={
+                showEditWorkflowDialog && (
+                    <AutomationWorkflowDialog
+                        onClose={() => setShowEditWorkflowDialog(false)}
+                        onSubmit={handleEditWorkflowSubmit}
+                        workflow={{description: workflow.description, label: workflow.label}}
+                    />
+                )
+            }
+            onDelete={handleDeleteWorkflowClick}
+            onEditClick={() => setShowEditWorkflowDialog(true)}
+            workflowLabel={workflow.label ?? workflow.workflowUuid}
+        >
+            <DropdownMenuItem className="dropdown-menu-item" onClick={handleDuplicateWorkflowClick}>
+                <CopyIcon /> Duplicate
+            </DropdownMenuItem>
+        </WorkflowListItemDropdownMenu>
+    );
+};
+
+export default AutomationWorkflowEditorWorkflowsListItemDropdownMenu;

--- a/client/src/ee/pages/embedded/automation-workflow/components/automation-workflow-editor/components/tests/AutomationWorkflowEditorWorkflowsListItem.test.tsx
+++ b/client/src/ee/pages/embedded/automation-workflow/components/automation-workflow-editor/components/tests/AutomationWorkflowEditorWorkflowsListItem.test.tsx
@@ -1,6 +1,7 @@
 import {TooltipProvider} from '@/components/ui/tooltip';
 import AutomationWorkflowEditorWorkflowsListItem from '@/ee/pages/embedded/automation-workflow/components/automation-workflow-editor/components/AutomationWorkflowEditorWorkflowsListItem';
-import {fireEvent, render, screen} from '@testing-library/react';
+import {fireEvent, render, screen} from '@/shared/util/test-utils';
+import {MemoryRouter} from 'react-router-dom';
 import {describe, expect, it, vi} from 'vitest';
 
 const workflow = {
@@ -18,18 +19,33 @@ const workflow = {
     workflowUuid: 'wf-1',
 };
 
+const project = {
+    categoryId: null,
+    description: null,
+    id: 'project-1',
+    lastPublishedVersion: null,
+    name: 'Project One',
+    published: false,
+    tagIds: [],
+    version: 1,
+    workflowTemplates: [workflow],
+};
+
 describe('AutomationWorkflowEditorWorkflowsListItem', () => {
     it('renders the workflow label, the edited date, and a component icon', () => {
         render(
-            <TooltipProvider>
-                <ul>
-                    <AutomationWorkflowEditorWorkflowsListItem
-                        currentWorkflowId="wf-other"
-                        onWorkflowClick={vi.fn()}
-                        workflow={workflow}
-                    />
-                </ul>
-            </TooltipProvider>
+            <MemoryRouter>
+                <TooltipProvider>
+                    <ul>
+                        <AutomationWorkflowEditorWorkflowsListItem
+                            currentWorkflowId="wf-other"
+                            onWorkflowClick={vi.fn()}
+                            project={project}
+                            workflow={workflow}
+                        />
+                    </ul>
+                </TooltipProvider>
+            </MemoryRouter>
         );
 
         expect(screen.getByText('Mailer')).toBeInTheDocument();
@@ -40,15 +56,18 @@ describe('AutomationWorkflowEditorWorkflowsListItem', () => {
 
     it('marks the card as current when the ids match', () => {
         const {container} = render(
-            <TooltipProvider>
-                <ul>
-                    <AutomationWorkflowEditorWorkflowsListItem
-                        currentWorkflowId="wf-1"
-                        onWorkflowClick={vi.fn()}
-                        workflow={workflow}
-                    />
-                </ul>
-            </TooltipProvider>
+            <MemoryRouter>
+                <TooltipProvider>
+                    <ul>
+                        <AutomationWorkflowEditorWorkflowsListItem
+                            currentWorkflowId="wf-1"
+                            onWorkflowClick={vi.fn()}
+                            project={project}
+                            workflow={workflow}
+                        />
+                    </ul>
+                </TooltipProvider>
+            </MemoryRouter>
         );
 
         expect(container.querySelector('li')).toHaveClass('border-stroke-brand-primary');
@@ -58,15 +77,18 @@ describe('AutomationWorkflowEditorWorkflowsListItem', () => {
         const onWorkflowClick = vi.fn();
 
         const {container} = render(
-            <TooltipProvider>
-                <ul>
-                    <AutomationWorkflowEditorWorkflowsListItem
-                        currentWorkflowId="wf-other"
-                        onWorkflowClick={onWorkflowClick}
-                        workflow={workflow}
-                    />
-                </ul>
-            </TooltipProvider>
+            <MemoryRouter>
+                <TooltipProvider>
+                    <ul>
+                        <AutomationWorkflowEditorWorkflowsListItem
+                            currentWorkflowId="wf-other"
+                            onWorkflowClick={onWorkflowClick}
+                            project={project}
+                            workflow={workflow}
+                        />
+                    </ul>
+                </TooltipProvider>
+            </MemoryRouter>
         );
 
         fireEvent.click(container.querySelector('li')!);

--- a/client/src/ee/pages/embedded/automation-workflow/components/automation-workflow-editor/components/tests/AutomationWorkflowEditorWorkflowsListItem.test.tsx
+++ b/client/src/ee/pages/embedded/automation-workflow/components/automation-workflow-editor/components/tests/AutomationWorkflowEditorWorkflowsListItem.test.tsx
@@ -51,7 +51,7 @@ describe('AutomationWorkflowEditorWorkflowsListItem', () => {
         expect(screen.getByText('Mailer')).toBeInTheDocument();
         expect(screen.getByText(/Edited/)).toBeInTheDocument();
         expect(screen.getByText(new Date('2026-02-11T09:30:00Z').toLocaleDateString())).toBeInTheDocument();
-        expect(screen.getByTitle('Gmail')).toBeInTheDocument();
+        expect(screen.getAllByLabelText('Workflow component icon')).toHaveLength(1);
     });
 
     it('marks the card as current when the ids match', () => {

--- a/client/src/ee/pages/embedded/automation-workflow/components/automation-workflow-editor/components/tests/AutomationWorkflowEditorWorkflowsListItemDropdownMenu.test.tsx
+++ b/client/src/ee/pages/embedded/automation-workflow/components/automation-workflow-editor/components/tests/AutomationWorkflowEditorWorkflowsListItemDropdownMenu.test.tsx
@@ -1,0 +1,194 @@
+import AutomationWorkflowEditorWorkflowsListItemDropdownMenu from '@/ee/pages/embedded/automation-workflow/components/automation-workflow-editor/components/AutomationWorkflowEditorWorkflowsListItemDropdownMenu';
+import {render, resetAll, screen, userEvent, windowResizeObserver} from '@/shared/util/test-utils';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+
+const hoisted = vi.hoisted(() => ({
+    deleteMutate: vi.fn(),
+    duplicateMutate: vi.fn(),
+    navigate: vi.fn(),
+    updateMutate: vi.fn(),
+}));
+
+vi.mock('react-router-dom', () => ({
+    useNavigate: () => hoisted.navigate,
+}));
+
+vi.mock('@/shared/middleware/graphql', () => ({
+    useDeleteAutomationWorkflowProjectWorkflowMutation: () => ({
+        mutate: (variables: unknown, options?: {onSuccess?: () => void}) => {
+            hoisted.deleteMutate(variables);
+
+            options?.onSuccess?.();
+        },
+    }),
+    useDuplicateAutomationWorkflowProjectWorkflowMutation: () => ({
+        mutate: (variables: unknown, options?: {onSuccess?: () => void}) => {
+            hoisted.duplicateMutate(variables);
+
+            options?.onSuccess?.();
+        },
+    }),
+    useUpdateAutomationWorkflowProjectWorkflowMutation: () => ({
+        mutate: (variables: unknown, options?: {onSuccess?: () => void}) => {
+            hoisted.updateMutate(variables);
+
+            options?.onSuccess?.();
+        },
+    }),
+}));
+
+vi.mock(
+    '@/ee/pages/embedded/automation-workflows/components/automation-workflow-dialog/AutomationWorkflowDialog',
+    () => ({
+        default: ({
+            onClose,
+            onSubmit,
+        }: {
+            onClose: () => void;
+            onSubmit: (values: {description: string; label: string}) => void;
+        }) => (
+            <div>
+                <span>Automation workflow dialog</span>
+
+                <button onClick={() => onSubmit({description: 'Renamed description', label: 'Renamed'})} type="button">
+                    Submit workflow
+                </button>
+
+                <button onClick={onClose} type="button">
+                    Close workflow dialog
+                </button>
+            </div>
+        ),
+    })
+);
+
+const workflow = {
+    components: [],
+    description: 'Sends mail',
+    label: 'Workflow One',
+    lastModifiedDate: '2026-02-11T09:30:00Z',
+    triggers: [],
+    workflowUuid: 'uuid-1',
+};
+
+const project = {
+    categoryId: null,
+    description: null,
+    id: 'project-1',
+    lastPublishedVersion: null,
+    name: 'Project One',
+    published: false,
+    tagIds: [],
+    version: 1,
+    workflowTemplates: [workflow, {...workflow, label: 'Workflow Two', workflowUuid: 'uuid-2'}],
+};
+
+const renderMenu = (currentWorkflowId = 'uuid-other', projectOverrides = {}) =>
+    render(
+        <AutomationWorkflowEditorWorkflowsListItemDropdownMenu
+            currentWorkflowId={currentWorkflowId}
+            project={{...project, ...projectOverrides}}
+            workflow={workflow}
+        />
+    );
+
+const openMenu = async () => {
+    await userEvent.click(screen.getByRole('button', {name: 'Workflow actions for Workflow One'}));
+};
+
+beforeEach(() => {
+    windowResizeObserver();
+});
+
+afterEach(() => {
+    resetAll();
+    vi.clearAllMocks();
+});
+
+describe('AutomationWorkflowEditorWorkflowsListItemDropdownMenu', () => {
+    it('offers Edit, Duplicate and Delete', async () => {
+        renderMenu();
+
+        await openMenu();
+
+        expect(screen.getAllByRole('menuitem').map((menuItem) => menuItem.textContent?.trim())).toEqual([
+            'Edit',
+            'Duplicate',
+            'Delete',
+        ]);
+    });
+
+    it('duplicates by workflow uuid', async () => {
+        renderMenu();
+
+        await openMenu();
+        await userEvent.click(screen.getByRole('menuitem', {name: 'Duplicate'}));
+
+        expect(hoisted.duplicateMutate).toHaveBeenCalledWith({workflowUuid: 'uuid-1'});
+    });
+
+    it('opens the edit dialog from Edit', async () => {
+        renderMenu();
+
+        await openMenu();
+        await userEvent.click(screen.getByRole('menuitem', {name: 'Edit'}));
+
+        expect(screen.getByText('Automation workflow dialog')).toBeInTheDocument();
+    });
+
+    it('renames the workflow and closes the dialog', async () => {
+        renderMenu();
+
+        await openMenu();
+        await userEvent.click(screen.getByRole('menuitem', {name: 'Edit'}));
+        await userEvent.click(screen.getByRole('button', {name: 'Submit workflow'}));
+
+        expect(hoisted.updateMutate).toHaveBeenCalledWith({
+            description: 'Renamed description',
+            label: 'Renamed',
+            workflowUuid: 'uuid-1',
+        });
+        expect(screen.queryByText('Automation workflow dialog')).not.toBeInTheDocument();
+    });
+
+    it('closes the edit dialog when it is dismissed', async () => {
+        renderMenu();
+
+        await openMenu();
+        await userEvent.click(screen.getByRole('menuitem', {name: 'Edit'}));
+        await userEvent.click(screen.getByRole('button', {name: 'Close workflow dialog'}));
+
+        expect(screen.queryByText('Automation workflow dialog')).not.toBeInTheDocument();
+    });
+
+    it('returns to the workflow list when the last workflow is deleted', async () => {
+        renderMenu('uuid-1', {workflowTemplates: [workflow]});
+
+        await openMenu();
+        await userEvent.click(screen.getByRole('menuitem', {name: 'Delete'}));
+        await userEvent.click(screen.getByRole('button', {name: 'Delete'}));
+
+        expect(hoisted.navigate).toHaveBeenCalledWith('/embedded/automation-workflows');
+    });
+
+    it('navigates to the first remaining workflow when the open one is deleted', async () => {
+        renderMenu('uuid-1');
+
+        await openMenu();
+        await userEvent.click(screen.getByRole('menuitem', {name: 'Delete'}));
+        await userEvent.click(screen.getByRole('button', {name: 'Delete'}));
+
+        expect(hoisted.deleteMutate).toHaveBeenCalledWith({workflowUuid: 'uuid-1'});
+        expect(hoisted.navigate).toHaveBeenCalledWith('/embedded/automation-workflows/uuid-2/editor');
+    });
+
+    it('stays put when a workflow other than the open one is deleted', async () => {
+        renderMenu('uuid-other');
+
+        await openMenu();
+        await userEvent.click(screen.getByRole('menuitem', {name: 'Delete'}));
+        await userEvent.click(screen.getByRole('button', {name: 'Delete'}));
+
+        expect(hoisted.navigate).not.toHaveBeenCalled();
+    });
+});

--- a/client/src/ee/pages/embedded/automation-workflow/tests/AutomationWorkflow.test.tsx
+++ b/client/src/ee/pages/embedded/automation-workflow/tests/AutomationWorkflow.test.tsx
@@ -70,6 +70,7 @@ vi.mock('@/shared/middleware/graphql', () => ({
     useDuplicateAutomationWorkflowProjectWorkflowMutation: () => ({isPending: false, mutate: vi.fn()}),
     usePublishAutomationWorkflowProjectMutation: () => ({isPending: false, mutate: hoisted.publishMutationMock}),
     useUpdateAutomationWorkflowProjectMutation: () => ({isPending: false, mutate: vi.fn()}),
+    useUpdateAutomationWorkflowProjectWorkflowMutation: () => ({isPending: false, mutate: vi.fn()}),
 }));
 
 vi.mock('@/shared/queries/automation/workflows.queries', () => ({

--- a/client/src/ee/pages/embedded/automation-workflows/AutomationWorkflows.tsx
+++ b/client/src/ee/pages/embedded/automation-workflows/AutomationWorkflows.tsx
@@ -36,6 +36,7 @@ type AutomationWorkflowProjectType = AutomationWorkflowProjectsQuery['automation
 
 const AutomationWorkflows = () => {
     const [editProject, setEditProject] = useState<AutomationWorkflowProjectType | undefined>();
+    const [newlyCreatedProjectId, setNewlyCreatedProjectId] = useState<string | undefined>();
     const [pendingWorkflowProjectId, setPendingWorkflowProjectId] = useState<string | null>(null);
     const [showProjectDialog, setShowProjectDialog] = useState(false);
     const [showWorkflowDialog, setShowWorkflowDialog] = useState(false);
@@ -134,7 +135,9 @@ const AutomationWorkflows = () => {
                     tags: values.tags,
                 },
                 {
-                    onSuccess: () => {
+                    onSuccess: (data) => {
+                        setNewlyCreatedProjectId(data.createAutomationWorkflowProject);
+
                         invalidateProjects();
 
                         closeProjectDialog();
@@ -283,6 +286,7 @@ const AutomationWorkflows = () => {
             <PageLoader errors={[projectsError]} loading={projectsIsLoading}>
                 {filteredProjects.length > 0 ? (
                     <AutomationWorkflowProjectList
+                        newlyCreatedProjectId={newlyCreatedProjectId}
                         onCreateWorkflow={handleCreateWorkflow}
                         onDeleteProject={handleDeleteProject}
                         onDeleteWorkflow={handleDeleteWorkflow}

--- a/client/src/ee/pages/embedded/automation-workflows/components/automation-workflow-project-list/AutomationWorkflowProjectList.tsx
+++ b/client/src/ee/pages/embedded/automation-workflows/components/automation-workflow-project-list/AutomationWorkflowProjectList.tsx
@@ -1,6 +1,6 @@
 import {Collapsible, CollapsibleContent} from '@/components/ui/collapsible';
 import {AutomationWorkflowProjectTagsQuery, AutomationWorkflowProjectsQuery} from '@/shared/middleware/graphql';
-import {useState} from 'react';
+import {useEffect, useState} from 'react';
 
 import AutomationWorkflowProjectListItem from './AutomationWorkflowProjectListItem';
 import AutomationWorkflowProjectWorkflowList from './AutomationWorkflowProjectWorkflowList';
@@ -9,6 +9,7 @@ type AutomationWorkflowProjectType = AutomationWorkflowProjectsQuery['automation
 type EmbeddedTagType = AutomationWorkflowProjectTagsQuery['automationWorkflowProjectTags'][number];
 
 interface AutomationWorkflowProjectListProps {
+    newlyCreatedProjectId?: string;
     onCreateWorkflow: (projectId: string) => void;
     onDeleteProject: (projectId: string) => void;
     onDeleteWorkflow: (workflowUuid: string) => void;
@@ -22,6 +23,7 @@ interface AutomationWorkflowProjectListProps {
 }
 
 const AutomationWorkflowProjectList = ({
+    newlyCreatedProjectId,
     onCreateWorkflow,
     onDeleteProject,
     onDeleteWorkflow,
@@ -34,6 +36,18 @@ const AutomationWorkflowProjectList = ({
     tags,
 }: AutomationWorkflowProjectListProps) => {
     const [openProjectIds, setOpenProjectIds] = useState<Set<string>>(new Set());
+
+    useEffect(() => {
+        if (newlyCreatedProjectId) {
+            setOpenProjectIds((previousOpenProjectIds) => {
+                const nextOpenProjectIds = new Set(previousOpenProjectIds);
+
+                nextOpenProjectIds.add(newlyCreatedProjectId);
+
+                return nextOpenProjectIds;
+            });
+        }
+    }, [newlyCreatedProjectId]);
 
     return (
         <div className="w-full px-4 3xl:mx-auto 3xl:w-4/5">

--- a/client/src/ee/pages/embedded/integration/Integration.tsx
+++ b/client/src/ee/pages/embedded/integration/Integration.tsx
@@ -119,13 +119,11 @@ const Integration = () => {
                         <ResizableHandle className="bg-muted" />
 
                         <ResizablePanel className="bg-background" defaultSize={0} panelRef={bottomResizablePanelRef}>
-                            {(workflowIsRunning || workflowTestExecution) && (
-                                <WorkflowExecutionsTestOutput
-                                    onCloseClick={handleWorkflowExecutionsTestOutputCloseClick}
-                                    workflowIsRunning={workflowIsRunning}
-                                    workflowTestExecution={workflowTestExecution}
-                                />
-                            )}
+                            <WorkflowExecutionsTestOutput
+                                onCloseClick={handleWorkflowExecutionsTestOutputCloseClick}
+                                workflowIsRunning={workflowIsRunning}
+                                workflowTestExecution={workflowTestExecution}
+                            />
                         </ResizablePanel>
                     </ResizablePanelGroup>
                 </div>

--- a/client/src/ee/pages/embedded/integration/components/integrations-sidebar/IntegrationsLeftSidebar.tsx
+++ b/client/src/ee/pages/embedded/integration/components/integrations-sidebar/IntegrationsLeftSidebar.tsx
@@ -86,6 +86,8 @@ const IntegrationsLeftSidebar = ({
 
     const findIntegrationIdByWorkflow = getWorkflowsIntegrationId(integrations || []);
 
+    const selectedIntegration = integrations?.find((integration) => integration.id === selectedIntegrationId);
+
     const filteredWorkflowsList = useMemo(
         () => getFilteredWorkflows(workflows, sortBy, searchValue),
         [workflows, sortBy, searchValue, getFilteredWorkflows]
@@ -198,6 +200,7 @@ const IntegrationsLeftSidebar = ({
                                     calculateTimeDifference={calculateTimeDifference}
                                     currentWorkflowId={currentWorkflowId}
                                     findIntegrationIdByWorkflow={findIntegrationIdByWorkflow}
+                                    integration={selectedIntegration}
                                     key={workflow.id}
                                     onIntegrationClick={onIntegrationClick}
                                     setSelectedIntegrationId={setSelectedIntegrationId}

--- a/client/src/ee/pages/embedded/integration/components/integrations-sidebar/components/IntegrationWorkflowsList.tsx
+++ b/client/src/ee/pages/embedded/integration/components/integrations-sidebar/components/IntegrationWorkflowsList.tsx
@@ -77,6 +77,7 @@ const IntegrationWorkflowsList = ({
                             calculateTimeDifference={calculateTimeDifference}
                             currentWorkflowId={currentWorkflowId}
                             findIntegrationIdByWorkflow={findIntegrationIdByWorkflow}
+                            integration={integration}
                             key={workflow.id}
                             onIntegrationClick={onIntegrationClick}
                             setSelectedIntegrationId={setSelectedIntegrationId}

--- a/client/src/ee/pages/embedded/integration/components/integrations-sidebar/components/IntegrationWorkflowsListItem.tsx
+++ b/client/src/ee/pages/embedded/integration/components/integrations-sidebar/components/IntegrationWorkflowsListItem.tsx
@@ -1,9 +1,10 @@
 import {Tooltip, TooltipContent, TooltipTrigger} from '@/components/ui/tooltip';
-import {Workflow} from '@/ee/shared/middleware/embedded/configuration';
+import IntegrationWorkflowsListItemDropdownMenu from '@/ee/pages/embedded/integration/components/integrations-sidebar/components/IntegrationWorkflowsListItemDropdownMenu';
+import {Integration, Workflow} from '@/ee/shared/middleware/embedded/configuration';
 import useWorkflowDataStore from '@/pages/platform/workflow-editor/stores/useWorkflowDataStore';
 import WorkflowComponentsList from '@/shared/components/WorkflowComponentsList';
 import {ComponentDefinitionBasic} from '@/shared/middleware/platform/configuration';
-import {useMemo} from 'react';
+import {MouseEvent, useMemo} from 'react';
 import {twMerge} from 'tailwind-merge';
 import {useShallow} from 'zustand/react/shallow';
 
@@ -11,6 +12,7 @@ interface IntegrationWorkflowsListItemProps {
     calculateTimeDifference: (date: string) => string;
     currentWorkflowId: string;
     findIntegrationIdByWorkflow: (workflow: Workflow) => number;
+    integration?: Integration;
     onIntegrationClick: (integrationId: number, integrationWorkflowId: number) => void;
     setSelectedIntegrationId: (integrationId: number) => void;
     workflow: Workflow;
@@ -20,6 +22,7 @@ const IntegrationWorkflowsListItem = ({
     calculateTimeDifference,
     currentWorkflowId,
     findIntegrationIdByWorkflow,
+    integration,
     onIntegrationClick,
     setSelectedIntegrationId,
     workflow,
@@ -63,7 +66,11 @@ const IntegrationWorkflowsListItem = ({
         [calculateTimeDifference, workflow?.lastModifiedDate]
     );
 
-    const handleSelectWorkflowClick = () => {
+    const handleCardClick = (event: MouseEvent<HTMLLIElement>) => {
+        if (!event.currentTarget.contains(event.target as Node)) {
+            return;
+        }
+
         onIntegrationClick(integrationId, integrationWorkflowId);
 
         setSelectedIntegrationId(integrationId);
@@ -76,32 +83,42 @@ const IntegrationWorkflowsListItem = ({
                 workflow.id === currentWorkflowId && 'border-stroke-brand-primary bg-background'
             )}
             key={workflow.id}
-            onClick={() => handleSelectWorkflowClick()}
+            onClick={handleCardClick}
         >
-            <div className="flex flex-col gap-3 overflow-hidden">
-                <WorkflowComponentsList
-                    filteredComponentNames={filteredComponentNames}
-                    workflowComponentDefinitions={workflowComponentDefinitions}
-                    workflowTaskDispatcherDefinitions={workflowTaskDispatcherDefinitions}
-                />
+            <div className="flex items-center justify-between gap-2">
+                <div className="flex min-w-0 flex-col gap-3 overflow-hidden">
+                    <WorkflowComponentsList
+                        filteredComponentNames={filteredComponentNames}
+                        workflowComponentDefinitions={workflowComponentDefinitions}
+                        workflowTaskDispatcherDefinitions={workflowTaskDispatcherDefinitions}
+                    />
 
-                <Tooltip>
-                    <TooltipTrigger asChild>
-                        <div className="flex flex-col gap-1 text-start">
-                            <span className="truncate overflow-hidden text-sm font-medium">{workflow.label}</span>
+                    <Tooltip>
+                        <TooltipTrigger asChild>
+                            <div className="flex flex-col gap-1 text-start">
+                                <span className="truncate overflow-hidden text-sm font-medium">{workflow.label}</span>
 
-                            <div className="flex gap-1 text-xs text-content-neutral-secondary">
-                                <span>Edited</span>
+                                <div className="flex gap-1 text-xs text-content-neutral-secondary">
+                                    <span>Edited</span>
 
-                                {timeAgo}
+                                    {timeAgo}
+                                </div>
                             </div>
-                        </div>
-                    </TooltipTrigger>
+                        </TooltipTrigger>
 
-                    {workflow.label && workflow.label.length > 40 && (
-                        <TooltipContent className="max-w-96">{workflow.label}</TooltipContent>
-                    )}
-                </Tooltip>
+                        {workflow.label && workflow.label.length > 40 && (
+                            <TooltipContent className="max-w-96">{workflow.label}</TooltipContent>
+                        )}
+                    </Tooltip>
+                </div>
+
+                {integration && (
+                    <IntegrationWorkflowsListItemDropdownMenu
+                        currentWorkflowId={currentWorkflowId}
+                        integration={integration}
+                        workflow={workflow}
+                    />
+                )}
             </div>
         </li>
     );

--- a/client/src/ee/pages/embedded/integration/components/integrations-sidebar/components/IntegrationWorkflowsListItemDropdownMenu.tsx
+++ b/client/src/ee/pages/embedded/integration/components/integrations-sidebar/components/IntegrationWorkflowsListItemDropdownMenu.tsx
@@ -1,0 +1,118 @@
+import {DropdownMenuItem} from '@/components/ui/dropdown-menu';
+import {Integration, Workflow} from '@/ee/shared/middleware/embedded/configuration';
+import {useDeleteWorkflowMutation, useUpdateWorkflowMutation} from '@/ee/shared/mutations/embedded/workflows.mutations';
+import {IntegrationWorkflowKeys} from '@/ee/shared/queries/embedded/integrationWorkflows.queries';
+import {IntegrationKeys} from '@/ee/shared/queries/embedded/integrations.queries';
+import {WorkflowKeys, useGetWorkflowQuery} from '@/ee/shared/queries/embedded/workflows.queries';
+import WorkflowDialog from '@/shared/components/workflow/WorkflowDialog';
+import WorkflowListItemDropdownMenu from '@/shared/components/workflow/WorkflowListItemDropdownMenu';
+
+import '@/shared/styles/dropdownMenu.css';
+import {useQueryClient} from '@tanstack/react-query';
+import {DownloadIcon} from 'lucide-react';
+import {useState} from 'react';
+import {useNavigate, useSearchParams} from 'react-router-dom';
+
+interface IntegrationWorkflowsListItemDropdownMenuProps {
+    currentWorkflowId: string;
+    integration: Integration;
+    workflow: Workflow;
+}
+
+const IntegrationWorkflowsListItemDropdownMenu = ({
+    currentWorkflowId,
+    integration,
+    workflow,
+}: IntegrationWorkflowsListItemDropdownMenuProps) => {
+    const [showEditWorkflowDialog, setShowEditWorkflowDialog] = useState(false);
+
+    const navigate = useNavigate();
+    const [searchParams] = useSearchParams();
+
+    const queryClient = useQueryClient();
+
+    const integrationId = integration.id!;
+
+    const deleteWorkflowMutation = useDeleteWorkflowMutation({
+        onSuccess: () => {
+            const deletedIntegrationWorkflowId = workflow.integrationWorkflowId;
+
+            queryClient.removeQueries({queryKey: WorkflowKeys.workflow(workflow.id!)});
+
+            if (deletedIntegrationWorkflowId) {
+                queryClient.removeQueries({
+                    queryKey: IntegrationWorkflowKeys.integrationWorkflow(integrationId, deletedIntegrationWorkflowId),
+                });
+            }
+
+            queryClient.invalidateQueries({
+                queryKey: IntegrationWorkflowKeys.integrationWorkflows(integrationId),
+            });
+            queryClient.invalidateQueries({queryKey: IntegrationKeys.integrations});
+
+            if (workflow.id !== currentWorkflowId) {
+                return;
+            }
+
+            const firstRemainingIntegrationWorkflowId = integration.integrationWorkflowIds?.find(
+                (integrationWorkflowId) => integrationWorkflowId !== deletedIntegrationWorkflowId
+            );
+
+            if (firstRemainingIntegrationWorkflowId) {
+                navigate(
+                    `/embedded/integrations/${integrationId}/integration-workflows/${firstRemainingIntegrationWorkflowId}?${searchParams}`
+                );
+            } else {
+                navigate('/embedded/integrations');
+            }
+        },
+    });
+
+    const updateWorkflowMutation = useUpdateWorkflowMutation({
+        onSuccess: () => {
+            queryClient.invalidateQueries({
+                queryKey: IntegrationWorkflowKeys.integrationWorkflows(integrationId),
+            });
+            queryClient.invalidateQueries({queryKey: WorkflowKeys.workflow(workflow.id!)});
+
+            setShowEditWorkflowDialog(false);
+        },
+    });
+
+    return (
+        <WorkflowListItemDropdownMenu
+            dialogs={
+                showEditWorkflowDialog && (
+                    <WorkflowDialog
+                        onClose={() => setShowEditWorkflowDialog(false)}
+                        onSave={() => {
+                            if (workflow.integrationWorkflowId) {
+                                queryClient.invalidateQueries({
+                                    queryKey: IntegrationWorkflowKeys.integrationWorkflow(
+                                        integrationId,
+                                        workflow.integrationWorkflowId
+                                    ),
+                                });
+                            }
+                        }}
+                        updateWorkflowMutation={updateWorkflowMutation}
+                        useGetWorkflowQuery={useGetWorkflowQuery}
+                        workflowId={workflow.id!}
+                    />
+                )
+            }
+            onDelete={() => deleteWorkflowMutation.mutate({id: workflow.id!})}
+            onEditClick={() => setShowEditWorkflowDialog(true)}
+            workflowLabel={workflow.label}
+        >
+            <DropdownMenuItem
+                className="dropdown-menu-item"
+                onClick={() => (window.location.href = `/api/embedded/internal/workflows/${workflow.id}/export`)}
+            >
+                <DownloadIcon /> Export
+            </DropdownMenuItem>
+        </WorkflowListItemDropdownMenu>
+    );
+};
+
+export default IntegrationWorkflowsListItemDropdownMenu;

--- a/client/src/ee/pages/embedded/integration/components/integrations-sidebar/components/tests/IntegrationWorkflowsListItemDropdownMenu.test.tsx
+++ b/client/src/ee/pages/embedded/integration/components/integrations-sidebar/components/tests/IntegrationWorkflowsListItemDropdownMenu.test.tsx
@@ -1,0 +1,193 @@
+import IntegrationWorkflowsListItemDropdownMenu from '@/ee/pages/embedded/integration/components/integrations-sidebar/components/IntegrationWorkflowsListItemDropdownMenu';
+import {render, resetAll, screen, userEvent, windowResizeObserver} from '@/shared/util/test-utils';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+
+const hoisted = vi.hoisted(() => ({
+    deleteMutate: vi.fn(),
+    navigate: vi.fn(),
+    updateMutate: vi.fn(),
+}));
+
+vi.mock('react-router-dom', () => ({
+    useNavigate: () => hoisted.navigate,
+    useSearchParams: () => [new URLSearchParams(), vi.fn()],
+}));
+
+vi.mock('@/ee/shared/mutations/embedded/workflows.mutations', () => ({
+    useDeleteWorkflowMutation: (mutationProps?: {onSuccess?: () => void}) => ({
+        mutate: (...args: unknown[]) => {
+            hoisted.deleteMutate(...args);
+
+            mutationProps?.onSuccess?.();
+        },
+    }),
+    useUpdateWorkflowMutation: (mutationProps?: {onSuccess?: () => void}) => ({
+        mutate: (...args: unknown[]) => {
+            hoisted.updateMutate(...args);
+
+            mutationProps?.onSuccess?.();
+        },
+    }),
+}));
+
+vi.mock('@/shared/components/workflow/WorkflowDialog', () => ({
+    default: ({
+        onClose,
+        onSave,
+        updateWorkflowMutation,
+    }: {
+        onClose: () => void;
+        onSave: () => void;
+        updateWorkflowMutation: {mutate: (values: unknown) => void};
+    }) => (
+        <div>
+            <span>Workflow dialog</span>
+
+            <button onClick={onSave} type="button">
+                Save workflow
+            </button>
+
+            <button onClick={() => updateWorkflowMutation.mutate({id: 'workflow-1'})} type="button">
+                Update workflow
+            </button>
+
+            <button onClick={onClose} type="button">
+                Close workflow dialog
+            </button>
+        </div>
+    ),
+}));
+
+const integration = {
+    componentName: 'accelo',
+    id: 100,
+    integrationWorkflowIds: [10, 11],
+    multipleInstances: false,
+    name: 'Integration One',
+};
+
+const workflow = {
+    id: 'workflow-1',
+    integrationWorkflowId: 10,
+    label: 'Workflow One',
+};
+
+const renderMenu = (currentWorkflowId = 'workflow-other', integrationOverrides = {}) =>
+    render(
+        <IntegrationWorkflowsListItemDropdownMenu
+            currentWorkflowId={currentWorkflowId}
+            integration={{...integration, ...integrationOverrides}}
+            workflow={workflow}
+        />
+    );
+
+const openMenu = async () => {
+    await userEvent.click(screen.getByRole('button', {name: 'Workflow actions for Workflow One'}));
+};
+
+beforeEach(() => {
+    windowResizeObserver();
+});
+
+afterEach(() => {
+    resetAll();
+    vi.clearAllMocks();
+});
+
+describe('IntegrationWorkflowsListItemDropdownMenu', () => {
+    it('offers Edit, Export and Delete', async () => {
+        renderMenu();
+
+        await openMenu();
+
+        expect(screen.getAllByRole('menuitem').map((menuItem) => menuItem.textContent?.trim())).toEqual([
+            'Edit',
+            'Export',
+            'Delete',
+        ]);
+    });
+
+    it('opens the edit dialog from Edit', async () => {
+        renderMenu();
+
+        await openMenu();
+        await userEvent.click(screen.getByRole('menuitem', {name: 'Edit'}));
+
+        expect(screen.getByText('Workflow dialog')).toBeInTheDocument();
+    });
+
+    it('deletes the workflow once the confirmation is accepted', async () => {
+        renderMenu();
+
+        await openMenu();
+        await userEvent.click(screen.getByRole('menuitem', {name: 'Delete'}));
+        await userEvent.click(screen.getByRole('button', {name: 'Delete'}));
+
+        expect(hoisted.deleteMutate).toHaveBeenCalledWith({id: 'workflow-1'});
+    });
+
+    it('stays put when a workflow other than the open one is deleted', async () => {
+        renderMenu('workflow-other');
+
+        await openMenu();
+        await userEvent.click(screen.getByRole('menuitem', {name: 'Delete'}));
+        await userEvent.click(screen.getByRole('button', {name: 'Delete'}));
+
+        expect(hoisted.navigate).not.toHaveBeenCalled();
+    });
+
+    it('exports through the embedded endpoint', async () => {
+        const location = {href: ''};
+
+        Object.defineProperty(window, 'location', {configurable: true, value: location, writable: true});
+
+        renderMenu();
+
+        await openMenu();
+        await userEvent.click(screen.getByRole('menuitem', {name: 'Export'}));
+
+        expect(location.href).toBe('/api/embedded/internal/workflows/workflow-1/export');
+    });
+
+    it('closes the edit dialog once the workflow is updated', async () => {
+        renderMenu();
+
+        await openMenu();
+        await userEvent.click(screen.getByRole('menuitem', {name: 'Edit'}));
+        await userEvent.click(screen.getByRole('button', {name: 'Save workflow'}));
+        await userEvent.click(screen.getByRole('button', {name: 'Update workflow'}));
+
+        expect(hoisted.updateMutate).toHaveBeenCalledWith({id: 'workflow-1'});
+        expect(screen.queryByText('Workflow dialog')).not.toBeInTheDocument();
+    });
+
+    it('closes the edit dialog when it is dismissed', async () => {
+        renderMenu();
+
+        await openMenu();
+        await userEvent.click(screen.getByRole('menuitem', {name: 'Edit'}));
+        await userEvent.click(screen.getByRole('button', {name: 'Close workflow dialog'}));
+
+        expect(screen.queryByText('Workflow dialog')).not.toBeInTheDocument();
+    });
+
+    it('returns to the integration list when the last workflow is deleted', async () => {
+        renderMenu('workflow-1', {integrationWorkflowIds: [10]});
+
+        await openMenu();
+        await userEvent.click(screen.getByRole('menuitem', {name: 'Delete'}));
+        await userEvent.click(screen.getByRole('button', {name: 'Delete'}));
+
+        expect(hoisted.navigate).toHaveBeenCalledWith('/embedded/integrations');
+    });
+
+    it('navigates to the first remaining workflow when the open one is deleted', async () => {
+        renderMenu('workflow-1');
+
+        await openMenu();
+        await userEvent.click(screen.getByRole('menuitem', {name: 'Delete'}));
+        await userEvent.click(screen.getByRole('button', {name: 'Delete'}));
+
+        expect(hoisted.navigate).toHaveBeenCalledWith('/embedded/integrations/100/integration-workflows/11?');
+    });
+});

--- a/client/src/ee/pages/embedded/integrations/Integrations.tsx
+++ b/client/src/ee/pages/embedded/integrations/Integrations.tsx
@@ -15,6 +15,7 @@ import LayoutContainer from '@/shared/layout/LayoutContainer';
 import {useGetTaskDispatcherDefinitionsQuery} from '@/shared/queries/platform/taskDispatcherDefinitions.queries';
 import {useFeatureFlagsStore} from '@/shared/stores/useFeatureFlagsStore';
 import {SquareIcon} from 'lucide-react';
+import {useState} from 'react';
 import {useNavigate, useSearchParams} from 'react-router-dom';
 
 export enum Type {
@@ -24,6 +25,8 @@ export enum Type {
 }
 
 const Integrations = () => {
+    const [newlyCreatedIntegrationId, setNewlyCreatedIntegrationId] = useState<number | undefined>();
+
     const [searchParams] = useSearchParams();
 
     const categoryId = searchParams.get('categoryId');
@@ -79,6 +82,9 @@ const Integrations = () => {
                                             );
                                         }
                                     }}
+                                    onSuccess={(integrationId) =>
+                                        integrationId && setNewlyCreatedIntegrationId(integrationId)
+                                    }
                                     triggerNode={<Button label="New Integration" />}
                                 />
                             )
@@ -112,6 +118,7 @@ const Integrations = () => {
                     <IntegrationList
                         componentDefinitions={componentDefinitions}
                         integrations={integrations}
+                        newlyCreatedIntegrationId={newlyCreatedIntegrationId}
                         tags={tags}
                         taskDispatcherDefinitions={taskDispatcherDefinitions}
                     />
@@ -127,6 +134,9 @@ const Integrations = () => {
                                         );
                                     }
                                 }}
+                                onSuccess={(integrationId) =>
+                                    integrationId && setNewlyCreatedIntegrationId(integrationId)
+                                }
                                 triggerNode={<Button label="Create Integration" />}
                             />
                         }

--- a/client/src/ee/pages/embedded/integrations/components/IntegrationDialog.tsx
+++ b/client/src/ee/pages/embedded/integrations/components/IntegrationDialog.tsx
@@ -36,10 +36,11 @@ import {useForm} from 'react-hook-form';
 interface IntegrationDialogProps {
     integration: Integration | undefined;
     onClose?: (integration?: Integration) => void;
+    onSuccess?: (integrationId: number | void) => void;
     triggerNode?: ReactNode;
 }
 
-const IntegrationDialog = ({integration, onClose, triggerNode}: IntegrationDialogProps) => {
+const IntegrationDialog = ({integration, onClose, onSuccess, triggerNode}: IntegrationDialogProps) => {
     const [isOpen, setIsOpen] = useState(!triggerNode);
 
     const {captureIntegrationCreated} = useAnalytics();
@@ -74,7 +75,7 @@ const IntegrationDialog = ({integration, onClose, triggerNode}: IntegrationDialo
 
     const queryClient = useQueryClient();
 
-    const onSuccess = (integrationId: number | void) => {
+    const onSuccessHandler = (integrationId: number | void) => {
         captureIntegrationCreated();
 
         if (!integrationId && integration) {
@@ -97,15 +98,19 @@ const IntegrationDialog = ({integration, onClose, triggerNode}: IntegrationDialo
             queryKey: IntegrationTagKeys.integrationTags,
         });
 
+        if (onSuccess) {
+            onSuccess(integrationId);
+        }
+
         closeDialog();
     };
 
     const createIntegrationMutation = useCreateIntegrationMutation({
-        onSuccess,
+        onSuccess: onSuccessHandler,
     });
 
     const updateIntegrationMutation = useUpdateIntegrationMutation({
-        onSuccess,
+        onSuccess: onSuccessHandler,
     });
 
     const tagNames = integration?.tags?.map((tag) => tag.name);

--- a/client/src/ee/pages/embedded/integrations/components/integration-list/IntegrationList.tsx
+++ b/client/src/ee/pages/embedded/integrations/components/integration-list/IntegrationList.tsx
@@ -2,27 +2,61 @@ import {Collapsible, CollapsibleContent} from '@/components/ui/collapsible';
 import IntegrationListItem from '@/ee/pages/embedded/integrations/components/integration-list/IntegrationListItem';
 import {Integration, Tag} from '@/ee/shared/middleware/embedded/configuration';
 import {ComponentDefinitionBasic, TaskDispatcherDefinition} from '@/shared/middleware/platform/configuration';
+import {useEffect, useState} from 'react';
 
 import IntegrationWorkflowList from '../integration-workflow-list/IntegrationWorkflowList';
 
 const IntegrationList = ({
     componentDefinitions,
     integrations,
+    newlyCreatedIntegrationId,
     tags,
     taskDispatcherDefinitions,
 }: {
     componentDefinitions?: ComponentDefinitionBasic[];
     integrations: Integration[];
+    newlyCreatedIntegrationId?: number;
     tags: Tag[];
     taskDispatcherDefinitions?: TaskDispatcherDefinition[];
 }) => {
+    const [openCollapsibles, setOpenCollapsibles] = useState<Set<number>>(new Set());
+
+    useEffect(() => {
+        if (newlyCreatedIntegrationId) {
+            setOpenCollapsibles((previousOpenCollapsibles) => {
+                const nextOpenCollapsibles = new Set(previousOpenCollapsibles);
+
+                nextOpenCollapsibles.add(newlyCreatedIntegrationId);
+
+                return nextOpenCollapsibles;
+            });
+        }
+    }, [newlyCreatedIntegrationId]);
+
     return (
         <div className="w-full px-4 3xl:mx-auto 3xl:w-4/5">
             {integrations.map((integration) => {
                 const integrationTagIds = integration.tags?.map((tag) => tag.id);
 
                 return (
-                    <Collapsible className="group mb-2 rounded border border-border/50" key={integration.id}>
+                    <Collapsible
+                        className="group mb-2 rounded border border-border/50"
+                        key={integration.id}
+                        onOpenChange={(open) => {
+                            setOpenCollapsibles((previousOpenCollapsibles) => {
+                                const openCollapsibles = new Set(previousOpenCollapsibles);
+
+                                if (open) {
+                                    openCollapsibles.add(integration.id!);
+                                } else {
+                                    openCollapsibles.delete(integration.id!);
+                                }
+
+                                return openCollapsibles;
+                            });
+                        }}
+                        open={openCollapsibles.has(integration.id!)}
+                    >
                         <IntegrationListItem
                             integration={integration}
                             key={integration.id}

--- a/client/src/ee/pages/embedded/integrations/components/integration-list/IntegrationListItem.tsx
+++ b/client/src/ee/pages/embedded/integrations/components/integration-list/IntegrationListItem.tsx
@@ -11,6 +11,7 @@ import {
     AlertDialogHeader,
     AlertDialogTitle,
 } from '@/components/ui/alert-dialog';
+import {ButtonGroup} from '@/components/ui/button-group';
 import {CollapsibleTrigger} from '@/components/ui/collapsible';
 import {
     DropdownMenu,
@@ -203,9 +204,9 @@ const IntegrationListItem = ({integration, remainingTags}: IntegrationItemProps)
                         </div>
 
                         <div className="relative mt-2 sm:flex sm:items-center sm:justify-between">
-                            <div className="flex items-center">
+                            <div className="flex items-center gap-2">
                                 <CollapsibleTrigger
-                                    className="group mr-4 flex items-center text-xs font-semibold text-muted-foreground"
+                                    className="group flex min-w-28 items-center text-xs font-semibold text-muted-foreground"
                                     ref={workflowsCollapsibleTriggerRef}
                                 >
                                     <div className="mr-1">
@@ -216,6 +217,51 @@ const IntegrationListItem = ({integration, remainingTags}: IntegrationItemProps)
 
                                     <ChevronDownIcon className="size-4 duration-300 group-data-[state=open]:rotate-180" />
                                 </CollapsibleTrigger>
+
+                                <ButtonGroup aria-label="Workflow Creation Actions">
+                                    <Button
+                                        aria-label="Create Workflow"
+                                        onClick={(event) => {
+                                            event.stopPropagation();
+
+                                            setShowWorkflowDialog(true);
+                                        }}
+                                        size="xs"
+                                        variant="outline"
+                                    >
+                                        <PlusIcon />
+                                        Workflow
+                                    </Button>
+
+                                    <DropdownMenu>
+                                        <DropdownMenuTrigger asChild>
+                                            <Button
+                                                aria-label="More Workflow Creation Actions"
+                                                icon={<ChevronDownIcon />}
+                                                size="xs"
+                                                variant="outline"
+                                            >
+                                                {' '}
+                                            </Button>
+                                        </DropdownMenuTrigger>
+
+                                        <DropdownMenuContent align="end" className="p-0">
+                                            <DropdownMenuItem
+                                                aria-label="Import Workflow"
+                                                className="dropdown-menu-item"
+                                                onClick={(event) => {
+                                                    event.stopPropagation();
+
+                                                    if (hiddenFileInputRef.current) {
+                                                        hiddenFileInputRef.current.click();
+                                                    }
+                                                }}
+                                            >
+                                                <UploadIcon /> Import Workflow
+                                            </DropdownMenuItem>
+                                        </DropdownMenuContent>
+                                    </DropdownMenu>
+                                </ButtonGroup>
 
                                 <div onClick={(event) => event.preventDefault()}>
                                     {integration.tags && (
@@ -301,27 +347,9 @@ const IntegrationListItem = ({integration, remainingTags}: IntegrationItemProps)
 
                                 <DropdownMenuItem
                                     className="dropdown-menu-item"
-                                    onClick={() => setShowWorkflowDialog(true)}
-                                >
-                                    <PlusIcon /> New Workflow
-                                </DropdownMenuItem>
-
-                                <DropdownMenuItem
-                                    className="dropdown-menu-item"
                                     onClick={() => setShowPublishIntegrationDialog(true)}
                                 >
                                     <SendIcon /> Publish
-                                </DropdownMenuItem>
-
-                                <DropdownMenuItem
-                                    className="dropdown-menu-item"
-                                    onClick={() => {
-                                        if (hiddenFileInputRef.current) {
-                                            hiddenFileInputRef.current.click();
-                                        }
-                                    }}
-                                >
-                                    <UploadIcon /> Import Workflow
                                 </DropdownMenuItem>
 
                                 <DropdownMenuSeparator className="m-0" />

--- a/client/src/ee/pages/embedded/integrations/components/integration-list/tests/IntegrationList.test.tsx
+++ b/client/src/ee/pages/embedded/integrations/components/integration-list/tests/IntegrationList.test.tsx
@@ -1,0 +1,73 @@
+import IntegrationList from '@/ee/pages/embedded/integrations/components/integration-list/IntegrationList';
+import {render, resetAll, screen, userEvent, windowResizeObserver} from '@/shared/util/test-utils';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+
+vi.mock('@/ee/pages/embedded/integrations/components/integration-list/IntegrationListItem', async () => {
+    const {CollapsibleTrigger} = await import('@/components/ui/collapsible');
+
+    return {
+        default: ({integration}: {integration: {name: string}}) => (
+            <CollapsibleTrigger>{integration.name} header</CollapsibleTrigger>
+        ),
+    };
+});
+
+vi.mock('@/ee/pages/embedded/integrations/components/integration-workflow-list/IntegrationWorkflowList', () => ({
+    default: ({integration}: {integration: {name: string}}) => <div>{integration.name} workflows</div>,
+}));
+
+const integrations = [
+    {componentName: 'accelo', id: 1, multipleInstances: false, name: 'Accelo', tags: []},
+    {componentName: 'asana', id: 2, multipleInstances: false, name: 'Asana', tags: []},
+];
+
+const renderList = (newlyCreatedIntegrationId?: number) =>
+    render(
+        <IntegrationList integrations={integrations} newlyCreatedIntegrationId={newlyCreatedIntegrationId} tags={[]} />
+    );
+
+beforeEach(() => {
+    windowResizeObserver();
+});
+
+afterEach(() => {
+    resetAll();
+    vi.clearAllMocks();
+});
+
+describe('IntegrationList', () => {
+    it('keeps every integration collapsed by default', () => {
+        renderList();
+
+        expect(screen.getByText('Accelo header')).toBeInTheDocument();
+        expect(screen.queryByText('Accelo workflows')).not.toBeInTheDocument();
+    });
+
+    it('expands the newly created integration and leaves the others closed', () => {
+        renderList(2);
+
+        expect(screen.getByText('Asana workflows')).toBeInTheDocument();
+        expect(screen.queryByText('Accelo workflows')).not.toBeInTheDocument();
+    });
+
+    it('expands and collapses an integration on its own', async () => {
+        renderList();
+
+        await userEvent.click(screen.getByText('Accelo header'));
+
+        expect(screen.getByText('Accelo workflows')).toBeInTheDocument();
+        expect(screen.queryByText('Asana workflows')).not.toBeInTheDocument();
+
+        await userEvent.click(screen.getByText('Accelo header'));
+
+        expect(screen.queryByText('Accelo workflows')).not.toBeInTheDocument();
+    });
+
+    it('lets the newly created integration be collapsed again', async () => {
+        renderList(2);
+
+        await userEvent.click(screen.getByText('Asana header'));
+
+        expect(screen.queryByText('Asana workflows')).not.toBeInTheDocument();
+    });
+});

--- a/client/src/ee/pages/embedded/workflow-builder/WorkflowBuilder.tsx
+++ b/client/src/ee/pages/embedded/workflow-builder/WorkflowBuilder.tsx
@@ -115,13 +115,11 @@ const WorkflowBuilder = () => {
                     <ResizableHandle className="bg-muted" />
 
                     <ResizablePanel className="bg-background" defaultSize={0} panelRef={bottomResizablePanelRef}>
-                        {(workflowIsRunning || workflowTestExecution) && (
-                            <WorkflowExecutionsTestOutput
-                                onCloseClick={handleWorkflowExecutionsTestOutputCloseClick}
-                                workflowIsRunning={workflowIsRunning}
-                                workflowTestExecution={workflowTestExecution}
-                            />
-                        )}
+                        <WorkflowExecutionsTestOutput
+                            onCloseClick={handleWorkflowExecutionsTestOutputCloseClick}
+                            workflowIsRunning={workflowIsRunning}
+                            workflowTestExecution={workflowTestExecution}
+                        />
                     </ResizablePanel>
                 </ResizablePanelGroup>
             </div>

--- a/client/src/graphql/automation/configuration/mcpProjectWorkflowProperties.graphql
+++ b/client/src/graphql/automation/configuration/mcpProjectWorkflowProperties.graphql
@@ -12,7 +12,10 @@ query mcpProjectWorkflowProperties($mcpProjectWorkflowId: ID!) {
             controlType
             defaultValue
             label
+            maxLength
+            minLength
             placeholder
+            regex
         }
         ... on IntegerProperty {
             controlType

--- a/client/src/graphql/embedded/configuration/mcpIntegrationInstanceConfigurationWorkflowProperties.graphql
+++ b/client/src/graphql/embedded/configuration/mcpIntegrationInstanceConfigurationWorkflowProperties.graphql
@@ -12,7 +12,10 @@ query mcpIntegrationInstanceConfigurationWorkflowProperties($mcpIntegrationInsta
             controlType
             defaultValue
             label
+            maxLength
+            minLength
             placeholder
+            regex
         }
         ... on IntegerProperty {
             controlType

--- a/client/src/graphql/embedded/configuration/updateAutomationWorkflowProjectWorkflow.graphql
+++ b/client/src/graphql/embedded/configuration/updateAutomationWorkflowProjectWorkflow.graphql
@@ -1,0 +1,3 @@
+mutation updateAutomationWorkflowProjectWorkflow($workflowUuid: ID!, $label: String!, $description: String) {
+    updateAutomationWorkflowProjectWorkflow(workflowUuid: $workflowUuid, label: $label, description: $description)
+}

--- a/client/src/pages/automation/project/Project.tsx
+++ b/client/src/pages/automation/project/Project.tsx
@@ -134,14 +134,12 @@ const Project = () => {
                             defaultSize={0}
                             panelRef={bottomResizablePanelRef}
                         >
-                            {(workflowIsRunning || workflowTestExecution) && (
-                                <WorkflowExecutionsTestOutput
-                                    onCloseClick={handleWorkflowExecutionsTestOutputCloseClick}
-                                    onEditSubflowClick={handleEditSubflowClick}
-                                    workflowIsRunning={workflowIsRunning}
-                                    workflowTestExecution={workflowTestExecution}
-                                />
-                            )}
+                            <WorkflowExecutionsTestOutput
+                                onCloseClick={handleWorkflowExecutionsTestOutputCloseClick}
+                                onEditSubflowClick={handleEditSubflowClick}
+                                workflowIsRunning={workflowIsRunning}
+                                workflowTestExecution={workflowTestExecution}
+                            />
                         </ResizablePanel>
                     </ResizablePanelGroup>
                 </div>

--- a/client/src/pages/automation/project/components/projects-sidebar/ProjectsLeftSidebar.test.tsx
+++ b/client/src/pages/automation/project/components/projects-sidebar/ProjectsLeftSidebar.test.tsx
@@ -159,6 +159,7 @@ const mockNavigate = vi.hoisted(() => vi.fn());
 
 vi.mock('react-router-dom', async () => ({
     useNavigate: () => mockNavigate,
+    useSearchParams: () => [new URLSearchParams(), vi.fn()],
 }));
 
 // Helper to set default mocks per test scenario

--- a/client/src/pages/automation/project/components/projects-sidebar/ProjectsLeftSidebar.tsx
+++ b/client/src/pages/automation/project/components/projects-sidebar/ProjectsLeftSidebar.tsx
@@ -86,6 +86,8 @@ const ProjectsLeftSidebar = ({
 
     const findProjectIdByWorkflow = getWorkflowsProjectId(projects || []);
 
+    const selectedProject = projects?.find((project) => project.id === selectedProjectId);
+
     const filteredWorkflowsList = useMemo(
         () => getFilteredWorkflows(workflows, sortBy, searchValue),
         [workflows, sortBy, searchValue, getFilteredWorkflows]
@@ -323,6 +325,7 @@ const ProjectsLeftSidebar = ({
                                     findProjectIdByWorkflow={findProjectIdByWorkflow}
                                     key={workflow.id}
                                     onProjectClick={onProjectClick}
+                                    project={selectedProject}
                                     setSelectedProjectId={setSelectedProjectId}
                                     workflow={workflow}
                                 />

--- a/client/src/pages/automation/project/components/projects-sidebar/components/ProjectWorkflowsList.tsx
+++ b/client/src/pages/automation/project/components/projects-sidebar/components/ProjectWorkflowsList.tsx
@@ -79,6 +79,7 @@ const ProjectWorkflowsList = ({
                             findProjectIdByWorkflow={findProjectIdByWorkflow}
                             key={workflow.id}
                             onProjectClick={onProjectClick}
+                            project={project}
                             setSelectedProjectId={setSelectedProjectId}
                             workflow={workflow}
                         />

--- a/client/src/pages/automation/project/components/projects-sidebar/components/WorkflowComponentsIcon.tsx
+++ b/client/src/pages/automation/project/components/projects-sidebar/components/WorkflowComponentsIcon.tsx
@@ -3,10 +3,12 @@ import {Skeleton} from '@/components/ui/skeleton';
 import {Tooltip, TooltipContent, TooltipTrigger} from '@/components/ui/tooltip';
 import {ComponentDefinitionBasic} from '@/shared/middleware/platform/configuration';
 
+export type WorkflowComponentIconDefinitionType = Pick<ComponentDefinitionBasic, 'icon' | 'name' | 'title'>;
+
 interface WorkflowComponentsIconsProps {
-    workflowComponentDefinitions: Record<string, ComponentDefinitionBasic | undefined>;
+    workflowComponentDefinitions: Record<string, WorkflowComponentIconDefinitionType | undefined>;
     name: string;
-    workflowTaskDispatcherDefinitions: Record<string, ComponentDefinitionBasic | undefined>;
+    workflowTaskDispatcherDefinitions: Record<string, WorkflowComponentIconDefinitionType | undefined>;
 }
 
 const WorkflowComponentsIcon = ({

--- a/client/src/pages/automation/project/components/projects-sidebar/components/WorkflowsListItem.tsx
+++ b/client/src/pages/automation/project/components/projects-sidebar/components/WorkflowsListItem.tsx
@@ -1,9 +1,10 @@
 import {Tooltip, TooltipContent, TooltipTrigger} from '@/components/ui/tooltip';
+import WorkflowsListItemDropdownMenu from '@/pages/automation/project/components/projects-sidebar/components/WorkflowsListItemDropdownMenu';
 import useWorkflowDataStore from '@/pages/platform/workflow-editor/stores/useWorkflowDataStore';
 import WorkflowComponentsList from '@/shared/components/WorkflowComponentsList';
-import {Workflow} from '@/shared/middleware/automation/configuration';
+import {Project, Workflow} from '@/shared/middleware/automation/configuration';
 import {ComponentDefinitionBasic} from '@/shared/middleware/platform/configuration';
-import {useMemo} from 'react';
+import {MouseEvent, useMemo} from 'react';
 import {twMerge} from 'tailwind-merge';
 import {useShallow} from 'zustand/react/shallow';
 
@@ -13,6 +14,7 @@ interface WorkflowsListItemProps {
     currentWorkflowId: string;
     onProjectClick: (projectId: number, projectWorkflowId: number) => void;
     findProjectIdByWorkflow: (workflow: Workflow) => number;
+    project?: Project;
     setSelectedProjectId: (projectId: number) => void;
 }
 
@@ -21,6 +23,7 @@ const WorkflowsListItem = ({
     currentWorkflowId,
     findProjectIdByWorkflow,
     onProjectClick,
+    project,
     setSelectedProjectId,
     workflow,
 }: WorkflowsListItemProps) => {
@@ -63,7 +66,11 @@ const WorkflowsListItem = ({
         [calculateTimeDifference, workflow?.lastModifiedDate]
     );
 
-    const handleSelectWorkflowClick = () => {
+    const handleCardClick = (event: MouseEvent<HTMLLIElement>) => {
+        if (!event.currentTarget.contains(event.target as Node)) {
+            return;
+        }
+
         onProjectClick(projectId, projectWorkflowId);
 
         setSelectedProjectId(projectId);
@@ -76,32 +83,42 @@ const WorkflowsListItem = ({
                 workflow.id === currentWorkflowId && 'border-stroke-brand-primary bg-background'
             )}
             key={workflow.id}
-            onClick={() => handleSelectWorkflowClick()}
+            onClick={handleCardClick}
         >
-            <div className="flex flex-col gap-3 overflow-hidden">
-                <WorkflowComponentsList
-                    filteredComponentNames={filteredComponentNames}
-                    workflowComponentDefinitions={workflowComponentDefinitions}
-                    workflowTaskDispatcherDefinitions={workflowTaskDispatcherDefinitions}
-                />
+            <div className="flex items-center justify-between gap-2">
+                <div className="flex min-w-0 flex-col gap-3 overflow-hidden">
+                    <WorkflowComponentsList
+                        filteredComponentNames={filteredComponentNames}
+                        workflowComponentDefinitions={workflowComponentDefinitions}
+                        workflowTaskDispatcherDefinitions={workflowTaskDispatcherDefinitions}
+                    />
 
-                <Tooltip>
-                    <TooltipTrigger asChild>
-                        <div className="flex flex-col gap-1 text-start">
-                            <span className="truncate overflow-hidden text-sm font-medium">{workflow.label}</span>
+                    <Tooltip>
+                        <TooltipTrigger asChild>
+                            <div className="flex flex-col gap-1 text-start">
+                                <span className="truncate overflow-hidden text-sm font-medium">{workflow.label}</span>
 
-                            <div className="flex gap-1 text-xs text-content-neutral-secondary">
-                                <span>Edited</span>
+                                <div className="flex gap-1 text-xs text-content-neutral-secondary">
+                                    <span>Edited</span>
 
-                                {timeAgo}
+                                    {timeAgo}
+                                </div>
                             </div>
-                        </div>
-                    </TooltipTrigger>
+                        </TooltipTrigger>
 
-                    {workflow.label && workflow.label.length > 40 && (
-                        <TooltipContent className="max-w-96">{workflow.label}</TooltipContent>
-                    )}
-                </Tooltip>
+                        {workflow.label && workflow.label.length > 40 && (
+                            <TooltipContent className="max-w-96">{workflow.label}</TooltipContent>
+                        )}
+                    </Tooltip>
+                </div>
+
+                {project && (
+                    <WorkflowsListItemDropdownMenu
+                        currentWorkflowId={currentWorkflowId}
+                        project={project}
+                        workflow={workflow}
+                    />
+                )}
             </div>
         </li>
     );

--- a/client/src/pages/automation/project/components/projects-sidebar/components/WorkflowsListItemDropdownMenu.tsx
+++ b/client/src/pages/automation/project/components/projects-sidebar/components/WorkflowsListItemDropdownMenu.tsx
@@ -1,0 +1,182 @@
+import {DropdownMenuItem} from '@/components/ui/dropdown-menu';
+import {WorkflowShareDialog} from '@/pages/automation/project/components/WorkflowShareDialog';
+import WorkflowDialog from '@/shared/components/workflow/WorkflowDialog';
+import WorkflowListItemDropdownMenu from '@/shared/components/workflow/WorkflowListItemDropdownMenu';
+import {Project, Workflow} from '@/shared/middleware/automation/configuration';
+import {
+    useDeleteWorkflowMutation,
+    useDuplicateWorkflowMutation,
+    useUpdateWorkflowMutation,
+} from '@/shared/mutations/automation/workflows.mutations';
+import {ProjectWorkflowKeys} from '@/shared/queries/automation/projectWorkflows.queries';
+import {ProjectKeys} from '@/shared/queries/automation/projects.queries';
+import {WorkflowKeys, useGetWorkflowQuery} from '@/shared/queries/automation/workflows.queries';
+import {WorkflowTestConfigurationKeys} from '@/shared/queries/platform/workflowTestConfigurations.queries';
+
+import '@/shared/styles/dropdownMenu.css';
+import {useApplicationInfoStore} from '@/shared/stores/useApplicationInfoStore';
+import {useFeatureFlagsStore} from '@/shared/stores/useFeatureFlagsStore';
+import {useQueryClient} from '@tanstack/react-query';
+import {CopyIcon, DownloadIcon, Share2Icon} from 'lucide-react';
+import {useState} from 'react';
+import {useNavigate, useSearchParams} from 'react-router-dom';
+import {toast} from 'sonner';
+
+interface WorkflowsListItemDropdownMenuProps {
+    currentWorkflowId: string;
+    project: Project;
+    workflow: Workflow;
+}
+
+const WorkflowsListItemDropdownMenu = ({currentWorkflowId, project, workflow}: WorkflowsListItemDropdownMenuProps) => {
+    const [showEditWorkflowDialog, setShowEditWorkflowDialog] = useState(false);
+    const [showWorkflowShareDialog, setShowWorkflowShareDialog] = useState(false);
+
+    const templatesSubmissionForm = useApplicationInfoStore((state) => state.templatesSubmissionForm.workflows);
+
+    const ff_2939 = useFeatureFlagsStore()('ff-2939');
+
+    const navigate = useNavigate();
+    const [searchParams] = useSearchParams();
+
+    const queryClient = useQueryClient();
+
+    const projectId = project.id!;
+
+    const deleteWorkflowMutation = useDeleteWorkflowMutation({
+        onSuccess: () => {
+            const deletedProjectWorkflowId = workflow.projectWorkflowId;
+
+            queryClient.removeQueries({queryKey: WorkflowKeys.workflow(workflow.id!)});
+
+            if (deletedProjectWorkflowId) {
+                queryClient.removeQueries({
+                    queryKey: ProjectWorkflowKeys.projectWorkflow(projectId, deletedProjectWorkflowId),
+                });
+            }
+
+            queryClient.invalidateQueries({queryKey: ProjectWorkflowKeys.projectWorkflows(projectId)});
+            queryClient.invalidateQueries({queryKey: ProjectKeys.projects});
+            queryClient.invalidateQueries({exact: true, queryKey: ProjectKeys.project(projectId)});
+
+            if (workflow.id !== currentWorkflowId) {
+                return;
+            }
+
+            const firstRemainingProjectWorkflowId = project.projectWorkflowIds?.find(
+                (projectWorkflowId) => projectWorkflowId !== deletedProjectWorkflowId
+            );
+
+            if (firstRemainingProjectWorkflowId) {
+                navigate(
+                    `/automation/projects/${projectId}/project-workflows/${firstRemainingProjectWorkflowId}?${searchParams}`
+                );
+            } else {
+                navigate('/automation/projects');
+            }
+        },
+    });
+
+    const duplicateWorkflowMutation = useDuplicateWorkflowMutation({
+        onError: () => {
+            queryClient.invalidateQueries({queryKey: ProjectWorkflowKeys.projectWorkflows(projectId)});
+        },
+        onSuccess: () => {
+            queryClient.invalidateQueries({queryKey: ProjectWorkflowKeys.projectWorkflows(projectId)});
+            queryClient.invalidateQueries({queryKey: ProjectKeys.projects});
+
+            toast('Workflow duplicated successfully.');
+        },
+    });
+
+    const updateWorkflowMutation = useUpdateWorkflowMutation({
+        onSuccess: () => {
+            queryClient.invalidateQueries({queryKey: ProjectWorkflowKeys.projectWorkflows(projectId)});
+            queryClient.invalidateQueries({queryKey: ProjectKeys.projects});
+            queryClient.invalidateQueries({
+                queryKey: WorkflowTestConfigurationKeys.workflowTestConfiguration(workflow.id!),
+            });
+            queryClient.invalidateQueries({queryKey: WorkflowKeys.workflow(workflow.id!)});
+
+            setShowEditWorkflowDialog(false);
+        },
+    });
+
+    return (
+        <WorkflowListItemDropdownMenu
+            dialogs={
+                <>
+                    {showEditWorkflowDialog && (
+                        <WorkflowDialog
+                            onClose={() => setShowEditWorkflowDialog(false)}
+                            onSave={() => {
+                                if (workflow.projectWorkflowId) {
+                                    queryClient.invalidateQueries({
+                                        queryKey: ProjectWorkflowKeys.projectWorkflow(
+                                            projectId,
+                                            workflow.projectWorkflowId
+                                        ),
+                                    });
+                                }
+                            }}
+                            updateWorkflowMutation={updateWorkflowMutation}
+                            useGetWorkflowQuery={useGetWorkflowQuery}
+                            workflowId={workflow.id!}
+                        />
+                    )}
+
+                    {showWorkflowShareDialog && (
+                        <WorkflowShareDialog
+                            onOpenChange={() => setShowWorkflowShareDialog(false)}
+                            open={showWorkflowShareDialog}
+                            projectVersion={project.lastProjectVersion!}
+                            workflowId={workflow.id!}
+                            workflowUuid={workflow.workflowUuid!}
+                        />
+                    )}
+                </>
+            }
+            onDelete={() => deleteWorkflowMutation.mutate({id: workflow.id!})}
+            onEditClick={() => setShowEditWorkflowDialog(true)}
+            workflowLabel={workflow.label}
+        >
+            <DropdownMenuItem
+                className="dropdown-menu-item"
+                onClick={() =>
+                    duplicateWorkflowMutation.mutate({
+                        id: projectId,
+                        workflowId: workflow.id!,
+                    })
+                }
+            >
+                <CopyIcon /> Duplicate
+            </DropdownMenuItem>
+
+            <DropdownMenuItem className="dropdown-menu-item" onClick={() => setShowWorkflowShareDialog(true)}>
+                <Share2Icon /> Share
+            </DropdownMenuItem>
+
+            {ff_2939 && (
+                <DropdownMenuItem
+                    className="dropdown-menu-item"
+                    onClick={() => {
+                        if (templatesSubmissionForm) {
+                            window.open(templatesSubmissionForm, '_blank');
+                        }
+                    }}
+                >
+                    <Share2Icon /> Share with Community
+                </DropdownMenuItem>
+            )}
+
+            <DropdownMenuItem
+                className="dropdown-menu-item"
+                onClick={() => (window.location.href = `/api/automation/internal/workflows/${workflow.id}/export`)}
+            >
+                <DownloadIcon /> Export
+            </DropdownMenuItem>
+        </WorkflowListItemDropdownMenu>
+    );
+};
+
+export default WorkflowsListItemDropdownMenu;

--- a/client/src/pages/automation/project/components/projects-sidebar/tests/ProjectWorkflowsList.test.tsx
+++ b/client/src/pages/automation/project/components/projects-sidebar/tests/ProjectWorkflowsList.test.tsx
@@ -2,6 +2,7 @@ import {TooltipProvider} from '@/components/ui/tooltip';
 import ProjectWorkflowsList from '@/pages/automation/project/components/projects-sidebar/components/ProjectWorkflowsList';
 import {Project, Workflow} from '@/shared/middleware/automation/configuration';
 import {render, screen} from '@/shared/util/test-utils';
+import {MemoryRouter} from 'react-router-dom';
 import {expect, it, vi} from 'vitest';
 
 const mockProject: Project = {
@@ -27,17 +28,19 @@ const mockFilteredWorkflowsList: Workflow[] = [
 
 const renderProjectWorkflowsList = (mockUnpublishedProject?: Project) => {
     render(
-        <TooltipProvider>
-            <ProjectWorkflowsList
-                calculateTimeDifference={vi.fn()}
-                currentWorkflowId="1001"
-                filteredWorkflowsList={mockFilteredWorkflowsList}
-                findProjectIdByWorkflow={vi.fn().mockReturnValue(1050)}
-                onProjectClick={vi.fn()}
-                project={mockUnpublishedProject ?? mockProject}
-                setSelectedProjectId={vi.fn()}
-            />
-        </TooltipProvider>
+        <MemoryRouter>
+            <TooltipProvider>
+                <ProjectWorkflowsList
+                    calculateTimeDifference={vi.fn()}
+                    currentWorkflowId="1001"
+                    filteredWorkflowsList={mockFilteredWorkflowsList}
+                    findProjectIdByWorkflow={vi.fn().mockReturnValue(1050)}
+                    onProjectClick={vi.fn()}
+                    project={mockUnpublishedProject ?? mockProject}
+                    setSelectedProjectId={vi.fn()}
+                />
+            </TooltipProvider>
+        </MemoryRouter>
     );
 };
 

--- a/client/src/pages/automation/project/components/projects-sidebar/tests/WorkflowsListItem.test.tsx
+++ b/client/src/pages/automation/project/components/projects-sidebar/tests/WorkflowsListItem.test.tsx
@@ -1,27 +1,41 @@
 import {TooltipProvider} from '@/components/ui/tooltip';
 import WorkflowsListItem from '@/pages/automation/project/components/projects-sidebar/components/WorkflowsListItem';
-import {fireEvent, render, screen} from '@/shared/util/test-utils';
-import {expect, it, vi} from 'vitest';
+import {fireEvent, render, screen, userEvent} from '@/shared/util/test-utils';
+import {MemoryRouter} from 'react-router-dom';
+import {beforeEach, expect, it, vi} from 'vitest';
 
 const mockOnProjectClick = vi.fn();
+
+const mockProject = {
+    id: 1050,
+    name: 'Project One',
+    workspaceId: 1,
+};
 
 const mockWorkflow = {
     label: 'Workflow One',
     projectWorkflowId: 1001,
 };
 
+beforeEach(() => {
+    vi.clearAllMocks();
+});
+
 const renderWorkflowsListItem = () => {
     render(
-        <TooltipProvider>
-            <WorkflowsListItem
-                calculateTimeDifference={vi.fn().mockReturnValue('1 hour ago')}
-                currentWorkflowId="1001"
-                findProjectIdByWorkflow={vi.fn().mockReturnValue(1050)}
-                onProjectClick={mockOnProjectClick}
-                setSelectedProjectId={vi.fn()}
-                workflow={mockWorkflow}
-            />
-        </TooltipProvider>
+        <MemoryRouter>
+            <TooltipProvider>
+                <WorkflowsListItem
+                    calculateTimeDifference={vi.fn().mockReturnValue('1 hour ago')}
+                    currentWorkflowId="1001"
+                    findProjectIdByWorkflow={vi.fn().mockReturnValue(1050)}
+                    onProjectClick={mockOnProjectClick}
+                    project={mockProject}
+                    setSelectedProjectId={vi.fn()}
+                    workflow={mockWorkflow}
+                />
+            </TooltipProvider>
+        </MemoryRouter>
     );
 };
 
@@ -45,6 +59,22 @@ it('should call onProjectClick with correct projectId and selectedProjectId when
     expect(mockOnProjectClick).toHaveBeenCalledWith(1050, 1001);
 });
 
+it('should not select the workflow when the actions menu is used', async () => {
+    renderWorkflowsListItem();
+
+    await userEvent.click(screen.getByRole('button', {name: 'Workflow actions for Workflow One'}));
+
+    expect(mockOnProjectClick).not.toHaveBeenCalled();
+
+    await userEvent.click(screen.getByRole('menuitem', {name: 'Delete'}));
+
+    expect(screen.getByText('Are you absolutely sure?')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', {name: 'Cancel'}));
+
+    expect(mockOnProjectClick).not.toHaveBeenCalled();
+});
+
 it('should render component icons for workflow', () => {
     const mockWorkflowWithComponents = {
         ...mockWorkflow,
@@ -53,16 +83,19 @@ it('should render component icons for workflow', () => {
     };
 
     render(
-        <TooltipProvider>
-            <WorkflowsListItem
-                calculateTimeDifference={vi.fn().mockReturnValue('1 hour ago')}
-                currentWorkflowId="1001"
-                findProjectIdByWorkflow={vi.fn().mockReturnValue(1050)}
-                onProjectClick={mockOnProjectClick}
-                setSelectedProjectId={vi.fn()}
-                workflow={mockWorkflowWithComponents}
-            />
-        </TooltipProvider>
+        <MemoryRouter>
+            <TooltipProvider>
+                <WorkflowsListItem
+                    calculateTimeDifference={vi.fn().mockReturnValue('1 hour ago')}
+                    currentWorkflowId="1001"
+                    findProjectIdByWorkflow={vi.fn().mockReturnValue(1050)}
+                    onProjectClick={mockOnProjectClick}
+                    project={mockProject}
+                    setSelectedProjectId={vi.fn()}
+                    workflow={mockWorkflowWithComponents}
+                />
+            </TooltipProvider>
+        </MemoryRouter>
     );
 
     expect(screen.getAllByLabelText('Workflow component icon')).toHaveLength(5);
@@ -76,16 +109,19 @@ it('should show +X indicator when there are more than 7 components', () => {
     };
 
     render(
-        <TooltipProvider>
-            <WorkflowsListItem
-                calculateTimeDifference={vi.fn().mockReturnValue('1 hour ago')}
-                currentWorkflowId="1001"
-                findProjectIdByWorkflow={vi.fn().mockReturnValue(1050)}
-                onProjectClick={mockOnProjectClick}
-                setSelectedProjectId={vi.fn()}
-                workflow={mockWorkflowWithComponents}
-            />
-        </TooltipProvider>
+        <MemoryRouter>
+            <TooltipProvider>
+                <WorkflowsListItem
+                    calculateTimeDifference={vi.fn().mockReturnValue('1 hour ago')}
+                    currentWorkflowId="1001"
+                    findProjectIdByWorkflow={vi.fn().mockReturnValue(1050)}
+                    onProjectClick={mockOnProjectClick}
+                    project={mockProject}
+                    setSelectedProjectId={vi.fn()}
+                    workflow={mockWorkflowWithComponents}
+                />
+            </TooltipProvider>
+        </MemoryRouter>
     );
 
     expect(screen.getByText('+2')).toBeInTheDocument();

--- a/client/src/pages/automation/project/components/projects-sidebar/tests/WorkflowsListItemDropdownMenu.test.tsx
+++ b/client/src/pages/automation/project/components/projects-sidebar/tests/WorkflowsListItemDropdownMenu.test.tsx
@@ -1,0 +1,252 @@
+import WorkflowsListItemDropdownMenu from '@/pages/automation/project/components/projects-sidebar/components/WorkflowsListItemDropdownMenu';
+import {render, resetAll, screen, userEvent, windowResizeObserver} from '@/shared/util/test-utils';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+
+const hoisted = vi.hoisted(() => ({
+    deleteMutate: vi.fn(),
+    duplicateMutate: vi.fn(),
+    featureFlagEnabled: false,
+    navigate: vi.fn(),
+    toast: vi.fn(),
+    updateMutate: vi.fn(),
+}));
+
+vi.mock('react-router-dom', () => ({
+    useNavigate: () => hoisted.navigate,
+    useSearchParams: () => [new URLSearchParams(), vi.fn()],
+}));
+
+vi.mock('sonner', () => ({
+    toast: hoisted.toast,
+}));
+
+vi.mock('@/shared/mutations/automation/workflows.mutations', () => ({
+    useDeleteWorkflowMutation: (mutationProps?: {onSuccess?: () => void}) => ({
+        mutate: (...args: unknown[]) => {
+            hoisted.deleteMutate(...args);
+
+            mutationProps?.onSuccess?.();
+        },
+    }),
+    useDuplicateWorkflowMutation: (mutationProps?: {onError?: () => void; onSuccess?: () => void}) => ({
+        mutate: (...args: unknown[]) => {
+            hoisted.duplicateMutate(...args);
+
+            mutationProps?.onError?.();
+            mutationProps?.onSuccess?.();
+        },
+    }),
+    useUpdateWorkflowMutation: (mutationProps?: {onSuccess?: () => void}) => ({
+        mutate: (...args: unknown[]) => {
+            hoisted.updateMutate(...args);
+
+            mutationProps?.onSuccess?.();
+        },
+    }),
+}));
+
+vi.mock('@/shared/stores/useFeatureFlagsStore', () => ({
+    useFeatureFlagsStore: () => () => hoisted.featureFlagEnabled,
+}));
+
+vi.mock('@/shared/stores/useApplicationInfoStore', () => ({
+    useApplicationInfoStore: () => 'https://templates.example.com',
+}));
+
+vi.mock('@/shared/components/workflow/WorkflowDialog', () => ({
+    default: ({
+        onClose,
+        onSave,
+        updateWorkflowMutation,
+    }: {
+        onClose: () => void;
+        onSave: () => void;
+        updateWorkflowMutation: {mutate: (values: unknown) => void};
+    }) => (
+        <div>
+            <span>Workflow dialog</span>
+
+            <button onClick={onSave} type="button">
+                Save workflow
+            </button>
+
+            <button onClick={() => updateWorkflowMutation.mutate({id: 'workflow-1'})} type="button">
+                Update workflow
+            </button>
+
+            <button onClick={onClose} type="button">
+                Close workflow dialog
+            </button>
+        </div>
+    ),
+}));
+
+vi.mock('@/pages/automation/project/components/WorkflowShareDialog', () => ({
+    WorkflowShareDialog: ({onOpenChange}: {onOpenChange: () => void}) => (
+        <div>
+            <span>Workflow share dialog</span>
+
+            <button onClick={onOpenChange} type="button">
+                Close share dialog
+            </button>
+        </div>
+    ),
+}));
+
+const project = {
+    id: 50,
+    lastProjectVersion: 3,
+    name: 'Project One',
+    projectWorkflowIds: [10, 11],
+    workspaceId: 1,
+};
+
+const workflow = {
+    id: 'workflow-1',
+    label: 'Workflow One',
+    projectWorkflowId: 10,
+    workflowUuid: 'uuid-1',
+};
+
+const renderMenu = (currentWorkflowId = 'workflow-other', projectOverrides = {}) =>
+    render(
+        <WorkflowsListItemDropdownMenu
+            currentWorkflowId={currentWorkflowId}
+            project={{...project, ...projectOverrides}}
+            workflow={workflow}
+        />
+    );
+
+const openMenu = async () => {
+    await userEvent.click(screen.getByRole('button', {name: 'Workflow actions for Workflow One'}));
+};
+
+const deleteWorkflow = async () => {
+    await openMenu();
+    await userEvent.click(screen.getByRole('menuitem', {name: 'Delete'}));
+    await userEvent.click(screen.getByRole('button', {name: 'Delete'}));
+};
+
+beforeEach(() => {
+    windowResizeObserver();
+    hoisted.featureFlagEnabled = false;
+});
+
+afterEach(() => {
+    resetAll();
+    vi.clearAllMocks();
+});
+
+describe('WorkflowsListItemDropdownMenu', () => {
+    it('offers Edit, Duplicate, Share, Export and Delete', async () => {
+        renderMenu();
+
+        await openMenu();
+
+        expect(screen.getAllByRole('menuitem').map((menuItem) => menuItem.textContent?.trim())).toEqual([
+            'Edit',
+            'Duplicate',
+            'Share',
+            'Export',
+            'Delete',
+        ]);
+    });
+
+    it('opens the community template form when ff-2939 is on', async () => {
+        hoisted.featureFlagEnabled = true;
+
+        const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+
+        renderMenu();
+
+        await openMenu();
+        await userEvent.click(screen.getByRole('menuitem', {name: 'Share with Community'}));
+
+        expect(openSpy).toHaveBeenCalledWith('https://templates.example.com', '_blank');
+
+        openSpy.mockRestore();
+    });
+
+    it('exports through the automation endpoint', async () => {
+        const location = {href: ''};
+
+        Object.defineProperty(window, 'location', {configurable: true, value: location, writable: true});
+
+        renderMenu();
+
+        await openMenu();
+        await userEvent.click(screen.getByRole('menuitem', {name: 'Export'}));
+
+        expect(location.href).toBe('/api/automation/internal/workflows/workflow-1/export');
+    });
+
+    it('duplicates into the same project and reports success', async () => {
+        renderMenu();
+
+        await openMenu();
+        await userEvent.click(screen.getByRole('menuitem', {name: 'Duplicate'}));
+
+        expect(hoisted.duplicateMutate).toHaveBeenCalledWith({id: 50, workflowId: 'workflow-1'});
+        expect(hoisted.toast).toHaveBeenCalledWith('Workflow duplicated successfully.');
+    });
+
+    it('closes the edit dialog once the workflow is updated', async () => {
+        renderMenu();
+
+        await openMenu();
+        await userEvent.click(screen.getByRole('menuitem', {name: 'Edit'}));
+        await userEvent.click(screen.getByRole('button', {name: 'Save workflow'}));
+        await userEvent.click(screen.getByRole('button', {name: 'Update workflow'}));
+
+        expect(hoisted.updateMutate).toHaveBeenCalledWith({id: 'workflow-1'});
+        expect(screen.queryByText('Workflow dialog')).not.toBeInTheDocument();
+    });
+
+    it('closes the edit dialog when it is dismissed', async () => {
+        renderMenu();
+
+        await openMenu();
+        await userEvent.click(screen.getByRole('menuitem', {name: 'Edit'}));
+        await userEvent.click(screen.getByRole('button', {name: 'Close workflow dialog'}));
+
+        expect(screen.queryByText('Workflow dialog')).not.toBeInTheDocument();
+    });
+
+    it('opens and closes the share dialog', async () => {
+        renderMenu();
+
+        await openMenu();
+        await userEvent.click(screen.getByRole('menuitem', {name: 'Share'}));
+
+        expect(screen.getByText('Workflow share dialog')).toBeInTheDocument();
+
+        await userEvent.click(screen.getByRole('button', {name: 'Close share dialog'}));
+
+        expect(screen.queryByText('Workflow share dialog')).not.toBeInTheDocument();
+    });
+
+    it('navigates to the first remaining workflow when the open one is deleted', async () => {
+        renderMenu('workflow-1');
+
+        await deleteWorkflow();
+
+        expect(hoisted.deleteMutate).toHaveBeenCalledWith({id: 'workflow-1'});
+        expect(hoisted.navigate).toHaveBeenCalledWith('/automation/projects/50/project-workflows/11?');
+    });
+
+    it('returns to the project list when the last workflow is deleted', async () => {
+        renderMenu('workflow-1', {projectWorkflowIds: [10]});
+
+        await deleteWorkflow();
+
+        expect(hoisted.navigate).toHaveBeenCalledWith('/automation/projects');
+    });
+
+    it('stays put when a workflow other than the open one is deleted', async () => {
+        renderMenu('workflow-other');
+
+        await deleteWorkflow();
+
+        expect(hoisted.navigate).not.toHaveBeenCalled();
+    });
+});

--- a/client/src/pages/platform/workflow-editor/WorkflowEditorLayout.tsx
+++ b/client/src/pages/platform/workflow-editor/WorkflowEditorLayout.tsx
@@ -195,7 +195,7 @@ const WorkflowEditorLayout = ({
         <ReactFlowProvider>
             <div
                 className={twMerge(
-                    'relative mx-3 mb-3 flex w-full',
+                    'relative mx-3 mb-3 flex w-full overflow-hidden rounded-lg border border-stroke-neutral-secondary',
                     leftSidebarOpen && 'ml-0',
                     copilotLayoutShifted && 'mr-0'
                 )}

--- a/client/src/pages/platform/workflow-editor/components/workflow-test-chat/WorkflowTestChatPanel.tsx
+++ b/client/src/pages/platform/workflow-editor/components/workflow-test-chat/WorkflowTestChatPanel.tsx
@@ -1,25 +1,35 @@
+import Button from '@/components/Button/Button';
 import {Thread} from '@/components/assistant-ui/thread';
+import {Tooltip, TooltipContent, TooltipTrigger} from '@/components/ui/tooltip';
 import {WorkflowTestChatRuntimeProvider} from '@/pages/platform/workflow-editor/components/workflow-test-chat/runtime-providers/WorkflowTestChatRuntimeProvider';
 import useWorkflowTestChatStore from '@/pages/platform/workflow-editor/stores/useWorkflowTestChatStore';
 import useCopilotLayoutShifted from '@/shared/components/copilot/hooks/useCopilotLayoutShifted';
-import {XIcon} from 'lucide-react';
+import {MessageSquareXIcon, XIcon} from 'lucide-react';
 import {useEffect} from 'react';
 import {twMerge} from 'tailwind-merge';
 import {useShallow} from 'zustand/react/shallow';
 
 const WorkflowTestChatPanel = () => {
-    const {generateConversationId, setWorkflowTestChatPanelOpen, workflowTestChatPanelOpen} = useWorkflowTestChatStore(
-        useShallow((state) => ({
-            generateConversationId: state.generateConversationId,
-            setWorkflowTestChatPanelOpen: state.setWorkflowTestChatPanelOpen,
-            workflowTestChatPanelOpen: state.workflowTestChatPanelOpen,
-        }))
-    );
+    const {generateConversationId, resetMessages, setWorkflowTestChatPanelOpen, workflowTestChatPanelOpen} =
+        useWorkflowTestChatStore(
+            useShallow((state) => ({
+                generateConversationId: state.generateConversationId,
+                resetMessages: state.resetMessages,
+                setWorkflowTestChatPanelOpen: state.setWorkflowTestChatPanelOpen,
+                workflowTestChatPanelOpen: state.workflowTestChatPanelOpen,
+            }))
+        );
 
     const copilotLayoutShifted = useCopilotLayoutShifted();
 
     const handlePanelClose = () => {
         setWorkflowTestChatPanelOpen(false);
+    };
+
+    const handleResetChatClick = () => {
+        resetMessages();
+
+        generateConversationId();
     };
 
     useEffect(() => {
@@ -41,13 +51,29 @@ const WorkflowTestChatPanel = () => {
                 <header className="flex items-center p-4 text-lg font-medium">
                     <span>Playground</span>
 
-                    <button
-                        aria-label="Close the node details dialog"
-                        className="ml-auto pr-0"
-                        onClick={handlePanelClose}
-                    >
-                        <XIcon aria-hidden="true" className="size-4 cursor-pointer" />
-                    </button>
+                    <div className="ml-auto flex items-center gap-2">
+                        <Tooltip>
+                            <TooltipTrigger asChild>
+                                <Button
+                                    aria-label="Reset the conversation"
+                                    icon={<MessageSquareXIcon />}
+                                    onClick={handleResetChatClick}
+                                    size="iconSm"
+                                    variant="ghost"
+                                />
+                            </TooltipTrigger>
+
+                            <TooltipContent>Reset conversation</TooltipContent>
+                        </Tooltip>
+
+                        <Button
+                            aria-label="Close the playground panel"
+                            icon={<XIcon />}
+                            onClick={handlePanelClose}
+                            size="iconSm"
+                            variant="ghost"
+                        />
+                    </div>
                 </header>
 
                 <div className="absolute inset-x-0 top-16 bottom-0">

--- a/client/src/pages/platform/workflow-editor/components/workflow-test-chat/tests/WorkflowTestChatPanel.test.tsx
+++ b/client/src/pages/platform/workflow-editor/components/workflow-test-chat/tests/WorkflowTestChatPanel.test.tsx
@@ -1,0 +1,80 @@
+import {TooltipProvider} from '@/components/ui/tooltip';
+import WorkflowTestChatPanel from '@/pages/platform/workflow-editor/components/workflow-test-chat/WorkflowTestChatPanel';
+import useWorkflowTestChatStore from '@/pages/platform/workflow-editor/stores/useWorkflowTestChatStore';
+import {render, resetAll, screen, userEvent, windowResizeObserver} from '@/shared/util/test-utils';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+
+vi.mock('@/components/assistant-ui/thread', () => ({
+    Thread: () => <div>Thread</div>,
+}));
+
+vi.mock(
+    '@/pages/platform/workflow-editor/components/workflow-test-chat/runtime-providers/WorkflowTestChatRuntimeProvider',
+    () => ({
+        WorkflowTestChatRuntimeProvider: ({children}: {children: React.ReactNode}) => <div>{children}</div>,
+    })
+);
+
+vi.mock('@/shared/components/copilot/hooks/useCopilotLayoutShifted', () => ({
+    default: () => false,
+}));
+
+const renderPanel = () =>
+    render(
+        <TooltipProvider>
+            <WorkflowTestChatPanel />
+        </TooltipProvider>
+    );
+
+beforeEach(() => {
+    windowResizeObserver();
+
+    useWorkflowTestChatStore.setState({
+        conversationId: undefined,
+        messages: [],
+        resumeUrl: null,
+        workflowTestChatPanelOpen: true,
+    });
+});
+
+afterEach(() => {
+    resetAll();
+    vi.clearAllMocks();
+});
+
+describe('WorkflowTestChatPanel', () => {
+    it('renders nothing while the panel is closed', () => {
+        useWorkflowTestChatStore.setState({workflowTestChatPanelOpen: false});
+
+        renderPanel();
+
+        expect(screen.queryByText('Playground')).not.toBeInTheDocument();
+    });
+
+    it('clears the conversation and starts a new one when reset', async () => {
+        renderPanel();
+
+        useWorkflowTestChatStore.setState({
+            messages: [{content: 'Hello', role: 'user'}],
+            resumeUrl: 'https://example.com/resume',
+        });
+
+        const conversationIdBeforeReset = useWorkflowTestChatStore.getState().conversationId;
+
+        await userEvent.click(screen.getByRole('button', {name: 'Reset the conversation'}));
+
+        const state = useWorkflowTestChatStore.getState();
+
+        expect(state.messages).toEqual([]);
+        expect(state.resumeUrl).toBeNull();
+        expect(state.conversationId).not.toBe(conversationIdBeforeReset);
+    });
+
+    it('closes the panel', async () => {
+        renderPanel();
+
+        await userEvent.click(screen.getByRole('button', {name: 'Close the playground panel'}));
+
+        expect(useWorkflowTestChatStore.getState().workflowTestChatPanelOpen).toBe(false);
+    });
+});

--- a/client/src/shared/components/WorkflowComponentsList.tsx
+++ b/client/src/shared/components/WorkflowComponentsList.tsx
@@ -1,13 +1,14 @@
 import {Tooltip, TooltipContent, TooltipTrigger} from '@/components/ui/tooltip';
-import WorkflowComponentsIcon from '@/pages/automation/project/components/projects-sidebar/components/WorkflowComponentsIcon';
-import {ComponentDefinitionBasic} from '@/shared/middleware/platform/configuration';
+import WorkflowComponentsIcon, {
+    WorkflowComponentIconDefinitionType,
+} from '@/pages/automation/project/components/projects-sidebar/components/WorkflowComponentsIcon';
 import {useMemo} from 'react';
 
 interface WorkflowComponentsListProps {
     filteredComponentNames: string[];
     maxIcons?: number;
-    workflowComponentDefinitions: Record<string, ComponentDefinitionBasic | undefined>;
-    workflowTaskDispatcherDefinitions: Record<string, ComponentDefinitionBasic | undefined>;
+    workflowComponentDefinitions: Record<string, WorkflowComponentIconDefinitionType | undefined>;
+    workflowTaskDispatcherDefinitions: Record<string, WorkflowComponentIconDefinitionType | undefined>;
 }
 
 const WorkflowComponentsList = ({

--- a/client/src/shared/components/workflow/WorkflowListItemDropdownMenu.tsx
+++ b/client/src/shared/components/workflow/WorkflowListItemDropdownMenu.tsx
@@ -1,0 +1,82 @@
+import Button from '@/components/Button/Button';
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import DeleteWorkflowAlertDialog from '@/shared/components/DeleteWorkflowAlertDialog';
+
+import '@/shared/styles/dropdownMenu.css';
+import {EditIcon, EllipsisVerticalIcon, Trash2Icon} from 'lucide-react';
+import {ReactNode, useState} from 'react';
+
+interface WorkflowListItemDropdownMenuProps {
+    children?: ReactNode;
+    dialogs?: ReactNode;
+    onDelete: () => void;
+    onEditClick: () => void;
+    workflowLabel?: string | null;
+}
+
+const WorkflowListItemDropdownMenu = ({
+    children,
+    dialogs,
+    onDelete,
+    onEditClick,
+    workflowLabel,
+}: WorkflowListItemDropdownMenuProps) => {
+    const [showDeleteWorkflowAlertDialog, setShowDeleteWorkflowAlertDialog] = useState(false);
+
+    const ariaLabel = workflowLabel ? `Workflow actions for ${workflowLabel}` : 'Workflow actions';
+
+    return (
+        <>
+            <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                    <Button
+                        aria-label={ariaLabel}
+                        icon={<EllipsisVerticalIcon />}
+                        onClick={(event) => event.stopPropagation()}
+                        size="icon"
+                        variant="ghost"
+                    />
+                </DropdownMenuTrigger>
+
+                <DropdownMenuContent align="end" className="p-0">
+                    <DropdownMenuItem className="dropdown-menu-item" onClick={onEditClick}>
+                        <EditIcon /> Edit
+                    </DropdownMenuItem>
+
+                    {children}
+
+                    <DropdownMenuSeparator className="m-0" />
+
+                    <DropdownMenuItem
+                        className="dropdown-menu-item-destructive"
+                        onClick={() => setShowDeleteWorkflowAlertDialog(true)}
+                        variant="destructive"
+                    >
+                        <Trash2Icon /> Delete
+                    </DropdownMenuItem>
+                </DropdownMenuContent>
+            </DropdownMenu>
+
+            {showDeleteWorkflowAlertDialog && (
+                <DeleteWorkflowAlertDialog
+                    onClose={() => setShowDeleteWorkflowAlertDialog(false)}
+                    onDelete={() => {
+                        onDelete();
+
+                        setShowDeleteWorkflowAlertDialog(false);
+                    }}
+                />
+            )}
+
+            {dialogs}
+        </>
+    );
+};
+
+export default WorkflowListItemDropdownMenu;

--- a/client/src/shared/components/workflow/tests/WorkflowListItemDropdownMenu.test.tsx
+++ b/client/src/shared/components/workflow/tests/WorkflowListItemDropdownMenu.test.tsx
@@ -1,0 +1,120 @@
+import {DropdownMenuItem} from '@/components/ui/dropdown-menu';
+import WorkflowListItemDropdownMenu from '@/shared/components/workflow/WorkflowListItemDropdownMenu';
+import {render, resetAll, screen, userEvent, windowResizeObserver} from '@/shared/util/test-utils';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+
+const renderMenu = (overrides: {dialogs?: React.ReactNode; onDelete?: () => void; onEditClick?: () => void} = {}) => {
+    const onDelete = overrides.onDelete ?? vi.fn();
+    const onEditClick = overrides.onEditClick ?? vi.fn();
+
+    render(
+        <WorkflowListItemDropdownMenu
+            dialogs={overrides.dialogs}
+            onDelete={onDelete}
+            onEditClick={onEditClick}
+            workflowLabel="Workflow One"
+        >
+            <DropdownMenuItem>Export</DropdownMenuItem>
+        </WorkflowListItemDropdownMenu>
+    );
+
+    return {onDelete, onEditClick};
+};
+
+const openMenu = async () => {
+    await userEvent.click(screen.getByRole('button', {name: 'Workflow actions for Workflow One'}));
+};
+
+beforeEach(() => {
+    windowResizeObserver();
+});
+
+afterEach(() => {
+    resetAll();
+    vi.clearAllMocks();
+});
+
+describe('WorkflowListItemDropdownMenu', () => {
+    it('labels the trigger with the workflow label', () => {
+        renderMenu();
+
+        expect(screen.getByRole('button', {name: 'Workflow actions for Workflow One'})).toBeInTheDocument();
+    });
+
+    it('opens with Edit, then the surface items, then Delete', async () => {
+        renderMenu();
+
+        await openMenu();
+
+        const menuItems = screen.getAllByRole('menuitem');
+
+        expect(menuItems.map((menuItem) => menuItem.textContent?.trim())).toEqual(['Edit', 'Export', 'Delete']);
+    });
+
+    it('calls onEditClick when Edit is chosen', async () => {
+        const {onEditClick} = renderMenu();
+
+        await openMenu();
+        await userEvent.click(screen.getByRole('menuitem', {name: 'Edit'}));
+
+        expect(onEditClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('confirms before deleting', async () => {
+        const {onDelete} = renderMenu();
+
+        await openMenu();
+        await userEvent.click(screen.getByRole('menuitem', {name: 'Delete'}));
+
+        expect(screen.getByText('Are you absolutely sure?')).toBeInTheDocument();
+        expect(onDelete).not.toHaveBeenCalled();
+
+        await userEvent.click(screen.getByRole('button', {name: 'Delete'}));
+
+        expect(onDelete).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not delete when the confirmation is cancelled', async () => {
+        const {onDelete} = renderMenu();
+
+        await openMenu();
+        await userEvent.click(screen.getByRole('menuitem', {name: 'Delete'}));
+        await userEvent.click(screen.getByRole('button', {name: 'Cancel'}));
+
+        expect(onDelete).not.toHaveBeenCalled();
+        expect(screen.queryByText('Are you absolutely sure?')).not.toBeInTheDocument();
+    });
+
+    it('keeps a click on the trigger off the surrounding card', async () => {
+        const handleCardClick = vi.fn();
+
+        render(
+            <li onClick={handleCardClick}>
+                <WorkflowListItemDropdownMenu onDelete={vi.fn()} onEditClick={vi.fn()} workflowLabel="Workflow Two" />
+            </li>
+        );
+
+        await userEvent.click(screen.getByRole('button', {name: 'Workflow actions for Workflow Two'}));
+
+        expect(handleCardClick).not.toHaveBeenCalled();
+    });
+
+    it('falls back to a generic label when the workflow has none', () => {
+        render(<WorkflowListItemDropdownMenu onDelete={vi.fn()} onEditClick={vi.fn()} />);
+
+        expect(screen.getByRole('button', {name: 'Workflow actions'})).toBeInTheDocument();
+    });
+
+    it('renders the caller dialogs', () => {
+        render(
+            <WorkflowListItemDropdownMenu
+                dialogs={<span>Caller dialog</span>}
+                onDelete={vi.fn()}
+                onEditClick={vi.fn()}
+                workflowLabel="Workflow Two"
+            />
+        );
+
+        expect(screen.getByText('Caller dialog')).toBeInTheDocument();
+    });
+});

--- a/client/src/shared/middleware/graphql.ts
+++ b/client/src/shared/middleware/graphql.ts
@@ -1132,6 +1132,15 @@ export type ToolEligibleIntegrationVersionWorkflowsQueryVariables = Exact<{
 
 export type ToolEligibleIntegrationVersionWorkflowsQuery = { toolEligibleIntegrationVersionWorkflows: Array<{ id: string, integrationWorkflowId: string, label: string }> };
 
+export type UpdateAutomationWorkflowProjectWorkflowMutationVariables = Exact<{
+  workflowUuid: string | number;
+  label: string;
+  description?: string | null | undefined;
+}>;
+
+
+export type UpdateAutomationWorkflowProjectWorkflowMutation = { updateAutomationWorkflowProjectWorkflow: boolean };
+
 export type UpdateMcpIntegrationInstanceConfigurationMutationVariables = Exact<{
   id: string | number;
   input: Types.UpdateMcpIntegrationInstanceConfigurationInput;
@@ -5889,6 +5898,29 @@ export const useToolEligibleIntegrationVersionWorkflowsQuery = <
       {
     queryKey: ['toolEligibleIntegrationVersionWorkflows', variables],
     queryFn: fetcher<ToolEligibleIntegrationVersionWorkflowsQuery, ToolEligibleIntegrationVersionWorkflowsQueryVariables>(ToolEligibleIntegrationVersionWorkflowsDocument, variables),
+    ...options
+  }
+    )};
+
+export const UpdateAutomationWorkflowProjectWorkflowDocument = new TypedDocumentString(`
+    mutation updateAutomationWorkflowProjectWorkflow($workflowUuid: ID!, $label: String!, $description: String) {
+  updateAutomationWorkflowProjectWorkflow(
+    workflowUuid: $workflowUuid
+    label: $label
+    description: $description
+  )
+}
+    `);
+
+export const useUpdateAutomationWorkflowProjectWorkflowMutation = <
+      TError = unknown,
+      TContext = unknown
+    >(options?: UseMutationOptions<UpdateAutomationWorkflowProjectWorkflowMutation, TError, UpdateAutomationWorkflowProjectWorkflowMutationVariables, TContext>) => {
+    
+    return useMutation<UpdateAutomationWorkflowProjectWorkflowMutation, TError, UpdateAutomationWorkflowProjectWorkflowMutationVariables, TContext>(
+      {
+    mutationKey: ['updateAutomationWorkflowProjectWorkflow'],
+    mutationFn: (variables?: UpdateAutomationWorkflowProjectWorkflowMutationVariables) => fetcher<UpdateAutomationWorkflowProjectWorkflowMutation, UpdateAutomationWorkflowProjectWorkflowMutationVariables>(UpdateAutomationWorkflowProjectWorkflowDocument, variables)(),
     ...options
   }
     )};

--- a/client/src/shared/middleware/graphql.ts
+++ b/client/src/shared/middleware/graphql.ts
@@ -465,7 +465,7 @@ export type McpProjectWorkflowPropertiesQuery = { mcpProjectWorkflowProperties: 
     | { advancedOption: boolean | null, description: string | null, displayCondition: string | null, expressionEnabled: boolean | null, hidden: boolean | null, name: string | null, required: boolean | null, type: Types.PropertyType }
     | { controlType: Types.ControlType, label: string | null, placeholder: string | null, advancedOption: boolean | null, description: string | null, displayCondition: string | null, expressionEnabled: boolean | null, hidden: boolean | null, name: string | null, required: boolean | null, type: Types.PropertyType, numberDefaultValue: number | null }
     | { controlType: Types.ControlType, label: string | null, placeholder: string | null, advancedOption: boolean | null, description: string | null, displayCondition: string | null, expressionEnabled: boolean | null, hidden: boolean | null, name: string | null, required: boolean | null, type: Types.PropertyType, objectDefaultValue: any }
-    | { controlType: Types.ControlType, defaultValue: string | null, label: string | null, placeholder: string | null, advancedOption: boolean | null, description: string | null, displayCondition: string | null, expressionEnabled: boolean | null, hidden: boolean | null, name: string | null, required: boolean | null, type: Types.PropertyType }
+    | { controlType: Types.ControlType, defaultValue: string | null, label: string | null, maxLength: number | null, minLength: number | null, placeholder: string | null, regex: string | null, advancedOption: boolean | null, description: string | null, displayCondition: string | null, expressionEnabled: boolean | null, hidden: boolean | null, name: string | null, required: boolean | null, type: Types.PropertyType }
     | { advancedOption: boolean | null, description: string | null, displayCondition: string | null, expressionEnabled: boolean | null, hidden: boolean | null, name: string | null, required: boolean | null, type: Types.PropertyType }
    | null> | null };
 
@@ -1101,7 +1101,7 @@ export type McpIntegrationInstanceConfigurationWorkflowPropertiesQuery = { mcpIn
     | { advancedOption: boolean | null, description: string | null, displayCondition: string | null, expressionEnabled: boolean | null, hidden: boolean | null, name: string | null, required: boolean | null, type: Types.PropertyType }
     | { controlType: Types.ControlType, label: string | null, placeholder: string | null, advancedOption: boolean | null, description: string | null, displayCondition: string | null, expressionEnabled: boolean | null, hidden: boolean | null, name: string | null, required: boolean | null, type: Types.PropertyType, numberDefaultValue: number | null }
     | { controlType: Types.ControlType, label: string | null, placeholder: string | null, advancedOption: boolean | null, description: string | null, displayCondition: string | null, expressionEnabled: boolean | null, hidden: boolean | null, name: string | null, required: boolean | null, type: Types.PropertyType, objectDefaultValue: any }
-    | { controlType: Types.ControlType, defaultValue: string | null, label: string | null, placeholder: string | null, advancedOption: boolean | null, description: string | null, displayCondition: string | null, expressionEnabled: boolean | null, hidden: boolean | null, name: string | null, required: boolean | null, type: Types.PropertyType }
+    | { controlType: Types.ControlType, defaultValue: string | null, label: string | null, maxLength: number | null, minLength: number | null, placeholder: string | null, regex: string | null, advancedOption: boolean | null, description: string | null, displayCondition: string | null, expressionEnabled: boolean | null, hidden: boolean | null, name: string | null, required: boolean | null, type: Types.PropertyType }
     | { advancedOption: boolean | null, description: string | null, displayCondition: string | null, expressionEnabled: boolean | null, hidden: boolean | null, name: string | null, required: boolean | null, type: Types.PropertyType }
    | null> | null };
 
@@ -3375,7 +3375,10 @@ export const McpProjectWorkflowPropertiesDocument = new TypedDocumentString(`
       controlType
       defaultValue
       label
+      maxLength
+      minLength
       placeholder
+      regex
     }
     ... on IntegerProperty {
       controlType
@@ -5701,7 +5704,10 @@ export const McpIntegrationInstanceConfigurationWorkflowPropertiesDocument = new
       controlType
       defaultValue
       label
+      maxLength
+      minLength
       placeholder
+      regex
     }
     ... on IntegerProperty {
       controlType

--- a/docs/content/docs/platform/automation/build/workflows/ai/agent/index.mdx
+++ b/docs/content/docs/platform/automation/build/workflows/ai/agent/index.mdx
@@ -106,7 +106,7 @@ The agent rejects configurations with more than one Check For Violations parent 
 
 In the **Tools this agent can use** section, click **+ Add Tool** to expose a workflow component, custom function, or another AI Agent as a callable tool. Each tool's name and description become part of the prompt the model sees, so the model can decide which to invoke.
 
-Every tool offers an optional **Tool Name** and **Tool Description** above its own properties. Left blank, the underlying operation's name and description are used - set them when the default reads poorly to a model, or when two tools would otherwise be hard to tell apart.
+Every tool offers an optional **Tool Name** and **Tool Description** above its own properties. Left blank, the underlying operation's name and description are used - set them when the default reads poorly to a model, or when two tools would otherwise be hard to tell apart. A tool name is limited to 64 characters made up of letters, digits, `_`, `-`, `.` and `/`; anything else, a space included, is rejected as you type.
 
 {/* TODO screenshot: - agent/agent-create-tools.png showing the Tools section with two tools attached. */}
 

--- a/docs/content/docs/platform/automation/deploy/mcp-servers.mdx
+++ b/docs/content/docs/platform/automation/deploy/mcp-servers.mdx
@@ -54,7 +54,7 @@ For each exposed action you decide which parameters you fix yourself (a constant
 1. From the server's row menu, choose **Add Workflows**.
 2. **Select a project** and a **published version**.
 3. **Select the workflows** from that deployment you want to expose.
-4. Complete each workflow's **tool mapping**, from the properties control on its row in the expanded server. The mapping offers a **Tool Name** and a **Tool Description** - both optional, both what the model sees - plus one field per input declared on the workflow's trigger schema. Left blank, the workflow's own name and description are used.
+4. Complete each workflow's **tool mapping**, from the properties control on its row in the expanded server. The mapping offers a **Tool Name** and a **Tool Description** - both optional, both what the model sees - plus one field per input declared on the workflow's trigger schema. Left blank, the workflow's own name and description are used. A tool name is limited to 64 characters made up of letters, digits, `_`, `-`, `.` and `/`; anything else, a space included, is rejected as you type.
 
 Each exposed workflow becomes one tool. Per-input values can be fixed constants or `fromAi(...)` expressions the assistant fills at call time. When the assistant calls the tool, ByteChef runs the workflow with those inputs and returns the result.
 

--- a/server/ee/libs/embedded/embedded-ai/embedded-ai-mcp-graphql/src/main/java/com/bytechef/ee/embedded/ai/mcp/web/graphql/McpIntegrationInstanceConfigurationWorkflowGraphQlController.java
+++ b/server/ee/libs/embedded/embedded-ai/embedded-ai-mcp-graphql/src/main/java/com/bytechef/ee/embedded/ai/mcp/web/graphql/McpIntegrationInstanceConfigurationWorkflowGraphQlController.java
@@ -7,15 +7,10 @@
 
 package com.bytechef.ee.embedded.ai.mcp.web.graphql;
 
-import static com.bytechef.component.definition.ComponentDsl.string;
-import static com.bytechef.platform.ai.tool.constant.ToolConstants.TOOL_DESCRIPTION;
-import static com.bytechef.platform.ai.tool.constant.ToolConstants.TOOL_NAME;
-
 import com.bytechef.atlas.configuration.domain.Workflow;
 import com.bytechef.atlas.configuration.service.WorkflowService;
 import com.bytechef.atlas.coordinator.annotation.ConditionalOnCoordinator;
 import com.bytechef.commons.util.MapUtils;
-import com.bytechef.component.definition.Property.ControlType;
 import com.bytechef.definition.BaseProperty.BaseValueProperty;
 import com.bytechef.ee.embedded.ai.mcp.domain.McpIntegrationInstanceConfigurationWorkflow;
 import com.bytechef.ee.embedded.ai.mcp.facade.McpIntegrationInstanceConfigurationWorkflowFacade;
@@ -26,6 +21,7 @@ import com.bytechef.ee.embedded.configuration.dto.IntegrationWorkflowDTO;
 import com.bytechef.ee.embedded.configuration.service.IntegrationInstanceConfigurationService;
 import com.bytechef.ee.embedded.configuration.service.IntegrationInstanceConfigurationWorkflowService;
 import com.bytechef.ee.embedded.configuration.service.IntegrationWorkflowService;
+import com.bytechef.platform.ai.tool.util.ToolPropertyUtils;
 import com.bytechef.platform.annotation.ConditionalOnEEVersion;
 import com.bytechef.platform.component.constant.WorkflowConstants;
 import com.bytechef.platform.component.definition.PropertyFactory;
@@ -162,26 +158,9 @@ class McpIntegrationInstanceConfigurationWorkflowGraphQlController {
 
         List<Property> properties = new ArrayList<>();
 
-        properties.add(
-            Property.toProperty(
-                string(TOOL_NAME)
-                    .label("Tool Name")
-                    .description(
-                        "The tool name exposed to the AI model. Defaults to the workflow name when left blank.")
-                    .placeholder("Defaults to workflow name")
-                    .expressionEnabled(false)
-                    .required(false)));
+        properties.add(ToolPropertyUtils.toolNameProperty("workflow"));
 
-        properties.add(
-            Property.toProperty(
-                string(TOOL_DESCRIPTION)
-                    .label("Tool Description")
-                    .description(
-                        "The tool description exposed to the AI model. Defaults to the workflow description when left blank.")
-                    .placeholder("Defaults to workflow description")
-                    .controlType(ControlType.TEXT_AREA)
-                    .expressionEnabled(false)
-                    .required(false)));
+        properties.add(ToolPropertyUtils.toolDescriptionProperty("workflow"));
 
         String inputSchema = MapUtils.getString(trigger.getParameters(), WorkflowConstants.INPUT_SCHEMA);
 

--- a/server/ee/libs/embedded/embedded-configuration/embedded-configuration-service/build.gradle.kts
+++ b/server/ee/libs/embedded/embedded-configuration/embedded-configuration-service/build.gradle.kts
@@ -18,6 +18,7 @@ dependencies {
     implementation(project(":server:libs:platform:platform-oauth2:platform-oauth2-api"))
     implementation(project(":server:libs:platform:platform-user:platform-user-api"))
     implementation(project(":server:libs:platform:platform-workflow:platform-workflow-execution:platform-workflow-execution-api"))
+    implementation(project(":server:libs:platform:platform-workflow:platform-workflow-task-dispatcher:platform-workflow-task-dispatcher-api"))
     implementation(project(":server:libs:platform:platform-workflow:platform-workflow-validator:platform-workflow-validator-api"))
 
     implementation(project(":server:libs:ai:ai-copilot:ai-copilot-api"))

--- a/server/ee/libs/embedded/embedded-configuration/embedded-configuration-service/src/main/java/com/bytechef/ee/embedded/configuration/facade/AutomationWorkflowProjectFacadeImpl.java
+++ b/server/ee/libs/embedded/embedded-configuration/embedded-configuration-service/src/main/java/com/bytechef/ee/embedded/configuration/facade/AutomationWorkflowProjectFacadeImpl.java
@@ -39,6 +39,8 @@ import com.bytechef.platform.configuration.service.WorkflowTestConfigurationServ
 import com.bytechef.platform.definition.WorkflowNodeType;
 import com.bytechef.platform.tag.domain.Tag;
 import com.bytechef.platform.tag.service.TagService;
+import com.bytechef.platform.workflow.task.dispatcher.domain.TaskDispatcherDefinition;
+import com.bytechef.platform.workflow.task.dispatcher.service.TaskDispatcherDefinitionService;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -77,6 +79,8 @@ public class AutomationWorkflowProjectFacadeImpl implements AutomationWorkflowPr
         }
         """;
 
+    private static final String MANUAL_COMPONENT_NAME = "manual";
+
     private final CategoryService categoryService;
     private final ComponentDefinitionService componentDefinitionService;
     private final ConnectedUserService connectedUserService;
@@ -85,6 +89,7 @@ public class AutomationWorkflowProjectFacadeImpl implements AutomationWorkflowPr
     private final ProjectWorkflowFacade projectWorkflowFacade;
     private final ProjectWorkflowService projectWorkflowService;
     private final TagService tagService;
+    private final TaskDispatcherDefinitionService taskDispatcherDefinitionService;
     private final WorkflowNodeTestOutputService workflowNodeTestOutputService;
     private final WorkflowService workflowService;
     private final WorkflowTestConfigurationService workflowTestConfigurationService;
@@ -95,6 +100,7 @@ public class AutomationWorkflowProjectFacadeImpl implements AutomationWorkflowPr
         ConnectedUserService connectedUserService, EmbeddedPermissionEvaluator embeddedPermissionEvaluator,
         ProjectService projectService, ProjectWorkflowFacade projectWorkflowFacade,
         ProjectWorkflowService projectWorkflowService, TagService tagService,
+        TaskDispatcherDefinitionService taskDispatcherDefinitionService,
         WorkflowNodeTestOutputService workflowNodeTestOutputService, WorkflowService workflowService,
         WorkflowTestConfigurationService workflowTestConfigurationService) {
 
@@ -106,6 +112,7 @@ public class AutomationWorkflowProjectFacadeImpl implements AutomationWorkflowPr
         this.projectWorkflowFacade = projectWorkflowFacade;
         this.projectWorkflowService = projectWorkflowService;
         this.tagService = tagService;
+        this.taskDispatcherDefinitionService = taskDispatcherDefinitionService;
         this.workflowNodeTestOutputService = workflowNodeTestOutputService;
         this.workflowService = workflowService;
         this.workflowTestConfigurationService = workflowTestConfigurationService;
@@ -403,57 +410,71 @@ public class AutomationWorkflowProjectFacadeImpl implements AutomationWorkflowPr
     }
 
     private List<ConnectedUserWorkflowTemplateDTO.Component> getTaskComponents(Workflow workflow) {
-        Map<String, WorkflowNodeType> componentsByName = new LinkedHashMap<>();
+        Map<String, WorkflowNodeType> workflowNodeTypesByName = new LinkedHashMap<>();
 
         for (WorkflowTask workflowTask : workflow.getTasks(true)) {
             WorkflowNodeType workflowNodeType = WorkflowNodeType.ofType(workflowTask.getType());
 
-            if (workflowNodeType.operation() != null
-                && !componentsByName.containsKey(workflowNodeType.name())) {
-
-                componentsByName.put(workflowNodeType.name(), workflowNodeType);
-            }
+            workflowNodeTypesByName.putIfAbsent(workflowNodeType.name(), workflowNodeType);
         }
 
-        return resolveComponents(componentsByName);
+        return resolveComponents(workflowNodeTypesByName);
     }
 
     private List<ConnectedUserWorkflowTemplateDTO.Component> getTriggerComponents(Workflow workflow) {
-        Map<String, WorkflowNodeType> componentsByName = new LinkedHashMap<>();
+        Map<String, WorkflowNodeType> workflowNodeTypesByName = new LinkedHashMap<>();
 
         for (WorkflowTrigger workflowTrigger : WorkflowTrigger.of(workflow)) {
             WorkflowNodeType workflowNodeType = WorkflowNodeType.ofType(workflowTrigger.getType());
 
-            if (workflowNodeType.operation() != null
-                && !componentsByName.containsKey(workflowNodeType.name())) {
-
-                componentsByName.put(workflowNodeType.name(), workflowNodeType);
-            }
+            workflowNodeTypesByName.putIfAbsent(workflowNodeType.name(), workflowNodeType);
         }
 
-        return resolveComponents(componentsByName);
+        if (workflowNodeTypesByName.isEmpty()) {
+            workflowNodeTypesByName.put(
+                MANUAL_COMPONENT_NAME, new WorkflowNodeType(MANUAL_COMPONENT_NAME, 1, MANUAL_COMPONENT_NAME));
+        }
+
+        return resolveComponents(workflowNodeTypesByName);
     }
 
     private List<ConnectedUserWorkflowTemplateDTO.Component> resolveComponents(
-        Map<String, WorkflowNodeType> componentsByName) {
+        Map<String, WorkflowNodeType> workflowNodeTypesByName) {
 
         List<ConnectedUserWorkflowTemplateDTO.Component> components = new ArrayList<>();
 
-        for (WorkflowNodeType workflowNodeType : componentsByName.values()) {
-            Optional<ComponentDefinition> componentDefinitionOptional =
-                componentDefinitionService.fetchComponentDefinition(
-                    workflowNodeType.name(), workflowNodeType.version());
-
-            if (componentDefinitionOptional.isPresent()) {
-                ComponentDefinition componentDefinition = componentDefinitionOptional.get();
-
-                components.add(
-                    new ConnectedUserWorkflowTemplateDTO.Component(
-                        componentDefinition.getName(), componentDefinition.getTitle(), componentDefinition.getIcon()));
-            }
+        for (WorkflowNodeType workflowNodeType : workflowNodeTypesByName.values()) {
+            components.add(resolveComponent(workflowNodeType));
         }
 
         return components;
+    }
+
+    private ConnectedUserWorkflowTemplateDTO.Component resolveComponent(WorkflowNodeType workflowNodeType) {
+        Optional<ComponentDefinition> componentDefinitionOptional =
+            componentDefinitionService.fetchComponentDefinition(workflowNodeType.name(), workflowNodeType.version());
+
+        if (componentDefinitionOptional.isPresent()) {
+            ComponentDefinition componentDefinition = componentDefinitionOptional.get();
+
+            return new ConnectedUserWorkflowTemplateDTO.Component(
+                componentDefinition.getName(), componentDefinition.getTitle(), componentDefinition.getIcon());
+        }
+
+        Optional<TaskDispatcherDefinition> taskDispatcherDefinitionOptional =
+            taskDispatcherDefinitionService.fetchTaskDispatcherDefinition(
+                workflowNodeType.name(), workflowNodeType.version());
+
+        if (taskDispatcherDefinitionOptional.isPresent()) {
+            TaskDispatcherDefinition taskDispatcherDefinition = taskDispatcherDefinitionOptional.get();
+
+            return new ConnectedUserWorkflowTemplateDTO.Component(
+                taskDispatcherDefinition.getName(), taskDispatcherDefinition.getTitle(),
+                taskDispatcherDefinition.getIcon());
+        }
+
+        return new ConnectedUserWorkflowTemplateDTO.Component(
+            workflowNodeType.name(), workflowNodeType.name(), null);
     }
 
     private Project getMarkedProject(long projectId) {

--- a/server/ee/libs/embedded/embedded-configuration/embedded-configuration-service/src/test/java/com/bytechef/ee/embedded/configuration/config/IntegrationIntTestConfigurationSharedMocks.java
+++ b/server/ee/libs/embedded/embedded-configuration/embedded-configuration-service/src/test/java/com/bytechef/ee/embedded/configuration/config/IntegrationIntTestConfigurationSharedMocks.java
@@ -59,6 +59,7 @@ import com.bytechef.platform.workflow.execution.facade.PrincipalJobFacade;
 import com.bytechef.platform.workflow.execution.facade.TriggerLifecycleFacade;
 import com.bytechef.platform.workflow.execution.service.PrincipalJobService;
 import com.bytechef.platform.workflow.execution.service.TriggerExecutionService;
+import com.bytechef.platform.workflow.task.dispatcher.service.TaskDispatcherDefinitionService;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -78,7 +79,8 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
     PrincipalJobService.class, JobFacade.class, JobService.class, McpComponentService.class,
     McpIntegrationInstanceConfigurationService.class, McpIntegrationInstanceConfigurationWorkflowService.class,
     McpIntegrationInstanceToolService.class, McpServerService.class, McpToolService.class, OAuth2Service.class,
-    TriggerDefinitionService.class, TriggerExecutionService.class, TriggerLifecycleFacade.class,
+    TaskDispatcherDefinitionService.class, TriggerDefinitionService.class, TriggerExecutionService.class,
+    TriggerLifecycleFacade.class,
     ComponentConnectionFacade.class, WorkflowFacade.class, WorkflowNodeParameterFacade.class,
     WorkflowNodeTestOutputService.class, WorkflowTestConfigurationService.class, OAuth2ParametersFacade.class,
     ProjectDeploymentFacade.class, ProjectDeploymentService.class, ProjectDeploymentWorkflowService.class,

--- a/server/ee/libs/embedded/embedded-configuration/embedded-configuration-service/src/test/java/com/bytechef/ee/embedded/configuration/facade/AutomationWorkflowProjectFacadeIntTest.java
+++ b/server/ee/libs/embedded/embedded-configuration/embedded-configuration-service/src/test/java/com/bytechef/ee/embedded/configuration/facade/AutomationWorkflowProjectFacadeIntTest.java
@@ -66,6 +66,7 @@ import com.bytechef.platform.workflow.execution.facade.PrincipalJobFacade;
 import com.bytechef.platform.workflow.execution.facade.TriggerLifecycleFacade;
 import com.bytechef.platform.workflow.execution.service.PrincipalJobService;
 import com.bytechef.platform.workflow.execution.service.TriggerExecutionService;
+import com.bytechef.platform.workflow.task.dispatcher.service.TaskDispatcherDefinitionService;
 import com.bytechef.test.config.testcontainers.PostgreSQLContainerConfiguration;
 import java.util.List;
 import java.util.Map;
@@ -105,7 +106,8 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
     OAuth2ParametersFacade.class,
     OAuth2Service.class, PrincipalJobFacade.class, PrincipalJobService.class, ProjectDeploymentFacade.class,
     ProjectDeploymentService.class, ProjectDeploymentWorkflowService.class, ProjectFacade.class,
-    TaskExecutionService.class, TriggerDefinitionService.class, TriggerExecutionService.class,
+    TaskDispatcherDefinitionService.class, TaskExecutionService.class, TriggerDefinitionService.class,
+    TriggerExecutionService.class,
     TriggerLifecycleFacade.class, UserService.class, WorkflowCacheManager.class,
     WorkflowNodeParameterFacade.class, WorkflowNodeTestOutputService.class,
     WorkflowTestConfigurationFacade.class, WorkflowTestConfigurationService.class,
@@ -374,6 +376,65 @@ public class AutomationWorkflowProjectFacadeIntTest {
             .getFirst();
 
         assertThat(connectedUserWorkflowTemplateDTO.components()).isNotNull();
+    }
+
+    @Test
+    void testWorkflowComponentsIncludeTaskDispatchers() {
+        String workflowDefinitionWithTaskDispatcher = """
+            {
+                "label": "Branching Workflow",
+                "description": "Branches",
+                "inputs": [],
+                "triggers": [],
+                "tasks": [
+                    {
+                        "label": "Check",
+                        "name": "condition_1",
+                        "type": "condition/v1",
+                        "parameters": {}
+                    }
+                ]
+            }
+            """;
+
+        long projectId = automationWorkflowProjectFacade.createProject("BranchCatalog", "", null, List.of(), null);
+
+        automationWorkflowProjectFacade.createProjectWorkflow(projectId, workflowDefinitionWithTaskDispatcher, null);
+
+        AutomationWorkflowProjectDTO project = automationWorkflowProjectFacade.getProject(projectId);
+
+        ConnectedUserWorkflowTemplateDTO workflowTemplate = project.workflowTemplates()
+            .getFirst();
+
+        assertThat(workflowTemplate.components())
+            .extracting(ConnectedUserWorkflowTemplateDTO.Component::name)
+            .containsExactly("condition");
+    }
+
+    @Test
+    void testWorkflowTriggersFallBackToManual() {
+        String workflowDefinitionWithoutTrigger = """
+            {
+                "label": "Manual Workflow",
+                "description": "Runs manually",
+                "inputs": [],
+                "triggers": [],
+                "tasks": []
+            }
+            """;
+
+        long projectId = automationWorkflowProjectFacade.createProject("ManualCatalog", "", null, List.of(), null);
+
+        automationWorkflowProjectFacade.createProjectWorkflow(projectId, workflowDefinitionWithoutTrigger, null);
+
+        AutomationWorkflowProjectDTO project = automationWorkflowProjectFacade.getProject(projectId);
+
+        ConnectedUserWorkflowTemplateDTO workflowTemplate = project.workflowTemplates()
+            .getFirst();
+
+        assertThat(workflowTemplate.triggers())
+            .extracting(ConnectedUserWorkflowTemplateDTO.Component::name)
+            .containsExactly("manual");
     }
 
     @Test

--- a/server/ee/libs/embedded/embedded-configuration/embedded-configuration-service/src/test/java/com/bytechef/ee/embedded/configuration/facade/AutomationWorkflowProjectFacadePermissionFilterTest.java
+++ b/server/ee/libs/embedded/embedded-configuration/embedded-configuration-service/src/test/java/com/bytechef/ee/embedded/configuration/facade/AutomationWorkflowProjectFacadePermissionFilterTest.java
@@ -30,6 +30,7 @@ import com.bytechef.platform.configuration.domain.Environment;
 import com.bytechef.platform.configuration.service.WorkflowNodeTestOutputService;
 import com.bytechef.platform.configuration.service.WorkflowTestConfigurationService;
 import com.bytechef.platform.tag.service.TagService;
+import com.bytechef.platform.workflow.task.dispatcher.service.TaskDispatcherDefinitionService;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -57,6 +58,8 @@ class AutomationWorkflowProjectFacadePermissionFilterTest {
     private final ProjectWorkflowFacade projectWorkflowFacade = mock(ProjectWorkflowFacade.class);
     private final ProjectWorkflowService projectWorkflowService = mock(ProjectWorkflowService.class);
     private final TagService tagService = mock(TagService.class);
+    private final TaskDispatcherDefinitionService taskDispatcherDefinitionService =
+        mock(TaskDispatcherDefinitionService.class);
     private final WorkflowNodeTestOutputService workflowNodeTestOutputService =
         mock(WorkflowNodeTestOutputService.class);
     private final WorkflowService workflowService = mock(WorkflowService.class);
@@ -65,8 +68,8 @@ class AutomationWorkflowProjectFacadePermissionFilterTest {
 
     private final AutomationWorkflowProjectFacadeImpl facade = new AutomationWorkflowProjectFacadeImpl(
         categoryService, componentDefinitionService, connectedUserService, embeddedPermissionEvaluator,
-        projectService, projectWorkflowFacade, projectWorkflowService, tagService, workflowNodeTestOutputService,
-        workflowService, workflowTestConfigurationService);
+        projectService, projectWorkflowFacade, projectWorkflowService, tagService, taskDispatcherDefinitionService,
+        workflowNodeTestOutputService, workflowService, workflowTestConfigurationService);
 
     @Test
     void testGetPublishedProjectsHidesProjectWhenExpressionIsFalse() {

--- a/server/libs/automation/automation-ai/automation-ai-mcp/automation-ai-mcp-graphql/src/main/java/com/bytechef/automation/ai/mcp/web/graphql/McpProjectWorkflowGraphQlController.java
+++ b/server/libs/automation/automation-ai/automation-ai-mcp/automation-ai-mcp-graphql/src/main/java/com/bytechef/automation/ai/mcp/web/graphql/McpProjectWorkflowGraphQlController.java
@@ -16,9 +16,6 @@
 
 package com.bytechef.automation.ai.mcp.web.graphql;
 
-import static com.bytechef.component.definition.ComponentDsl.string;
-import static com.bytechef.platform.ai.tool.constant.ToolConstants.TOOL_DESCRIPTION;
-import static com.bytechef.platform.ai.tool.constant.ToolConstants.TOOL_NAME;
 import static com.bytechef.platform.component.constant.WorkflowConstants.NEW_WORKFLOW_CALL;
 import static com.bytechef.platform.component.constant.WorkflowConstants.WORKFLOW;
 
@@ -33,8 +30,8 @@ import com.bytechef.automation.configuration.domain.ProjectWorkflow;
 import com.bytechef.automation.configuration.service.ProjectDeploymentWorkflowService;
 import com.bytechef.automation.configuration.service.ProjectWorkflowService;
 import com.bytechef.commons.util.MapUtils;
-import com.bytechef.component.definition.Property.ControlType;
 import com.bytechef.definition.BaseProperty.BaseValueProperty;
+import com.bytechef.platform.ai.tool.util.ToolPropertyUtils;
 import com.bytechef.platform.component.constant.WorkflowConstants;
 import com.bytechef.platform.component.definition.PropertyFactory;
 import com.bytechef.platform.component.domain.Property;
@@ -139,26 +136,9 @@ public class McpProjectWorkflowGraphQlController {
 
         List<Property> properties = new ArrayList<>();
 
-        properties.add(
-            Property.toProperty(
-                string(TOOL_NAME)
-                    .label("Tool Name")
-                    .description(
-                        "The tool name exposed to the AI model. Defaults to the workflow name when left blank.")
-                    .placeholder("Defaults to workflow name")
-                    .expressionEnabled(false)
-                    .required(false)));
+        properties.add(ToolPropertyUtils.toolNameProperty("workflow"));
 
-        properties.add(
-            Property.toProperty(
-                string(TOOL_DESCRIPTION)
-                    .label("Tool Description")
-                    .description(
-                        "The tool description exposed to the AI model. Defaults to the workflow description when left blank.")
-                    .placeholder("Defaults to workflow description")
-                    .controlType(ControlType.TEXT_AREA)
-                    .expressionEnabled(false)
-                    .required(false)));
+        properties.add(ToolPropertyUtils.toolDescriptionProperty("workflow"));
 
         String inputSchema = MapUtils.getString(trigger.getParameters(), WorkflowConstants.INPUT_SCHEMA);
 

--- a/server/libs/platform/platform-ai/platform-ai-api/src/main/java/com/bytechef/platform/ai/tool/util/ToolPropertyUtils.java
+++ b/server/libs/platform/platform-ai/platform-ai-api/src/main/java/com/bytechef/platform/ai/tool/util/ToolPropertyUtils.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2025 ByteChef
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.bytechef.platform.ai.tool.util;
+
+import static com.bytechef.component.definition.ComponentDsl.string;
+
+import com.bytechef.component.definition.Property.ControlType;
+import com.bytechef.platform.ai.tool.constant.ToolConstants;
+import com.bytechef.platform.component.domain.Property;
+
+/**
+ * @author Ivica Cardic
+ */
+public class ToolPropertyUtils {
+
+    private static final int TOOL_NAME_MAX_LENGTH = 64;
+
+    private static final String TOOL_NAME_DISALLOWED_CHARACTERS_REGEX = "[^A-Za-z0-9_./-]";
+
+    public static Property toolNameProperty(String defaultSourceName) {
+        return Property.toProperty(
+            string(ToolConstants.TOOL_NAME)
+                .label("Tool Name")
+                .description(
+                    "The tool name exposed to the AI model. Defaults to the " + defaultSourceName +
+                        " name when left blank. Up to " + TOOL_NAME_MAX_LENGTH +
+                        " characters, limited to letters, digits, '_', '-', '.' and '/'.")
+                .placeholder("Defaults to " + defaultSourceName + " name")
+                .expressionEnabled(false)
+                .maxLength(TOOL_NAME_MAX_LENGTH)
+                .regex(TOOL_NAME_DISALLOWED_CHARACTERS_REGEX)
+                .required(false));
+    }
+
+    public static Property toolDescriptionProperty(String defaultSourceName) {
+        return Property.toProperty(
+            string(ToolConstants.TOOL_DESCRIPTION)
+                .label("Tool Description")
+                .description(
+                    "The tool description exposed to the AI model. Defaults to the " + defaultSourceName +
+                        " description when left blank.")
+                .placeholder("Defaults to " + defaultSourceName + " description")
+                .controlType(ControlType.TEXT_AREA)
+                .expressionEnabled(false)
+                .required(false));
+    }
+}

--- a/server/libs/platform/platform-component/platform-component-service/src/main/java/com/bytechef/platform/component/service/ClusterElementDefinitionServiceImpl.java
+++ b/server/libs/platform/platform-component/platform-component-service/src/main/java/com/bytechef/platform/component/service/ClusterElementDefinitionServiceImpl.java
@@ -16,8 +16,6 @@
 
 package com.bytechef.platform.component.service;
 
-import static com.bytechef.component.definition.ComponentDsl.string;
-import static com.bytechef.component.definition.Property.ControlType.TEXT_AREA;
 import static com.bytechef.component.definition.ai.agent.BaseToolFunction.TOOLS;
 
 import com.bytechef.commons.util.CollectionUtils;
@@ -42,6 +40,7 @@ import com.bytechef.definition.BaseOutputDefinition;
 import com.bytechef.exception.ConfigurationException;
 import com.bytechef.exception.ExecutionException;
 import com.bytechef.platform.ai.tool.constant.ToolConstants;
+import com.bytechef.platform.ai.tool.util.ToolPropertyUtils;
 import com.bytechef.platform.component.ComponentConnection;
 import com.bytechef.platform.component.ComponentDefinitionRegistry;
 import com.bytechef.platform.component.annotation.WithTokenRefresh;
@@ -78,23 +77,9 @@ import org.springframework.stereotype.Service;
 @Service("clusterElementDefinitionService")
 public class ClusterElementDefinitionServiceImpl implements ClusterElementDefinitionService {
 
-    private static final Property TOOL_NAME_PROPERTY = Property.toProperty(
-        string(ToolConstants.TOOL_NAME)
-            .label("Tool Name")
-            .description("The tool name exposed to the AI model. Defaults to the tool name when left blank.")
-            .placeholder("Defaults to tool name")
-            .expressionEnabled(false)
-            .required(false));
+    private static final Property TOOL_NAME_PROPERTY = ToolPropertyUtils.toolNameProperty("tool");
 
-    private static final Property TOOL_DESCRIPTION_PROPERTY = Property.toProperty(
-        string(ToolConstants.TOOL_DESCRIPTION)
-            .label("Tool Description")
-            .description(
-                "The tool description exposed to the AI model. Defaults to the tool description when left blank.")
-            .placeholder("Defaults to tool description")
-            .controlType(TEXT_AREA)
-            .expressionEnabled(false)
-            .required(false));
+    private static final Property TOOL_DESCRIPTION_PROPERTY = ToolPropertyUtils.toolDescriptionProperty("tool");
 
     private final ComponentDefinitionRegistry componentDefinitionRegistry;
     private final ContextFactory contextFactory;


### PR DESCRIPTION
Workflow editor and embedded list polish, one commit per ticket.

| Commit | Ticket | Change |
|---|---|---|
| `5693` | #5693 | A per-item actions menu on the workflow cards in all three editor sidebars |
| `5694` | #5694 | The `+ Workflow` split button on the embedded integration card |
| `5695` | #5695 | A newly created integration or embedded project expands its workflow list |
| `5696` | #5696 | The canvas island gets the same border as the test output panel |
| `5697` | #5697 | A reset control in the Playground header |
| `5699` | #5699 | Tool name validated against the MCP tool-name rules |
| `5700` | #5700 | The test output island shows when the bottom panel opens before a run |

### Notes

**#5693** — each sidebar mirrors its own header's Workflow tab, so no surface gains an action it did not already have: automation gets Edit / Duplicate / Share / Share with Community (`ff-2939`) / Export / Delete, embedded integration gets Edit / Export / Delete, and the embedded automation-workflow sidebar gets Edit / Duplicate / Delete.

Dialog state is local to each menu rather than the global `useWorkflowEditorStore.showEditWorkflowDialog` flag the header uses, which would open every card's dialog at once. Deleting the currently open workflow navigates to the first remaining one; deleting any other just refreshes the list. The `project` / `integration` prop is optional and the menu renders only once it resolves, so the workflow list still renders while the workspace projects query is in flight.

The embedded automation-workflow sidebar's Edit uses `updateAutomationWorkflowProjectWorkflow`, which already existed in the schema and controller but had no client operation; the new `.graphql` document and its regenerated hook are included. Export is omitted on that surface — `AutomationWorkflowProjectWorkflowTemplate` exposes only `workflowUuid`, and the export endpoint needs the REST workflow id.

**#5699** — `StringProperty` already carried `minLength` / `maxLength` / `regex` and the client already validated all three; only the property definitions were missing them. Note the regex polarity in `useProperty.ts`: a **match means invalid**, so the rule is expressed as the disallowed set `[^A-Za-z0-9_./-]`. `minLength` is deliberately not set — an empty value is the documented "defaults to the workflow name" case.

**#5700** — `WorkflowExecutionsTestOutput` already renders a `Test Output` header and "The workflow has not yet been executed."; the four editor pages wrapped it in a `workflowIsRunning || workflowTestExecution` guard that made that empty state unreachable.

#5698 (Playground composer and suggestions layout) is **not** in this PR — `components/assistant-ui/thread.tsx` is vendored and shared by four panels, so it is not a Playground-local change. See the comment on that ticket.

### Verification

- `npm run check` — 433 test files, 4275 tests, lint and typecheck clean
- `npm run format` and `./gradlew spotlessApply`
- `compileJava` on the three touched server modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)
