### PR TITLE
5691 client - Open text area property inputs at the height of a single line input

### DIFF
--- a/client/src/pages/platform/workflow-editor/components/properties/components/PropertyTextArea.test.tsx
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/PropertyTextArea.test.tsx
@@ -58,10 +58,10 @@ describe('PropertyTextArea', () => {
         expect(screen.getByText('*')).toBeInTheDocument();
     });
 
-    it('opens on the shared text area floor', () => {
+    it('opens at the height of a single line input', () => {
         render(<PropertyTextArea error={false} errorMessage="" label="Notes" name="notes" />);
 
-        expect(screen.getByRole('textbox')).toHaveClass('min-h-14');
+        expect(screen.getByRole('textbox')).toHaveClass('min-h-9');
     });
 
     it('renders error state with error icon', () => {

--- a/client/src/pages/platform/workflow-editor/components/properties/components/PropertyTextArea.tsx
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/PropertyTextArea.tsx
@@ -88,7 +88,7 @@ const PropertyTextArea = forwardRef<HTMLTextAreaElement, PropertyTextAreaProps>(
 
                     <Textarea
                         className={twMerge(
-                            'min-h-14',
+                            'min-h-9',
                             error &&
                                 'border-stroke-destructive-secondary pr-10 text-rose-900 placeholder-stroke-destructive-secondary focus:border-rose-500 focus:ring-rose-500',
                             disabled && 'bg-gray-100 text-content-neutral-secondary',
@@ -102,7 +102,7 @@ const PropertyTextArea = forwardRef<HTMLTextAreaElement, PropertyTextAreaProps>(
                         onChange={onChange}
                         placeholder={placeholder}
                         ref={ref}
-                        rows={5}
+                        rows={1}
                         value={value}
                         {...props}
                     />

--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/PropertyMentionsInput.tsx
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/PropertyMentionsInput.tsx
@@ -298,7 +298,6 @@ const PropertyMentionsInput = forwardRef<Editor, PropertyMentionsInputProps>(
                             // Data pill chips size themselves, so the editor's own text-xs does not
                             // reach them. The modifier lets the stylesheet bring them down to match.
                             isFormulaMode && 'property-mentions-editor--formula-mode',
-                            controlType === 'TEXT_AREA' && !isFormulaMode && 'min-h-14',
                             leadingIcon && 'border-0 pr-0.5 pl-10',
                             className
                         )}

--- a/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/tests/textAreaMentionsInputHeight.test.tsx
+++ b/client/src/pages/platform/workflow-editor/components/properties/components/property-mentions-input/tests/textAreaMentionsInputHeight.test.tsx
@@ -13,8 +13,8 @@ import {beforeEach, describe, expect, it, vi} from 'vitest';
 import PropertyMentionsInput from '../PropertyMentionsInput';
 
 /**
- * A TEXT_AREA property renders as a mentions input outside a form, and as a text area inside one. Both sit on
- * the same min-h-14 floor, so the same property looks like the same control on either surface.
+ * A TEXT_AREA property renders as a mentions input outside a form, and as a text area inside one. Both open at
+ * the height of a single line input and grow with their content.
  */
 
 const renderInput = (controlType: ControlType, isFormulaMode = false) =>
@@ -44,21 +44,22 @@ describe('text area mentions input height', () => {
         } as unknown as Partial<ReturnType<typeof useWorkflowNodeDetailsPanelStore.getState>>);
     });
 
-    it('opens a text area taller than a single row', () => {
+    it('opens a text area at the height of a single line input', () => {
         const {container} = renderInput('TEXT_AREA');
 
-        expect(getEditorContainer(container)).toHaveClass('min-h-14');
+        expect(getEditorContainer(container)).toHaveClass('min-h-9');
     });
 
-    it('leaves a plain text property one row tall', () => {
+    it('opens a plain text property at the same height', () => {
         const {container} = renderInput('TEXT');
 
-        expect(getEditorContainer(container)).not.toHaveClass('min-h-14');
+        expect(getEditorContainer(container)).toHaveClass('min-h-9');
     });
 
-    it('keeps a text area in formula mode one row tall', () => {
-        const {container} = renderInput('TEXT_AREA', true);
+    it('grows with its content instead of reserving rows', () => {
+        const {container} = renderInput('TEXT_AREA');
 
         expect(getEditorContainer(container)).not.toHaveClass('min-h-14');
+        expect(getEditorContainer(container)).not.toHaveClass('min-h-16');
     });
 });


### PR DESCRIPTION
A text area property opened much taller than the input above it: the mentions editor reserved a two line floor and the plain text area reserved five rows.

- Both now open at the height of a single line input, the same `min-h-9` the text inputs use, so a form reads as one column of controls at rest.
- Both grow with their content. The mentions editor is content editable and grows as its text wraps; the text area relies on the `field-sizing-content` its primitive already carries, so it gains a line as you type instead of reserving rows up front.

The height tests are updated to state the new behaviour on both surfaces.

`npm run check` passes: Prettier, ESLint at zero warnings, typecheck, and the full test suite.
