### PR TITLE
5594 Remove the duplicate filterLatestVersions method that broke the build

### DIFF
--- a/server/libs/platform/platform-component/platform-component-service/src/main/java/com/bytechef/platform/component/service/ComponentDefinitionServiceImpl.java
+++ b/server/libs/platform/platform-component/platform-component-service/src/main/java/com/bytechef/platform/component/service/ComponentDefinitionServiceImpl.java
@@ -251,18 +251,6 @@ public class ComponentDefinitionServiceImpl implements ComponentDefinitionServic
         return componentDefinitionRegistry.hasComponentDefinition(name, version);
     }
 
-    private static List<ComponentDefinition> filterLatestVersions(List<ComponentDefinition> componentDefinitions) {
-        Map<String, ComponentDefinition> latestComponentDefinitions = new LinkedHashMap<>();
-
-        for (ComponentDefinition componentDefinition : componentDefinitions) {
-            latestComponentDefinitions.merge(
-                componentDefinition.getName(), componentDefinition,
-                (first, second) -> first.getVersion() >= second.getVersion() ? first : second);
-        }
-
-        return List.copyOf(latestComponentDefinitions.values());
-    }
-
     private static Predicate<ComponentDefinition> filter(
         @Nullable Boolean actionDefinitions, @Nullable Boolean clusterElementDefinitions,
         @Nullable Boolean connectionDefinitions, @Nullable Boolean triggerDefinitions, @Nullable List<String> include) {


### PR DESCRIPTION
`master` does not compile: `ComponentDefinitionServiceImpl` declares `filterLatestVersions` twice, so `:server:libs:platform:platform-component:platform-component-service:compileJava` fails and every pull request's server job fails with it.

The method was added by "5594 List only the latest version of each component definition" and a second copy arrived with "4362 Detect new rows by content instead of position in the v2 New Row triggers", which looks like a rebase duplicating it rather than an intended change.

Both copies do the same thing: they merge component definitions by name into a `LinkedHashMap`, keep the highest version, keep the incumbent on a tie, and return `List.copyOf` of the values. They differ only in style. This removes the copy that used the terse `first`/`second` lambda names and keeps the one whose names follow the repo convention.

Verified: the module compiles again, and its `check` passes (Spotless, Checkstyle, PMD, SpotBugs and 129 tests).
