### PR TITLE
5713 client - Show the workflow trigger apart from the task components in the workflow lists

### DIFF
--- a/client/src/ee/pages/embedded/integration/components/integrations-sidebar/components/IntegrationWorkflowsListItem.tsx
+++ b/client/src/ee/pages/embedded/integration/components/integrations-sidebar/components/IntegrationWorkflowsListItem.tsx
@@ -2,7 +2,7 @@ import {Tooltip, TooltipContent, TooltipTrigger} from '@/components/ui/tooltip';
 import IntegrationWorkflowsListItemDropdownMenu from '@/ee/pages/embedded/integration/components/integrations-sidebar/components/IntegrationWorkflowsListItemDropdownMenu';
 import {Integration, Workflow} from '@/ee/shared/middleware/embedded/configuration';
 import useWorkflowDataStore from '@/pages/platform/workflow-editor/stores/useWorkflowDataStore';
-import WorkflowComponentsList from '@/shared/components/WorkflowComponentsList';
+import WorkflowTriggerAndComponentsRow from '@/shared/components/workflow/WorkflowTriggerAndComponentsRow';
 import {ComponentDefinitionBasic} from '@/shared/middleware/platform/configuration';
 import {MouseEvent, useMemo} from 'react';
 import {twMerge} from 'tailwind-merge';
@@ -87,8 +87,9 @@ const IntegrationWorkflowsListItem = ({
         >
             <div className="flex items-center justify-between gap-2">
                 <div className="flex min-w-0 flex-col gap-3 overflow-hidden">
-                    <WorkflowComponentsList
+                    <WorkflowTriggerAndComponentsRow
                         filteredComponentNames={filteredComponentNames}
+                        workflow={workflow}
                         workflowComponentDefinitions={workflowComponentDefinitions}
                         workflowTaskDispatcherDefinitions={workflowTaskDispatcherDefinitions}
                     />

--- a/client/src/pages/automation/project/components/projects-sidebar/components/WorkflowsListItem.tsx
+++ b/client/src/pages/automation/project/components/projects-sidebar/components/WorkflowsListItem.tsx
@@ -1,7 +1,7 @@
 import {Tooltip, TooltipContent, TooltipTrigger} from '@/components/ui/tooltip';
 import WorkflowsListItemDropdownMenu from '@/pages/automation/project/components/projects-sidebar/components/WorkflowsListItemDropdownMenu';
 import useWorkflowDataStore from '@/pages/platform/workflow-editor/stores/useWorkflowDataStore';
-import WorkflowComponentsList from '@/shared/components/WorkflowComponentsList';
+import WorkflowTriggerAndComponentsRow from '@/shared/components/workflow/WorkflowTriggerAndComponentsRow';
 import {Project, Workflow} from '@/shared/middleware/automation/configuration';
 import {ComponentDefinitionBasic} from '@/shared/middleware/platform/configuration';
 import {MouseEvent, useMemo} from 'react';
@@ -87,8 +87,9 @@ const WorkflowsListItem = ({
         >
             <div className="flex items-center justify-between gap-2">
                 <div className="flex min-w-0 flex-col gap-3 overflow-hidden">
-                    <WorkflowComponentsList
+                    <WorkflowTriggerAndComponentsRow
                         filteredComponentNames={filteredComponentNames}
+                        workflow={workflow}
                         workflowComponentDefinitions={workflowComponentDefinitions}
                         workflowTaskDispatcherDefinitions={workflowTaskDispatcherDefinitions}
                     />

--- a/client/src/pages/automation/project/components/projects-sidebar/tests/WorkflowsListItem.test.tsx
+++ b/client/src/pages/automation/project/components/projects-sidebar/tests/WorkflowsListItem.test.tsx
@@ -75,7 +75,7 @@ it('should not select the workflow when the actions menu is used', async () => {
     expect(mockOnProjectClick).not.toHaveBeenCalled();
 });
 
-it('should render component icons for workflow', () => {
+it('should render the trigger apart from the task component icons', () => {
     const mockWorkflowWithComponents = {
         ...mockWorkflow,
         workflowTaskComponentNames: ['Task1', 'Task2', 'Task3', 'Task4'],
@@ -98,10 +98,10 @@ it('should render component icons for workflow', () => {
         </MemoryRouter>
     );
 
-    expect(screen.getAllByLabelText('Workflow component icon')).toHaveLength(5);
+    expect(screen.getAllByLabelText('Workflow component icon')).toHaveLength(4);
 });
 
-it('should show +X indicator when there are more than 7 components', () => {
+it('should show +X indicator when there are more task components than fit', () => {
     const mockWorkflowWithComponents = {
         ...mockWorkflow,
         workflowTaskComponentNames: ['Task1', 'Task2', 'Task3', 'Task4', 'Task5', 'Task6', 'Task7', 'Task8'],
@@ -124,5 +124,5 @@ it('should show +X indicator when there are more than 7 components', () => {
         </MemoryRouter>
     );
 
-    expect(screen.getByText('+2')).toBeInTheDocument();
+    expect(screen.getByText('+1')).toBeInTheDocument();
 });

--- a/client/src/pages/automation/projects/components/project-workflow-list/ProjectWorkflowListItem.tsx
+++ b/client/src/pages/automation/projects/components/project-workflow-list/ProjectWorkflowListItem.tsx
@@ -1,4 +1,3 @@
-import Badge from '@/components/Badge/Badge';
 import Button from '@/components/Button/Button';
 import {
     DropdownMenu,
@@ -9,8 +8,8 @@ import {
 } from '@/components/ui/dropdown-menu';
 import {Tooltip, TooltipContent, TooltipTrigger} from '@/components/ui/tooltip';
 import {WorkflowShareDialog} from '@/pages/automation/project/components/WorkflowShareDialog';
-import WorkflowComponentsList from '@/shared/components/WorkflowComponentsList';
 import WorkflowDialog from '@/shared/components/workflow/WorkflowDialog';
+import WorkflowTriggerAndComponentsRow from '@/shared/components/workflow/WorkflowTriggerAndComponentsRow';
 import {Project, Workflow} from '@/shared/middleware/automation/configuration';
 import {ComponentDefinitionBasic} from '@/shared/middleware/platform/configuration';
 import {
@@ -25,30 +24,13 @@ import {WorkflowTestConfigurationKeys} from '@/shared/queries/platform/workflowT
 
 import '@/shared/styles/dropdownMenu.css';
 import DeleteWorkflowAlertDialog from '@/shared/components/DeleteWorkflowAlertDialog';
-import {useGetComponentDefinitionQuery} from '@/shared/queries/platform/componentDefinitions.queries';
 import {useApplicationInfoStore} from '@/shared/stores/useApplicationInfoStore';
 import {useFeatureFlagsStore} from '@/shared/stores/useFeatureFlagsStore';
 import {useQueryClient} from '@tanstack/react-query';
-import {
-    ComponentIcon,
-    CopyIcon,
-    DownloadIcon,
-    EditIcon,
-    EllipsisVerticalIcon,
-    Share2Icon,
-    Trash2Icon,
-} from 'lucide-react';
-import {useMemo, useState} from 'react';
-import InlineSVG from 'react-inlinesvg';
+import {CopyIcon, DownloadIcon, EditIcon, EllipsisVerticalIcon, Share2Icon, Trash2Icon} from 'lucide-react';
+import {useState} from 'react';
 import {Link, useSearchParams} from 'react-router-dom';
 import {toast} from 'sonner';
-
-type TriggerDataType = {
-    componentName: string;
-    description: string;
-    iconSrc: string;
-    label: string;
-};
 
 const ProjectWorkflowListItem = ({
     filteredComponentNames,
@@ -78,58 +60,6 @@ const ProjectWorkflowListItem = ({
     const ff_2939 = useFeatureFlagsStore()('ff-2939');
 
     const queryClient = useQueryClient();
-
-    const triggerComponentName = workflow.workflowTriggerComponentNames?.[0];
-    const triggerType = workflow.triggers?.[0]?.type;
-
-    const triggerVersionNumber = triggerType ? +triggerType.split('/')[1].replace('v', '') : 1;
-
-    const {data: triggerComponentDefinition} = useGetComponentDefinitionQuery(
-        {
-            componentName: triggerComponentName || '',
-            componentVersion: triggerVersionNumber,
-        },
-        !!triggerComponentName
-    );
-
-    const triggerData = useMemo<TriggerDataType | null>(() => {
-        if (!triggerComponentName && !workflow.triggers?.[0]) {
-            return null;
-        }
-
-        const triggerFromWorkflow = workflow.triggers?.[0];
-        const triggerDefinition = workflowComponentDefinitions[triggerComponentName || ''];
-
-        const matchedTrigger = triggerComponentDefinition?.triggers?.find(
-            (trigger) => trigger.name === triggerFromWorkflow?.type?.split('/')[2]
-        );
-
-        if (!matchedTrigger && !triggerFromWorkflow) {
-            return null;
-        }
-
-        const description = matchedTrigger?.description || triggerFromWorkflow?.description || '';
-        const label = matchedTrigger?.title || triggerFromWorkflow?.label || '';
-        const componentName = triggerDefinition?.title || triggerComponentName || 'Unknown Trigger';
-        const iconSrc = triggerDefinition?.icon || '';
-
-        return {
-            componentName,
-            description,
-            iconSrc,
-            label,
-        };
-    }, [workflow, workflowComponentDefinitions, triggerComponentName, triggerComponentDefinition]);
-
-    const taskOnlyComponentNames = useMemo(() => {
-        if (!filteredComponentNames) {
-            return [];
-        }
-
-        const triggerCount = workflow.workflowTriggerComponentNames?.length ?? 0;
-
-        return filteredComponentNames.slice(triggerCount);
-    }, [filteredComponentNames, workflow.workflowTriggerComponentNames]);
 
     const deleteWorkflowMutation = useDeleteWorkflowMutation({
         onSuccess: () => {
@@ -205,62 +135,13 @@ const ProjectWorkflowListItem = ({
                     </div>
                 </div>
 
-                <div className="hidden items-center gap-1 sm:flex">
-                    {triggerData && (
-                        <div className="flex shrink-0 items-center gap-1">
-                            <Tooltip>
-                                <TooltipTrigger asChild>
-                                    <div className="flex shrink-0 items-center justify-center rounded-full border border-stroke-neutral-primary bg-surface-neutral-primary p-1">
-                                        {triggerData.iconSrc ? (
-                                            <InlineSVG
-                                                className="size-5"
-                                                loader={<ComponentIcon className="size-5 flex-none" />}
-                                                src={triggerData.iconSrc}
-                                                title={null}
-                                            />
-                                        ) : (
-                                            <ComponentIcon className="size-3 flex-none text-content-neutral-primary" />
-                                        )}
-                                    </div>
-                                </TooltipTrigger>
-
-                                <TooltipContent>{triggerData.componentName}</TooltipContent>
-                            </Tooltip>
-
-                            {triggerData.description ? (
-                                <Tooltip>
-                                    <TooltipTrigger asChild>
-                                        <div className="shrink-0">
-                                            <Badge
-                                                label={triggerData.label || triggerData.componentName}
-                                                styleType="outline-outline"
-                                                weight="semibold"
-                                            />
-                                        </div>
-                                    </TooltipTrigger>
-
-                                    <TooltipContent className="max-w-xs text-sm" side="right">
-                                        {triggerData.description}
-                                    </TooltipContent>
-                                </Tooltip>
-                            ) : (
-                                <div className="shrink-0">
-                                    <Badge
-                                        label={triggerData.label || triggerData.componentName}
-                                        styleType="outline-outline"
-                                        weight="semibold"
-                                    />
-                                </div>
-                            )}
-                        </div>
-                    )}
-
-                    <WorkflowComponentsList
-                        filteredComponentNames={taskOnlyComponentNames}
-                        workflowComponentDefinitions={workflowComponentDefinitions}
-                        workflowTaskDispatcherDefinitions={workflowTaskDispatcherDefinitions}
-                    />
-                </div>
+                <WorkflowTriggerAndComponentsRow
+                    className="hidden sm:flex"
+                    filteredComponentNames={filteredComponentNames}
+                    workflow={workflow}
+                    workflowComponentDefinitions={workflowComponentDefinitions}
+                    workflowTaskDispatcherDefinitions={workflowTaskDispatcherDefinitions}
+                />
             </Link>
 
             <div className="flex justify-end gap-x-6">

--- a/client/src/shared/components/workflow/WorkflowTriggerAndComponentsRow.tsx
+++ b/client/src/shared/components/workflow/WorkflowTriggerAndComponentsRow.tsx
@@ -1,0 +1,144 @@
+import Badge from '@/components/Badge/Badge';
+import {Tooltip, TooltipContent, TooltipTrigger} from '@/components/ui/tooltip';
+import {WorkflowComponentIconDefinitionType} from '@/pages/automation/project/components/projects-sidebar/components/WorkflowComponentsIcon';
+import WorkflowComponentsList from '@/shared/components/WorkflowComponentsList';
+import {useGetComponentDefinitionQuery} from '@/shared/queries/platform/componentDefinitions.queries';
+import {ComponentIcon} from 'lucide-react';
+import {useMemo} from 'react';
+import InlineSVG from 'react-inlinesvg';
+import {twMerge} from 'tailwind-merge';
+
+interface WorkflowTriggerSourceI {
+    triggers?: Array<{description?: string; label?: string; type?: string}>;
+    workflowTriggerComponentNames?: Array<string>;
+}
+
+interface TriggerDataI {
+    componentName: string;
+    description: string;
+    iconSrc: string;
+    label: string;
+}
+
+interface WorkflowTriggerAndComponentsRowProps {
+    className?: string;
+    filteredComponentNames?: string[];
+    maxIcons?: number;
+    workflow: WorkflowTriggerSourceI;
+    workflowComponentDefinitions: Record<string, WorkflowComponentIconDefinitionType | undefined>;
+    workflowTaskDispatcherDefinitions: Record<string, WorkflowComponentIconDefinitionType | undefined>;
+}
+
+const WorkflowTriggerAndComponentsRow = ({
+    className,
+    filteredComponentNames,
+    maxIcons,
+    workflow,
+    workflowComponentDefinitions,
+    workflowTaskDispatcherDefinitions,
+}: WorkflowTriggerAndComponentsRowProps) => {
+    const triggerComponentName = workflow.workflowTriggerComponentNames?.[0];
+    const triggerType = workflow.triggers?.[0]?.type;
+
+    const triggerVersionNumber = triggerType ? +triggerType.split('/')[1].replace('v', '') : 1;
+
+    const {data: triggerComponentDefinition} = useGetComponentDefinitionQuery(
+        {
+            componentName: triggerComponentName || '',
+            componentVersion: triggerVersionNumber,
+        },
+        !!triggerComponentName
+    );
+
+    const triggerData = useMemo<TriggerDataI | null>(() => {
+        if (!triggerComponentName && !workflow.triggers?.[0]) {
+            return null;
+        }
+
+        const triggerFromWorkflow = workflow.triggers?.[0];
+        const triggerDefinition = workflowComponentDefinitions[triggerComponentName || ''];
+
+        const matchedTrigger = triggerComponentDefinition?.triggers?.find(
+            (trigger) => trigger.name === triggerFromWorkflow?.type?.split('/')[2]
+        );
+
+        if (!matchedTrigger && !triggerFromWorkflow) {
+            return null;
+        }
+
+        return {
+            componentName: triggerDefinition?.title || triggerComponentName || 'Unknown Trigger',
+            description: matchedTrigger?.description || triggerFromWorkflow?.description || '',
+            iconSrc: triggerDefinition?.icon || '',
+            label: matchedTrigger?.title || triggerFromWorkflow?.label || '',
+        };
+    }, [workflow, workflowComponentDefinitions, triggerComponentName, triggerComponentDefinition]);
+
+    const taskOnlyComponentNames = useMemo(() => {
+        if (!filteredComponentNames) {
+            return [];
+        }
+
+        const triggerCount = workflow.workflowTriggerComponentNames?.length ?? 0;
+
+        return filteredComponentNames.slice(triggerCount);
+    }, [filteredComponentNames, workflow.workflowTriggerComponentNames]);
+
+    const triggerBadge = (
+        <div className="shrink-0">
+            <Badge
+                label={triggerData?.label || triggerData?.componentName || ''}
+                styleType="outline-outline"
+                weight="semibold"
+            />
+        </div>
+    );
+
+    return (
+        <div className={twMerge('flex items-center gap-1', className)}>
+            {triggerData && (
+                <div className="flex shrink-0 items-center gap-1">
+                    <Tooltip>
+                        <TooltipTrigger asChild>
+                            <div className="flex shrink-0 items-center justify-center rounded-full border border-stroke-neutral-primary bg-surface-neutral-primary p-1">
+                                {triggerData.iconSrc ? (
+                                    <InlineSVG
+                                        className="size-5"
+                                        loader={<ComponentIcon className="size-5 flex-none" />}
+                                        src={triggerData.iconSrc}
+                                        title={null}
+                                    />
+                                ) : (
+                                    <ComponentIcon className="size-3 flex-none text-content-neutral-primary" />
+                                )}
+                            </div>
+                        </TooltipTrigger>
+
+                        <TooltipContent>{triggerData.componentName}</TooltipContent>
+                    </Tooltip>
+
+                    {triggerData.description ? (
+                        <Tooltip>
+                            <TooltipTrigger asChild>{triggerBadge}</TooltipTrigger>
+
+                            <TooltipContent className="max-w-xs text-sm" side="right">
+                                {triggerData.description}
+                            </TooltipContent>
+                        </Tooltip>
+                    ) : (
+                        triggerBadge
+                    )}
+                </div>
+            )}
+
+            <WorkflowComponentsList
+                filteredComponentNames={taskOnlyComponentNames}
+                maxIcons={maxIcons}
+                workflowComponentDefinitions={workflowComponentDefinitions}
+                workflowTaskDispatcherDefinitions={workflowTaskDispatcherDefinitions}
+            />
+        </div>
+    );
+};
+
+export default WorkflowTriggerAndComponentsRow;

--- a/client/src/shared/components/workflow/tests/WorkflowTriggerAndComponentsRow.test.tsx
+++ b/client/src/shared/components/workflow/tests/WorkflowTriggerAndComponentsRow.test.tsx
@@ -1,0 +1,84 @@
+import {TooltipProvider} from '@/components/ui/tooltip';
+import WorkflowTriggerAndComponentsRow from '@/shared/components/workflow/WorkflowTriggerAndComponentsRow';
+import {render, screen} from '@/shared/util/test-utils';
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+
+const {useGetComponentDefinitionQueryMock} = vi.hoisted(() => ({
+    useGetComponentDefinitionQueryMock: vi.fn(),
+}));
+
+vi.mock('@/shared/queries/platform/componentDefinitions.queries', () => ({
+    useGetComponentDefinitionQuery: useGetComponentDefinitionQueryMock,
+}));
+
+const workflowComponentDefinitions = {
+    googleMail: {icon: '<svg />', name: 'googleMail', title: 'Gmail'},
+    openAi: {icon: '<svg />', name: 'openAi', title: 'OpenAI'},
+    slack: {icon: '<svg />', name: 'slack', title: 'Slack'},
+};
+
+const renderRow = (workflow: Parameters<typeof WorkflowTriggerAndComponentsRow>[0]['workflow']) =>
+    render(
+        <TooltipProvider>
+            <WorkflowTriggerAndComponentsRow
+                filteredComponentNames={['googleMail', 'slack', 'openAi']}
+                workflow={workflow}
+                workflowComponentDefinitions={workflowComponentDefinitions}
+                workflowTaskDispatcherDefinitions={{}}
+            />
+        </TooltipProvider>
+    );
+
+describe('WorkflowTriggerAndComponentsRow', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+
+        useGetComponentDefinitionQueryMock.mockReturnValue({data: undefined});
+    });
+
+    it('labels the trigger with the title from its definition', () => {
+        useGetComponentDefinitionQueryMock.mockReturnValue({
+            data: {triggers: [{description: 'Runs when a new email arrives', name: 'newEmail', title: 'New Email'}]},
+        });
+
+        renderRow({
+            triggers: [{type: 'googleMail/v1/newEmail'}],
+            workflowTriggerComponentNames: ['googleMail'],
+        });
+
+        expect(screen.getByText('New Email')).toBeInTheDocument();
+    });
+
+    it('falls back to the workflow trigger label when the definition has no matching trigger', () => {
+        renderRow({
+            triggers: [{label: 'Manual', type: 'manual/v1/manual'}],
+            workflowTriggerComponentNames: ['manual'],
+        });
+
+        expect(screen.getByText('Manual')).toBeInTheDocument();
+    });
+
+    it('names the component when the trigger carries no label of its own', () => {
+        renderRow({
+            triggers: [{type: 'slack/v1/newMessage'}],
+            workflowTriggerComponentNames: ['slack'],
+        });
+
+        expect(screen.getByText('Slack')).toBeInTheDocument();
+    });
+
+    it('leaves the trigger out of the component icons', () => {
+        renderRow({
+            triggers: [{label: 'Manual', type: 'manual/v1/manual'}],
+            workflowTriggerComponentNames: ['manual'],
+        });
+
+        expect(screen.getAllByLabelText('Workflow component icon')).toHaveLength(2);
+    });
+
+    it('renders only the components for a workflow without a trigger', () => {
+        renderRow({triggers: [], workflowTriggerComponentNames: []});
+
+        expect(screen.getAllByLabelText('Workflow component icon')).toHaveLength(3);
+    });
+});


### PR DESCRIPTION
Closes #5713

The same workflow read differently depending on where it was listed. The projects page showed the trigger as its own icon plus a labelled badge, for example `manual`, then the remaining task components as a count. The editor sidebars showed one flat row of component icons that collapses to a single `+N` circle at sidebar width, so the trigger was not identifiable at all.

- The trigger row is now one shared component, `WorkflowTriggerAndComponentsRow`, rather than markup duplicated per list.
- The automation projects sidebar, the embedded integrations sidebar, and the projects page list all render it, so they cannot drift apart again.
- The projects page keeps exactly what it had; its local trigger computation and the markup it fed are gone.

The embedded automation workflow editor sidebar is deliberately untouched. It lists workflow templates whose triggers carry only a name, title and icon, with no type, label or description, so there is nothing to build the badge from.

The sidebar test moves with the behaviour: one trigger and four tasks now render four component icons plus a trigger badge, instead of five icons.

`npm run check` passes: Prettier, ESLint at zero warnings, typecheck, and the full test suite.
