### PR TITLE
5732 client - Hide the Item Schema section when there is no variable output schema

### DIFF
--- a/client/src/pages/platform/workflow-editor/components/node-details-tabs/output-tab/OutputSchemaDisplay.test.tsx
+++ b/client/src/pages/platform/workflow-editor/components/node-details-tabs/output-tab/OutputSchemaDisplay.test.tsx
@@ -1,0 +1,78 @@
+import {NodeDataType, PropertyAllType} from '@/shared/types';
+import {render, resetAll, screen} from '@/shared/util/test-utils';
+import {afterEach, describe, expect, it, vi} from 'vitest';
+
+import OutputSchemaDisplay from './OutputSchemaDisplay';
+
+vi.mock('@/pages/platform/workflow-editor/components/PropertyField', () => ({
+    default: () => <div data-testid="property-field" />,
+}));
+
+vi.mock('@/pages/platform/workflow-editor/components/SchemaProperties', () => ({
+    default: () => <div data-testid="schema-properties" />,
+}));
+
+vi.mock('./ClusterElementTestButton', () => ({
+    default: () => <div data-testid="cluster-element-test-button" />,
+}));
+
+const currentNode = {
+    componentName: 'subflow',
+    label: 'Subflow',
+    name: 'subflow_1',
+    workflowNodeName: 'subflow_1',
+} as NodeDataType;
+
+const outputSchema = {
+    controlType: 'OBJECT_BUILDER',
+    properties: [{controlType: 'TEXT', name: 'message', type: 'STRING'}],
+    type: 'OBJECT',
+} as PropertyAllType;
+
+const variableOutputSchema = {
+    controlType: 'OBJECT_BUILDER',
+    properties: [{controlType: 'TEXT', name: 'item', type: 'STRING'}],
+    type: 'OBJECT',
+} as PropertyAllType;
+
+const renderOutputSchemaDisplay = (props: Partial<Parameters<typeof OutputSchemaDisplay>[0]> = {}) =>
+    render(
+        <OutputSchemaDisplay
+            connectionMissing={false}
+            copiedValue={null}
+            copyToClipboard={vi.fn()}
+            currentNode={currentNode}
+            handlePredefinedOutputSchemaClick={vi.fn()}
+            handleTestOperationClick={vi.fn()}
+            outputDefined={true}
+            outputSchema={outputSchema}
+            sampleOutput={{message: 'sample message'}}
+            saveWorkflowNodeTestOutputMutation={{isPending: false}}
+            setShowUploadDialog={vi.fn()}
+            {...props}
+        />
+    );
+
+afterEach(() => {
+    resetAll();
+});
+
+describe('OutputSchemaDisplay', () => {
+    it('should not render the Item Schema heading when there is no variable output schema', () => {
+        renderOutputSchemaDisplay({variableOutputSchema: undefined, variablePropertiesDefined: true});
+
+        expect(screen.queryByText('Item Schema')).not.toBeInTheDocument();
+    });
+
+    it('should render the Item Schema heading when a variable output schema is present', () => {
+        renderOutputSchemaDisplay({variableOutputSchema, variablePropertiesDefined: true});
+
+        expect(screen.getByText('Item Schema')).toBeInTheDocument();
+    });
+
+    it('should render the Output Schema section independently of the Item Schema section', () => {
+        renderOutputSchemaDisplay({variableOutputSchema: undefined, variablePropertiesDefined: true});
+
+        expect(screen.getByText('Output Schema')).toBeInTheDocument();
+    });
+});

--- a/client/src/pages/platform/workflow-editor/components/node-details-tabs/output-tab/OutputSchemaDisplay.tsx
+++ b/client/src/pages/platform/workflow-editor/components/node-details-tabs/output-tab/OutputSchemaDisplay.tsx
@@ -175,25 +175,23 @@ const OutputSchemaDisplay = ({
                 </>
             )}
 
-            {variablePropertiesDefined && (
+            {variablePropertiesDefined && variableOutputSchema && (
                 <>
                     <div className="my-3 flex items-center justify-between">
                         <h3 className="text-sm text-content-neutral-secondary">Item Schema</h3>
                     </div>
 
-                    {variableOutputSchema && (
-                        <PropertyField
-                            copiedValue={copiedValue}
-                            copyToClipboard={copyToClipboard}
-                            label={currentNode.name}
-                            property={variableOutputSchema}
-                            sampleOutput={variableSampleOutput}
-                            valueToCopy={`$\{${currentNode.name}}`}
-                            workflowNodeName={currentNode.name}
-                        />
-                    )}
+                    <PropertyField
+                        copiedValue={copiedValue}
+                        copyToClipboard={copyToClipboard}
+                        label={currentNode.name}
+                        property={variableOutputSchema}
+                        sampleOutput={variableSampleOutput}
+                        valueToCopy={`$\{${currentNode.name}}`}
+                        workflowNodeName={currentNode.name}
+                    />
 
-                    {variableOutputSchema && variableSampleOutput && (
+                    {variableSampleOutput && (
                         <SchemaProperties
                             copiedValue={copiedValue}
                             copyToClipboard={copyToClipboard}


### PR DESCRIPTION
Fixes #5732

## Problem

In the workflow editor's node details **Output** tab, an **Item Schema** heading rendered with nothing beneath it. It is clearly visible on a **Subflow** node: the *Output Schema* section renders correctly, and directly below it an empty *Item Schema* heading appears.

## Root cause

`OutputSchemaDisplay` gated the *Item Schema* section on two different kinds of truth:

- The **heading** was gated on `variablePropertiesDefined` — a *static capability flag* from the task dispatcher definition.
- The **content** beneath it was gated on `variableOutputSchema` — the *actual runtime data*, read from `workflowNodeOutput?.variableOutputResponse`.

When the flag was `true` and the data absent, the heading rendered with an empty body.

Subflow trips this because of how the flag is computed in `TaskDispatcherDefinition`:

```java
this.variablePropertiesDefined =
    OptionalUtils.mapOrElse(
        taskDispatcherDefinition.getVariableProperties(), variableProperties -> true, false) ||
        OptionalUtils.mapOrElse(
            taskDispatcherDefinition.getOutputDefinition(), outputDefinition -> true, false);
```

Subflow declares `"variableProperties": null` but does have an output definition, so the flag resolves to `true` even though Subflow never produces an item schema.

## Fix

Gate the whole section on the data as well as the flag, so the heading and its content share a single condition. That makes the two inner `variableOutputSchema &&` checks provably redundant, so they are hoisted into the section guard — one guard, one truth, instead of three checks that could disagree.

The server-side `||` is deliberately left alone. `variablePropertiesDefined` is also read by `filterWorkflowNodeOutputs`, `DataPillPanel`, and the output-schema creation controls in `OutputTab`, so narrowing it would be a behavioral change well beyond this bug.

## Tests

Adds `OutputSchemaDisplay.test.tsx` covering the render guard:

- the *Item Schema* heading is not rendered when there is no variable output schema (this test fails on `master` with `expected document not to contain element, found <h3>Item Schema</h3>`);
- the heading is still rendered when a variable output schema is present;
- the *Output Schema* section renders independently of the *Item Schema* section.

## Verification

`npm run check` (lint + typecheck + tests) passes: 473 test files, 4524 tests, exit code 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)