### PR TITLE
5693 client - Align the workflow actions menu with the sidebar card edge

### DIFF
--- a/client/src/ee/pages/embedded/automation-workflow/components/automation-workflow-editor/AutomationWorkflowEditorLeftSidebar.tsx
+++ b/client/src/ee/pages/embedded/automation-workflow/components/automation-workflow-editor/AutomationWorkflowEditorLeftSidebar.tsx
@@ -206,7 +206,7 @@ const AutomationWorkflowEditorLeftSidebar = ({currentWorkflowId}: AutomationWork
                 )}
 
                 {!projectsIsLoading && selectedProject && filteredAndSortedWorkflows.length > 0 && (
-                    <ul className="flex flex-col items-center gap-4">
+                    <ul className="flex flex-col gap-4">
                         {filteredAndSortedWorkflows.map((workflow) => (
                             <AutomationWorkflowEditorWorkflowsListItem
                                 currentWorkflowId={currentWorkflowId}

--- a/client/src/ee/pages/embedded/automation-workflow/components/automation-workflow-editor/components/AutomationWorkflowEditorWorkflowsListItem.tsx
+++ b/client/src/ee/pages/embedded/automation-workflow/components/automation-workflow-editor/components/AutomationWorkflowEditorWorkflowsListItem.tsx
@@ -56,7 +56,7 @@ const AutomationWorkflowEditorWorkflowsListItem = ({
     return (
         <li
             className={twMerge(
-                'w-80 cursor-pointer self-start rounded-md border border-transparent p-3 hover:bg-background',
+                'w-full cursor-pointer rounded-md border border-transparent py-3 pr-1 pl-3 hover:bg-background',
                 workflow.workflowUuid === currentWorkflowId && 'border-stroke-brand-primary bg-background'
             )}
             onClick={handleCardClick}

--- a/client/src/ee/pages/embedded/integration/components/integrations-sidebar/IntegrationsLeftSidebar.tsx
+++ b/client/src/ee/pages/embedded/integration/components/integrations-sidebar/IntegrationsLeftSidebar.tsx
@@ -175,7 +175,7 @@ const IntegrationsLeftSidebar = ({
                 {isLoading && <IntegrationWorkflowsListSkeleton />}
 
                 {!isLoading && (
-                    <ul className="flex flex-col items-center gap-4">
+                    <ul className="flex flex-col gap-4">
                         {selectedIntegrationId === 0 &&
                             (integrations ? (
                                 integrations.map((integration) => (

--- a/client/src/ee/pages/embedded/integration/components/integrations-sidebar/components/IntegrationWorkflowsList.tsx
+++ b/client/src/ee/pages/embedded/integration/components/integrations-sidebar/components/IntegrationWorkflowsList.tsx
@@ -39,7 +39,7 @@ const IntegrationWorkflowsList = ({
     return (
         <Fragment key={integration.id}>
             <li className="max-w-full pb-2 last:pb-0">
-                <div className="flex w-80 items-center justify-between">
+                <div className="flex w-full items-center justify-between">
                     <Tooltip>
                         <TooltipTrigger asChild>
                             <span className="inline-block w-56 truncate overflow-hidden rounded-md px-1 py-2 text-lg font-medium">
@@ -71,7 +71,7 @@ const IntegrationWorkflowsList = ({
                     )}
                 </div>
 
-                <ul className="flex flex-col items-center gap-2">
+                <ul className="flex flex-col gap-2">
                     {integrationWorkflows.map((workflow) => (
                         <IntegrationWorkflowsListItem
                             calculateTimeDifference={calculateTimeDifference}

--- a/client/src/ee/pages/embedded/integration/components/integrations-sidebar/components/IntegrationWorkflowsListItem.tsx
+++ b/client/src/ee/pages/embedded/integration/components/integrations-sidebar/components/IntegrationWorkflowsListItem.tsx
@@ -79,7 +79,7 @@ const IntegrationWorkflowsListItem = ({
     return (
         <li
             className={twMerge(
-                'w-80 cursor-pointer self-start rounded-md border border-transparent p-3 hover:bg-background',
+                'w-full cursor-pointer rounded-md border border-transparent py-3 pr-1 pl-3 hover:bg-background',
                 workflow.id === currentWorkflowId && 'border-stroke-brand-primary bg-background'
             )}
             key={workflow.id}

--- a/client/src/ee/pages/embedded/integration/components/integrations-sidebar/components/IntegrationWorkflowsListSkeleton.tsx
+++ b/client/src/ee/pages/embedded/integration/components/integrations-sidebar/components/IntegrationWorkflowsListSkeleton.tsx
@@ -2,8 +2,8 @@ import {Skeleton} from '@/components/ui/skeleton';
 
 const IntegrationWorkflowsListSkeleton = () => {
     return (
-        <ul className="flex flex-col items-center gap-4 pt-4">
-            <li className="flex w-80 flex-col gap-1">
+        <ul className="flex flex-col gap-4 pt-4">
+            <li className="flex w-full flex-col gap-1">
                 <Skeleton className="mb-1 size-5 rounded-full" />
 
                 <Skeleton className="h-6 w-full" />
@@ -11,7 +11,7 @@ const IntegrationWorkflowsListSkeleton = () => {
                 <Skeleton className="h-6 w-1/2" />
             </li>
 
-            <li className="flex w-80 flex-col gap-1">
+            <li className="flex w-full flex-col gap-1">
                 <Skeleton className="mb-1 size-5 rounded-full" />
 
                 <Skeleton className="h-6 w-full" />

--- a/client/src/pages/automation/project/components/projects-sidebar/ProjectsLeftSidebar.tsx
+++ b/client/src/pages/automation/project/components/projects-sidebar/ProjectsLeftSidebar.tsx
@@ -298,7 +298,7 @@ const ProjectsLeftSidebar = ({
                 {isLoading && <WorkflowsListSkeleton />}
 
                 {!isLoading && (
-                    <ul className="flex flex-col items-center gap-4">
+                    <ul className="flex flex-col gap-4">
                         {selectedProjectId === 0 &&
                             (projects ? (
                                 projects.map((project) => (

--- a/client/src/pages/automation/project/components/projects-sidebar/components/ProjectWorkflowsList.tsx
+++ b/client/src/pages/automation/project/components/projects-sidebar/components/ProjectWorkflowsList.tsx
@@ -39,7 +39,7 @@ const ProjectWorkflowsList = ({
     return (
         <Fragment key={project.id}>
             <li className="max-w-full pb-2 last:pb-0">
-                <div className="flex w-80 items-center justify-between">
+                <div className="flex w-full items-center justify-between">
                     <Tooltip>
                         <TooltipTrigger asChild>
                             <span className="inline-block w-56 truncate overflow-hidden rounded-md px-1 py-2 text-lg font-medium">
@@ -71,7 +71,7 @@ const ProjectWorkflowsList = ({
                     )}
                 </div>
 
-                <ul className="flex flex-col items-center gap-2">
+                <ul className="flex flex-col gap-2">
                     {projectWorkflows.map((workflow) => (
                         <WorkflowsListItem
                             calculateTimeDifference={calculateTimeDifference}

--- a/client/src/pages/automation/project/components/projects-sidebar/components/WorkflowsListItem.tsx
+++ b/client/src/pages/automation/project/components/projects-sidebar/components/WorkflowsListItem.tsx
@@ -79,7 +79,7 @@ const WorkflowsListItem = ({
     return (
         <li
             className={twMerge(
-                'w-80 cursor-pointer self-start rounded-md border border-transparent p-3 hover:bg-background',
+                'w-full cursor-pointer rounded-md border border-transparent py-3 pr-1 pl-3 hover:bg-background',
                 workflow.id === currentWorkflowId && 'border-stroke-brand-primary bg-background'
             )}
             key={workflow.id}

--- a/client/src/pages/automation/project/components/projects-sidebar/components/WorkflowsListSkeleton.tsx
+++ b/client/src/pages/automation/project/components/projects-sidebar/components/WorkflowsListSkeleton.tsx
@@ -2,8 +2,8 @@ import {Skeleton} from '@/components/ui/skeleton';
 
 const WorkflowsListSkeleton = () => {
     return (
-        <ul className="flex flex-col items-center gap-4 pt-4">
-            <li className="flex w-80 flex-col gap-1">
+        <ul className="flex flex-col gap-4 pt-4">
+            <li className="flex w-full flex-col gap-1">
                 <div className="mb-3 flex items-center gap-2">
                     <Skeleton className="size-6 rounded-full" />
 
@@ -15,7 +15,7 @@ const WorkflowsListSkeleton = () => {
                 <Skeleton className="h-6 w-1/2" />
             </li>
 
-            <li className="flex w-80 flex-col gap-1">
+            <li className="flex w-full flex-col gap-1">
                 <div className="mb-3 flex items-center gap-2">
                     <Skeleton className="size-6 rounded-full" />
 

--- a/client/src/shared/components/workflow/WorkflowListItemDropdownMenu.tsx
+++ b/client/src/shared/components/workflow/WorkflowListItemDropdownMenu.tsx
@@ -37,6 +37,7 @@ const WorkflowListItemDropdownMenu = ({
                 <DropdownMenuTrigger asChild>
                     <Button
                         aria-label={ariaLabel}
+                        className="-mr-1"
                         icon={<EllipsisVerticalIcon />}
                         onClick={(event) => event.stopPropagation()}
                         size="icon"


### PR DESCRIPTION
The workflow actions menu on the sidebar cards sat well inside the card instead of at its right edge, because the cards were a fixed 320px inside a 355px sidebar and the lists centred them.

- The cards fill the sidebar width, so a card's right edge is the sidebar's content edge.
- The card's right padding is trimmed, and the menu button pulls back part of its own inner padding, so the glyph lines up with the card edge rather than floating inside the button box.
- Same change in the three sidebars that share this layout: automation projects, embedded integrations and the embedded automation workflow editor. The alignment lives in the shared menu component, so the three stay in step.
- The loading skeletons follow the same width, so the list does not shift when it loads.

`npm run check` passes: Prettier, ESLint at zero warnings, typecheck, and 4318 tests with coverage.
