### PR TITLE
5733 Hide the Code Workflow component from the component list

### DIFF
--- a/server/ee/libs/embedded/embedded-configuration/embedded-configuration-service/src/main/java/com/bytechef/ee/embedded/configuration/filter/IntegrationComponentDefinitionFilter.java
+++ b/server/ee/libs/embedded/embedded-configuration/embedded-configuration-service/src/main/java/com/bytechef/ee/embedded/configuration/filter/IntegrationComponentDefinitionFilter.java
@@ -23,7 +23,7 @@ import org.springframework.stereotype.Component;
 @ConditionalOnEEVersion
 public class IntegrationComponentDefinitionFilter implements ComponentDefinitionFilter {
 
-    private static final List<String> COMPONENT_NAMES = List.of("apiPlatform", "webhook");
+    private static final List<String> COMPONENT_NAMES = List.of("apiPlatform", "codeWorkflow", "webhook");
 
     @Override
     public boolean filter(ComponentDefinition componentDefinition) {

--- a/server/libs/automation/automation-configuration/automation-configuration-service/src/main/java/com/bytechef/automation/configuration/filter/ProjectComponentDefinitionFilter.java
+++ b/server/libs/automation/automation-configuration/automation-configuration-service/src/main/java/com/bytechef/automation/configuration/filter/ProjectComponentDefinitionFilter.java
@@ -28,7 +28,8 @@ import org.springframework.stereotype.Component;
 @Component
 public class ProjectComponentDefinitionFilter implements ComponentDefinitionFilter {
 
-    private static final List<String> COMPONENT_NAMES = List.of("appEvent", "embeddedWorkflowBuilder", "request");
+    private static final List<String> COMPONENT_NAMES = List.of(
+        "appEvent", "codeWorkflow", "embeddedWorkflowBuilder", "request");
 
     @Override
     public boolean filter(ComponentDefinition componentDefinition) {


### PR DESCRIPTION
Fixes #5733

## What

Excludes the `codeWorkflow` component from the workflow editor's component list and component search.

Workflow definitions for code workflows are generated internally using the code workflow component, so the component is an implementation detail — it should never be selectable from the palette.

## How

`codeWorkflow` is added to the two `ComponentDefinitionFilter` exclusion lists, alongside the other internal-only components:

- `ProjectComponentDefinitionFilter` (`AUTOMATION`) — `appEvent`, **`codeWorkflow`**, `embeddedWorkflowBuilder`, `request`
- `IntegrationComponentDefinitionFilter` (`EMBEDDED`) — `apiPlatform`, **`codeWorkflow`**, `webhook`

The embedded one is included because the handler is registered EE-wide via `@ConditionalOnEEVersion`, so the component was also listed in the integration editor, where code workflows don't exist at all (`ProjectCodeWorkflow` is automation-only).

## Why this is safe for existing workflows

`ComponentDefinitionServiceImpl` applies these filters only in `getComponentDefinitions(...)` and `getComponentDefinitions(query, ...)` — the two list/search entry points behind both the REST controller and `ComponentDefinitionGraphQlController`. It does **not** apply them to `getComponentDefinition(name, version)`, which is the path `ComponentDefinitionHelper` uses to resolve each node of an existing workflow.

So generated definitions referencing `codeWorkflow/v1/perform` continue to resolve, render and execute — only the palette and search listing change.

## Verification

- `spotlessApply` and `compileJava` pass for both modified modules.
- No tests cover these filters today, and no client-side exclusion list exists — the server filter is the single source of truth for palette visibility.
- Not verified by booting the server; the filter is applied per request, so a restart of a running instance is enough to see it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)