### PR TITLE
5693 client - Narrow the workflow actions menu button on the sidebar cards

### DIFF
--- a/client/src/shared/components/workflow/WorkflowListItemDropdownMenu.tsx
+++ b/client/src/shared/components/workflow/WorkflowListItemDropdownMenu.tsx
@@ -37,7 +37,7 @@ const WorkflowListItemDropdownMenu = ({
                 <DropdownMenuTrigger asChild>
                     <Button
                         aria-label={ariaLabel}
-                        className="-mr-1"
+                        className="-mr-px w-6 px-0"
                         icon={<EllipsisVerticalIcon />}
                         onClick={(event) => event.stopPropagation()}
                         size="icon"


### PR DESCRIPTION
The workflow actions menu button on the sidebar cards was a 36px square with 10px padding on every side, so its hover chip read as a large box next to a narrow glyph.

- The button is 24px wide with no horizontal padding, keeping its 36px height so the click target stays comfortable.
- The negative right margin is trimmed to a single pixel, since the removed padding would otherwise have shifted the dots to the right.

The change is in the shared menu component, so the automation projects, embedded integrations and embedded automation workflow sidebars stay in step.

`npm run check` passes: Prettier, ESLint at zero warnings, typecheck, and the full test suite.
