### PR TITLE
5731 client - Remove the remaining top padding under page headers

### DIFF
--- a/client/src/ee/pages/automation/api-platform/api-clients/components/ApiClientTable.tsx
+++ b/client/src/ee/pages/automation/api-platform/api-clients/components/ApiClientTable.tsx
@@ -131,7 +131,7 @@ const ApiClientTable = ({apiClients}: ApiClientTableProps) => {
     const rows = reactTable.getRowModel().rows;
 
     return (
-        <div className="w-full space-y-4 self-start p-4 pt-2 text-sm 3xl:mx-auto 3xl:w-4/5">
+        <div className="w-full space-y-4 self-start p-4 pt-0 text-sm 3xl:mx-auto 3xl:w-4/5">
             <p>
                 API clients and their secret API keys are listed below. Please note that we do not display your secret
                 API keys again after you generate them.

--- a/client/src/ee/pages/automation/api-platform/api-collections/ApiCollections.tsx
+++ b/client/src/ee/pages/automation/api-platform/api-collections/ApiCollections.tsx
@@ -111,7 +111,7 @@ const ApiCollections = () => {
                 loading={apiCollectionsIsLoading || projectsIsLoading || tagsIsLoading}
             >
                 {apiCollections && apiCollections?.length > 0 ? (
-                    <div className="w-full divide-y divide-border/50 self-start p-4 pt-2 3xl:mx-auto 3xl:w-4/5">
+                    <div className="w-full divide-y divide-border/50 self-start p-4 pt-0 3xl:mx-auto 3xl:w-4/5">
                         <WorkflowReadOnlyProvider
                             value={{
                                 useGetComponentDefinitionsQuery: useGetComponentDefinitionsQuery,

--- a/client/src/ee/pages/embedded/app-events/components/AppEventList.tsx
+++ b/client/src/ee/pages/embedded/app-events/components/AppEventList.tsx
@@ -3,7 +3,7 @@ import {AppEvent} from '@/ee/shared/middleware/embedded/configuration';
 
 const AppEventList = ({appEvents}: {appEvents: AppEvent[]}) => {
     return (
-        <ul className="w-full divide-y divide-gray-100 self-start p-4 pt-2 3xl:mx-auto 3xl:w-4/5" role="list">
+        <ul className="w-full divide-y divide-gray-100 self-start p-4 pt-0 3xl:mx-auto 3xl:w-4/5" role="list">
             {appEvents.map((appEvent) => {
                 return <AppEventListItem appEvent={appEvent} key={appEvent.id} />;
             })}

--- a/client/src/ee/pages/embedded/automation-workflows/components/automation-workflow-project-list/AutomationWorkflowProjectList.tsx
+++ b/client/src/ee/pages/embedded/automation-workflows/components/automation-workflow-project-list/AutomationWorkflowProjectList.tsx
@@ -50,7 +50,7 @@ const AutomationWorkflowProjectList = ({
     }, [newlyCreatedProjectId]);
 
     return (
-        <div className="w-full self-start p-4 pt-2 3xl:mx-auto 3xl:w-4/5">
+        <div className="w-full self-start p-4 pt-0 3xl:mx-auto 3xl:w-4/5">
             {projects.map((project) => (
                 <Collapsible
                     className="group mb-2 rounded border border-border/50"

--- a/client/src/ee/pages/embedded/connected-users/components/ConnectedUserTable.tsx
+++ b/client/src/ee/pages/embedded/connected-users/components/ConnectedUserTable.tsx
@@ -187,7 +187,7 @@ const ConnectedUserTable = ({connectedUsers}: ConnectedUserTableProps) => {
     });
 
     return (
-        <div className="w-full self-start p-4 pt-2 3xl:mx-auto 3xl:w-4/5">
+        <div className="w-full self-start p-4 pt-0 3xl:mx-auto 3xl:w-4/5">
             <Table className="table-auto">
                 <TableHeader>
                     {headerGroups.map((headerGroup) => (

--- a/client/src/ee/pages/embedded/connections/components/connection-list/ConnectionList.tsx
+++ b/client/src/ee/pages/embedded/connections/components/connection-list/ConnectionList.tsx
@@ -13,7 +13,7 @@ const ConnectionList = ({
     tags: Tag[];
 }) => {
     return (
-        <ul className="w-full divide-y divide-border/50 self-start p-4 pt-2 3xl:mx-auto 3xl:w-4/5" role="list">
+        <ul className="w-full divide-y divide-border/50 self-start p-4 pt-0 3xl:mx-auto 3xl:w-4/5" role="list">
             {connections.map((connection) => {
                 const connectionTagIds = connection.tags?.map((tag) => tag.id);
 

--- a/client/src/ee/pages/embedded/integration-instance-configurations/IntegrationInstanceConfigurations.tsx
+++ b/client/src/ee/pages/embedded/integration-instance-configurations/IntegrationInstanceConfigurations.tsx
@@ -229,7 +229,7 @@ const IntegrationInstanceConfigurations = () => {
                 {componentDefinitions &&
                 integrationInstanceConfigurations &&
                 integrationInstanceConfigurations?.length > 0 ? (
-                    <div className="w-full divide-y divide-border/50 self-start p-4 pt-2 3xl:mx-auto 3xl:w-4/5">
+                    <div className="w-full divide-y divide-border/50 self-start p-4 pt-0 3xl:mx-auto 3xl:w-4/5">
                         <WorkflowReadOnlyProvider
                             value={{
                                 useGetComponentDefinitionsQuery: useGetComponentDefinitionsQuery,

--- a/client/src/ee/pages/embedded/integrations/components/integration-list/IntegrationList.tsx
+++ b/client/src/ee/pages/embedded/integrations/components/integration-list/IntegrationList.tsx
@@ -34,7 +34,7 @@ const IntegrationList = ({
     }, [newlyCreatedIntegrationId]);
 
     return (
-        <div className="w-full self-start p-4 pt-2 3xl:mx-auto 3xl:w-4/5">
+        <div className="w-full self-start p-4 pt-0 3xl:mx-auto 3xl:w-4/5">
             {integrations.map((integration) => {
                 const integrationTagIds = integration.tags?.map((tag) => tag.id);
 

--- a/client/src/ee/pages/embedded/mcp-servers/components/mcp-server-list/McpServerList.tsx
+++ b/client/src/ee/pages/embedded/mcp-servers/components/mcp-server-list/McpServerList.tsx
@@ -43,7 +43,7 @@ const McpServerList = ({mcpServers, tags}: McpServerListProps) => {
     const {createHandleRefresh, sortedMcpServers} = useMcpServerList(mcpServers);
 
     return (
-        <div className="w-full self-start p-4 pt-2 3xl:mx-auto 3xl:w-4/5">
+        <div className="w-full self-start p-4 pt-0 3xl:mx-auto 3xl:w-4/5">
             <WorkflowReadOnlyProvider
                 value={{
                     useGetComponentDefinitionsQuery: useGetComponentDefinitionsQuery,

--- a/client/src/ee/pages/embedded/workflow-executions/components/AutomationWorkflowExecutionsTable.tsx
+++ b/client/src/ee/pages/embedded/workflow-executions/components/AutomationWorkflowExecutionsTable.tsx
@@ -72,7 +72,7 @@ const AutomationWorkflowExecutionsTable = ({data}: {data: WorkflowExecution[]}) 
     };
 
     return (
-        <div className="w-full self-start p-4 pt-2 3xl:mx-auto 3xl:w-4/5">
+        <div className="w-full self-start p-4 pt-0 3xl:mx-auto 3xl:w-4/5">
             <Table>
                 <TableHeader>
                     {headerGroups.map((headerGroup) => (

--- a/client/src/ee/pages/embedded/workflow-executions/components/EmbeddedWorkflowExecutionsTable.tsx
+++ b/client/src/ee/pages/embedded/workflow-executions/components/EmbeddedWorkflowExecutionsTable.tsx
@@ -81,7 +81,7 @@ const EmbeddedWorkflowExecutionsTable = ({data}: {data: WorkflowExecution[]}) =>
     };
 
     return (
-        <div className="w-full self-start p-4 pt-2 3xl:mx-auto 3xl:w-4/5">
+        <div className="w-full self-start p-4 pt-0 3xl:mx-auto 3xl:w-4/5">
             <Table className="table-auto">
                 <TableHeader>
                     {headerGroups.map((headerGroup) => (

--- a/client/src/ee/pages/settings/automation/workspaces/components/WorkspaceList.tsx
+++ b/client/src/ee/pages/settings/automation/workspaces/components/WorkspaceList.tsx
@@ -3,7 +3,7 @@ import {Workspace} from '@/shared/middleware/automation/configuration';
 
 const WorkspaceList = ({workspaces}: {workspaces: Workspace[]}) => {
     return (
-        <ul className="w-full self-start p-4 pt-2 3xl:mx-auto 3xl:w-4/5" role="list">
+        <ul className="w-full self-start p-4 pt-0 3xl:mx-auto 3xl:w-4/5" role="list">
             {workspaces.map((workspace) => {
                 return <WorkspaceListItem key={workspace.id} workspace={workspace} />;
             })}

--- a/client/src/ee/pages/settings/embedded/signing-keys/components/SigningKeyTable.tsx
+++ b/client/src/ee/pages/settings/embedded/signing-keys/components/SigningKeyTable.tsx
@@ -99,7 +99,7 @@ const SigningKeyTable = ({signingKeys}: SigningKeyTableProps) => {
     const rows = reactTable.getRowModel().rows;
 
     return (
-        <div className="w-full space-y-8 self-start p-4 pt-2 text-sm 3xl:mx-auto 3xl:w-4/5">
+        <div className="w-full space-y-8 self-start p-4 pt-0 text-sm 3xl:mx-auto 3xl:w-4/5">
             <p>
                 Use your Signing Keys to sign requests made from the ByteChef SDK. <a href="#">Read our docs</a> for
                 more information.

--- a/client/src/ee/pages/settings/platform/api-connectors/components/ApiConnectorList.tsx
+++ b/client/src/ee/pages/settings/platform/api-connectors/components/ApiConnectorList.tsx
@@ -4,7 +4,7 @@ import ApiConnectorListItem from './ApiConnectorListItem';
 
 const ApiConnectorList = ({apiConnectors}: {apiConnectors: ApiConnector[]}) => {
     return (
-        <div className="w-full self-start p-4 pt-2 3xl:mx-auto 3xl:w-4/5">
+        <div className="w-full self-start p-4 pt-0 3xl:mx-auto 3xl:w-4/5">
             {apiConnectors.length > 0 && (
                 <div className="w-full divide-y divide-gray-100">
                     {apiConnectors.map((apiConnector) => (

--- a/client/src/ee/pages/settings/platform/billing/Billing.tsx
+++ b/client/src/ee/pages/settings/platform/billing/Billing.tsx
@@ -181,13 +181,13 @@ const Billing = () => {
             leftSidebarOpen={false}
         >
             {subscriptionError ? (
-                <div className="w-full self-start p-4 pt-2 3xl:mx-auto 3xl:w-4/5">
+                <div className="w-full self-start p-4 pt-0 3xl:mx-auto 3xl:w-4/5">
                     <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800">
                         Unable to load subscription. Please refresh the page or contact support if the problem persists.
                     </div>
                 </div>
             ) : (
-                <div className="w-full space-y-4 self-start p-4 pt-2 3xl:mx-auto 3xl:w-4/5">
+                <div className="w-full space-y-4 self-start p-4 pt-0 3xl:mx-auto 3xl:w-4/5">
                     {isCheckoutSuccess && (!subscription || isTrialSubscription) && (
                         <div className="rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-800">
                             {pollAttempts >= MAX_POLL_ATTEMPTS

--- a/client/src/ee/pages/settings/platform/custom-components/components/CustomComponentList.tsx
+++ b/client/src/ee/pages/settings/platform/custom-components/components/CustomComponentList.tsx
@@ -4,7 +4,7 @@ import CustomComponentListItem from './CustomComponentListItem';
 
 const CustomComponentList = ({customComponents}: {customComponents: CustomComponent[]}) => {
     return (
-        <div className="w-full self-start p-4 pt-2 3xl:mx-auto 3xl:w-4/5">
+        <div className="w-full self-start p-4 pt-0 3xl:mx-auto 3xl:w-4/5">
             {customComponents.length > 0 && (
                 <>
                     <div className="w-full divide-y divide-gray-100">

--- a/client/src/ee/pages/settings/platform/git-configuration/GitConfiguration.tsx
+++ b/client/src/ee/pages/settings/platform/git-configuration/GitConfiguration.tsx
@@ -15,7 +15,7 @@ const GitConfiguration = () => {
             header={<Header centerTitle={true} position="main" title="Git Configuration" />}
             leftSidebarOpen={false}
         >
-            <div className="w-full self-start p-4 pt-2 3xl:mx-auto 3xl:w-4/5">
+            <div className="w-full self-start p-4 pt-0 3xl:mx-auto 3xl:w-4/5">
                 <div className="max-w-xl divide-y divide-muted">
                     <GitConfigurationForm gitConfiguration={gitConfiguration} />
                 </div>

--- a/client/src/ee/pages/settings/platform/identity-providers/IdentityProvidersPage.tsx
+++ b/client/src/ee/pages/settings/platform/identity-providers/IdentityProvidersPage.tsx
@@ -22,7 +22,7 @@ export default function IdentityProvidersPage() {
             }
             leftSidebarOpen={false}
         >
-            <div className="w-full space-y-4 self-start p-4 pt-2 text-sm 3xl:mx-auto 3xl:w-4/5">
+            <div className="w-full space-y-4 self-start p-4 pt-0 text-sm 3xl:mx-auto 3xl:w-4/5">
                 <IdentityProvidersTable />
             </div>
 

--- a/client/src/ee/shared/components/api-keys/components/ApiKeyTable.tsx
+++ b/client/src/ee/shared/components/api-keys/components/ApiKeyTable.tsx
@@ -88,7 +88,7 @@ const ApiKeyTable = ({apiKeys}: ApiKeyTableProps) => {
     const rows = reactTable.getRowModel().rows;
 
     return (
-        <div className="w-full space-y-4 self-start p-4 pt-2 text-sm 3xl:mx-auto 3xl:w-4/5">
+        <div className="w-full space-y-4 self-start p-4 pt-0 text-sm 3xl:mx-auto 3xl:w-4/5">
             <Table>
                 <TableHeader>
                     {headerGroups.map((headerGroup) => (

--- a/client/src/pages/account/settings/AccountProfile.tsx
+++ b/client/src/pages/account/settings/AccountProfile.tsx
@@ -17,7 +17,7 @@ const AccountProfile = () => {
             header={<Header centerTitle={true} position="main" title="Your profile" />}
             leftSidebarOpen={false}
         >
-            <div className="w-full self-start p-4 pt-2 3xl:mx-auto 3xl:w-4/5">
+            <div className="w-full self-start p-4 pt-0 3xl:mx-auto 3xl:w-4/5">
                 <div className="max-w-xl divide-y divide-muted">
                     <AccountProfileDetails />
 

--- a/client/src/pages/account/settings/Appearance.tsx
+++ b/client/src/pages/account/settings/Appearance.tsx
@@ -31,7 +31,7 @@ export default function Appearance() {
             leftSidebarOpen={false}
         >
             <Form {...form}>
-                <form className="space-y-8 self-start p-4 pt-2 3xl:mx-auto 3xl:w-4/5">
+                <form className="space-y-8 self-start p-4 pt-0 3xl:mx-auto 3xl:w-4/5">
                     <FormField
                         control={form.control}
                         name="theme"

--- a/client/src/pages/account/settings/Sessions.tsx
+++ b/client/src/pages/account/settings/Sessions.tsx
@@ -68,7 +68,7 @@ const Sessions = () => {
         >
             <PageLoader loading={loading}>
                 {sessions && sessions?.length > 0 ? (
-                    <div className="w-full self-start p-4 pt-2 3xl:mx-auto 3xl:w-4/5">
+                    <div className="w-full self-start p-4 pt-0 3xl:mx-auto 3xl:w-4/5">
                         <Table className="table-auto">
                             <TableHeader>
                                 <TableRow className="border-b-border/50">

--- a/client/src/pages/automation/ai/skills/AiSkills.tsx
+++ b/client/src/pages/automation/ai/skills/AiSkills.tsx
@@ -10,21 +10,17 @@ import {
 import {Tooltip, TooltipContent, TooltipTrigger} from '@/components/ui/tooltip';
 import AiSkillsPanel from '@/pages/automation/ai/skills/AiSkillsPanel';
 import AiSkillsCreateDropdown from '@/pages/automation/ai/skills/components/AiSkillsCreateDropdown';
+import useAiSkills from '@/pages/automation/ai/skills/hooks/useAiSkills';
 import useAiSkillsTagFilterGroups from '@/pages/automation/ai/skills/hooks/useAiSkillsTagFilterGroups';
 import useAiSkillDetailToolbarStore from '@/pages/automation/ai/skills/stores/useAiSkillDetailToolbarStore';
 import {useAiSkillsStore} from '@/pages/automation/ai/skills/stores/useAiSkillsStore';
-import getAiSkillsBasePath from '@/pages/automation/ai/skills/utils/getAiSkillsBasePath';
-import invalidateSkillQueries from '@/pages/automation/ai/skills/utils/invalidateSkillQueries';
 import CopilotButton from '@/shared/components/copilot/CopilotButton';
-import useCopilotPostTurnRegistry from '@/shared/components/copilot/stores/useCopilotPostTurnRegistry';
-import useCopilotStateContributorRegistry from '@/shared/components/copilot/stores/useCopilotStateContributorRegistry';
 import {Source} from '@/shared/components/copilot/stores/useCopilotStore';
 import FilterBadges from '@/shared/components/filters/FilterBadges';
 import FilterMenu, {hasActiveFilters} from '@/shared/components/filters/FilterMenu';
 import Header from '@/shared/layout/Header';
 import LayoutContainer from '@/shared/layout/LayoutContainer';
 import {useFeatureFlagsStore} from '@/shared/stores/useFeatureFlagsStore';
-import {useQueryClient} from '@tanstack/react-query';
 import {
     ArrowLeftIcon,
     CodeIcon,
@@ -36,31 +32,11 @@ import {
     SparklesIcon,
     Trash2Icon,
 } from 'lucide-react';
-import {useEffect} from 'react';
-import {useLocation, useNavigate, useParams} from 'react-router-dom';
 import {useShallow} from 'zustand/react/shallow';
 
-type AiSkillsRouteType = 'detail' | 'list';
-
-const determineRoute = (skillId: string | undefined): AiSkillsRouteType => {
-    return skillId ? 'detail' : 'list';
-};
-
 const AiSkills = () => {
-    const {skillId} = useParams<{skillId?: string}>();
-
-    const location = useLocation();
-    const navigate = useNavigate();
-
-    const tagFilterGroups = useAiSkillsTagFilterGroups();
-
-    const closeSkillDetail = useAiSkillsStore((state) => state.closeSkillDetail);
-    const openSkillDetail = useAiSkillsStore((state) => state.openSkillDetail);
     const searchQuery = useAiSkillsStore((state) => state.searchQuery);
-    const selectedSkillId = useAiSkillsStore((state) => state.selectedSkillId);
     const setSearchQuery = useAiSkillsStore((state) => state.setSearchQuery);
-    const skillsHeaderInfo = useAiSkillsStore((state) => state.skillsHeaderInfo);
-    const skillsView = useAiSkillsStore((state) => state.skillsView);
 
     const {canSave, canToggleView, handlers, isSaving, viewMode} = useAiSkillDetailToolbarStore(
         useShallow((state) => ({
@@ -74,47 +50,11 @@ const AiSkills = () => {
 
     const setViewMode = useAiSkillDetailToolbarStore((state) => state.setViewMode);
 
+    const {handleBack, headerTitle, isDetailView, showSearchAndCreate, showToolbar} = useAiSkills();
+
+    const tagFilterGroups = useAiSkillsTagFilterGroups();
+
     const ff_4554 = useFeatureFlagsStore()('ff-4554');
-
-    const registerPostTurn = useCopilotPostTurnRegistry((state) => state.register);
-
-    const queryClient = useQueryClient();
-
-    useEffect(() => {
-        return registerPostTurn(Source.SKILLS, () => {
-            invalidateSkillQueries(queryClient);
-        });
-    }, [queryClient, registerPostTurn]);
-
-    useEffect(() => {
-        return useCopilotStateContributorRegistry.getState().register(() => {
-            const {selectedSkillId: activeSkillId, skillsHeaderInfo: activeHeaderInfo} = useAiSkillsStore.getState();
-
-            if (activeSkillId == null) {
-                return {};
-            }
-
-            return {
-                currentSelectedSkillId: activeSkillId,
-                currentSelectedSkillName: activeHeaderInfo.title,
-            };
-        });
-    }, []);
-
-    const route = determineRoute(skillId);
-
-    useEffect(() => {
-        if (route === 'detail' && skillId && selectedSkillId !== skillId) {
-            openSkillDetail(skillId, '');
-        } else if (route === 'list' && skillsView === 'detail') {
-            closeSkillDetail();
-        }
-    }, [closeSkillDetail, openSkillDetail, route, selectedSkillId, skillId, skillsView]);
-
-    const headerTitle = route === 'detail' ? (skillsHeaderInfo.title ?? 'Skill') : 'AI Skills';
-
-    const showToolbar = route === 'list';
-    const showSearchAndCreate = skillsView !== 'empty';
 
     let toolbarRight: React.ReactNode = undefined;
 
@@ -141,7 +81,7 @@ const AiSkills = () => {
                 {showSearchAndCreate && <AiSkillsCreateDropdown />}
             </div>
         );
-    } else if (route === 'detail' && handlers) {
+    } else if (isDetailView && handlers) {
         const inSourceMode = viewMode === 'source';
 
         toolbarRight = (
@@ -218,10 +158,6 @@ const AiSkills = () => {
         );
     }
 
-    const isDetailView = route === 'detail';
-
-    const skillsBasePath = getAiSkillsBasePath(location.pathname);
-
     // The detail view used to keep a skills-list sidebar for switching between skills. Inside Settings the
     // only sidebar on screen is the settings nav, so the way back to the list is an explicit control instead
     // — the CustomComponentDetail idiom, which solves the same problem one settings entry over.
@@ -230,7 +166,7 @@ const AiSkills = () => {
             <Button
                 aria-label="Back to skills"
                 icon={<ArrowLeftIcon className="size-5" />}
-                onClick={() => navigate(skillsBasePath)}
+                onClick={handleBack}
                 size="icon"
                 variant="ghost"
             />
@@ -253,7 +189,7 @@ const AiSkills = () => {
             }
             leftSidebarOpen={false}
         >
-            <div className="flex min-h-0 w-full flex-col p-4 pt-2 3xl:mx-auto 3xl:w-4/5">
+            <div className="flex min-h-0 w-full flex-col p-4 pt-0 3xl:mx-auto 3xl:w-4/5">
                 {showToolbar && showSearchAndCreate && hasActiveFilters(tagFilterGroups) && (
                     <div className="flex flex-wrap items-center gap-2 pt-0 pb-4">
                         <FilterBadges groups={tagFilterGroups} />

--- a/client/src/pages/automation/ai/skills/AiSkillsPanel.tsx
+++ b/client/src/pages/automation/ai/skills/AiSkillsPanel.tsx
@@ -1,11 +1,11 @@
 import AiSkillDetail from '@/pages/automation/ai/skills/components/AiSkillDetail';
 import AiSkillsEmptyState from '@/pages/automation/ai/skills/components/AiSkillsEmptyState';
 import AiSkillsList from '@/pages/automation/ai/skills/components/AiSkillsList';
-import useAiSkills from '@/pages/automation/ai/skills/hooks/useAiSkills';
+import useAiSkillsPanel from '@/pages/automation/ai/skills/hooks/useAiSkillsPanel';
 import {AlertTriangleIcon, Loader2Icon} from 'lucide-react';
 
 const AiSkillsPanel = () => {
-    const {isError, isLoading, skills, skillsView: currentView} = useAiSkills();
+    const {isError, isLoading, skills, skillsView: currentView} = useAiSkillsPanel();
 
     if (isLoading) {
         return (

--- a/client/src/pages/automation/ai/skills/hooks/tests/useAiSkills.test.tsx
+++ b/client/src/pages/automation/ai/skills/hooks/tests/useAiSkills.test.tsx
@@ -1,0 +1,161 @@
+import useCopilotPostTurnRegistry from '@/shared/components/copilot/stores/useCopilotPostTurnRegistry';
+import useCopilotStateContributorRegistry from '@/shared/components/copilot/stores/useCopilotStateContributorRegistry';
+import {Source} from '@/shared/components/copilot/stores/useCopilotStore';
+import {createTestQueryClientWrapper, renderHook, resetAll} from '@/shared/util/test-utils';
+import {ReactNode} from 'react';
+import {MemoryRouter, Route, Routes} from 'react-router-dom';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+
+import {useAiSkillsStore} from '../../stores/useAiSkillsStore';
+import useAiSkills from '../useAiSkills';
+
+const {closeSkillDetailMock, invalidateSkillQueriesMock, navigateMock, openSkillDetailMock} = vi.hoisted(() => ({
+    closeSkillDetailMock: vi.fn(),
+    invalidateSkillQueriesMock: vi.fn(),
+    navigateMock: vi.fn(),
+    openSkillDetailMock: vi.fn(),
+}));
+
+vi.mock('@/pages/automation/ai/skills/utils/invalidateSkillQueries', () => ({default: invalidateSkillQueriesMock}));
+
+vi.mock('react-router-dom', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('react-router-dom')>()),
+    useNavigate: () => navigateMock,
+}));
+
+const LIST_PATH = '/automation/settings/ai/skills';
+
+const renderAiSkills = (pathname = LIST_PATH) => {
+    const wrapper = ({children}: {children: ReactNode}) => {
+        const element = createTestQueryClientWrapper()({children});
+
+        return (
+            <MemoryRouter initialEntries={[pathname]}>
+                <Routes>
+                    <Route element={element} path="/:platform/settings/ai/skills/:skillId" />
+
+                    <Route element={element} path="/:platform/settings/ai/skills" />
+                </Routes>
+            </MemoryRouter>
+        );
+    };
+
+    return renderHook(() => useAiSkills(), {wrapper});
+};
+
+describe('useAiSkills', () => {
+    beforeEach(() => {
+        useAiSkillsStore.setState({
+            closeSkillDetail: closeSkillDetailMock,
+            openSkillDetail: openSkillDetailMock,
+            selectedSkillId: null,
+            skillsHeaderInfo: {},
+            skillsView: 'list',
+        });
+
+        useCopilotStateContributorRegistry.setState({contributors: []});
+    });
+
+    afterEach(() => {
+        resetAll();
+    });
+
+    it('titles the list route and keeps it on the list toolbar', () => {
+        const {result} = renderAiSkills();
+
+        expect(result.current.headerTitle).toBe('AI Skills');
+        expect(result.current.isDetailView).toBe(false);
+        expect(result.current.showToolbar).toBe(true);
+    });
+
+    it('titles the detail route with the skill name and drops the list toolbar', () => {
+        useAiSkillsStore.setState({selectedSkillId: '42', skillsHeaderInfo: {title: 'billing-runbook'}});
+
+        const {result} = renderAiSkills(`${LIST_PATH}/42`);
+
+        expect(result.current.headerTitle).toBe('billing-runbook');
+        expect(result.current.isDetailView).toBe(true);
+        expect(result.current.showToolbar).toBe(false);
+    });
+
+    it('falls back to Skill while the detail header carries no name', () => {
+        useAiSkillsStore.setState({selectedSkillId: '42'});
+
+        const {result} = renderAiSkills(`${LIST_PATH}/42`);
+
+        expect(result.current.headerTitle).toBe('Skill');
+    });
+
+    it('hides the search and create controls while the list is empty', () => {
+        useAiSkillsStore.setState({skillsView: 'empty'});
+
+        const {result} = renderAiSkills();
+
+        expect(result.current.showSearchAndCreate).toBe(false);
+    });
+
+    it('sends the back control to the skills mount the visitor is already on', () => {
+        const {result} = renderAiSkills('/embedded/settings/ai/skills/42');
+
+        result.current.handleBack();
+
+        expect(navigateMock).toHaveBeenCalledWith('/embedded/settings/ai/skills');
+    });
+
+    it('opens the skill the route points at', () => {
+        renderAiSkills(`${LIST_PATH}/42`);
+
+        expect(openSkillDetailMock).toHaveBeenCalledWith('42', '');
+    });
+
+    it('leaves the store alone when it already holds the skill the route points at', () => {
+        useAiSkillsStore.setState({selectedSkillId: '42', skillsView: 'detail'});
+
+        renderAiSkills(`${LIST_PATH}/42`);
+
+        expect(openSkillDetailMock).not.toHaveBeenCalled();
+    });
+
+    it('closes an open detail when the route returns to the list', () => {
+        useAiSkillsStore.setState({selectedSkillId: '42', skillsView: 'detail'});
+
+        renderAiSkills();
+
+        expect(closeSkillDetailMock).toHaveBeenCalled();
+    });
+
+    it('refreshes the skill queries after a copilot turn, until it unmounts', () => {
+        const {unmount} = renderAiSkills();
+
+        useCopilotPostTurnRegistry.getState().runFor(Source.SKILLS);
+
+        expect(invalidateSkillQueriesMock).toHaveBeenCalledTimes(1);
+
+        unmount();
+
+        useCopilotPostTurnRegistry.getState().runFor(Source.SKILLS);
+
+        expect(invalidateSkillQueriesMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('contributes the selected skill to the copilot state', () => {
+        useAiSkillsStore.setState({selectedSkillId: '42', skillsHeaderInfo: {title: 'billing-runbook'}});
+
+        renderAiSkills(`${LIST_PATH}/42`);
+
+        expect(useCopilotStateContributorRegistry.getState().contribute()).toEqual({
+            currentSelectedSkillId: '42',
+            currentSelectedSkillName: 'billing-runbook',
+        });
+    });
+
+    it('contributes nothing while no skill is selected', () => {
+        const {unmount} = renderAiSkills();
+
+        expect(useCopilotStateContributorRegistry.getState().contribute()).toEqual({});
+
+        unmount();
+
+        expect(useCopilotStateContributorRegistry.getState().contributors).toHaveLength(0);
+    });
+});

--- a/client/src/pages/automation/ai/skills/hooks/tests/useAiSkillsPanel.test.tsx
+++ b/client/src/pages/automation/ai/skills/hooks/tests/useAiSkillsPanel.test.tsx
@@ -1,0 +1,108 @@
+import {AiSkill} from '@/shared/middleware/graphql';
+import {renderHook, resetAll} from '@/shared/util/test-utils';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+
+import {useAiSkillsStore} from '../../stores/useAiSkillsStore';
+import useAiSkillsPanel from '../useAiSkillsPanel';
+
+const {isErrorRef, setSkillsPanelOpenMock, setSkillsViewMock, skillsRef, toastErrorMock} = vi.hoisted(() => ({
+    isErrorRef: {current: false},
+    setSkillsPanelOpenMock: vi.fn(),
+    setSkillsViewMock: vi.fn(),
+    skillsRef: {current: [] as AiSkill[]},
+    toastErrorMock: vi.fn(),
+}));
+
+vi.mock('@/shared/middleware/graphql', () => ({
+    useAiSkillsQuery: () => ({
+        data: {aiSkills: skillsRef.current},
+        isError: isErrorRef.current,
+        isLoading: false,
+    }),
+}));
+
+vi.mock('sonner', () => ({toast: {error: toastErrorMock}}));
+
+const skills = [{id: '1', name: 'billing-runbook'}] as unknown as AiSkill[];
+
+describe('useAiSkillsPanel', () => {
+    beforeEach(() => {
+        isErrorRef.current = false;
+        skillsRef.current = [];
+
+        useAiSkillsStore.setState({
+            setSkillsPanelOpen: setSkillsPanelOpenMock,
+            setSkillsView: setSkillsViewMock,
+            skillsView: 'list',
+        });
+    });
+
+    afterEach(() => {
+        resetAll();
+    });
+
+    it('returns the skills the query carries', () => {
+        skillsRef.current = skills;
+
+        const {result} = renderHook(() => useAiSkillsPanel());
+
+        expect(result.current.skills).toEqual(skills);
+        expect(result.current.isLoading).toBe(false);
+    });
+
+    it('turns an empty view into the list once a skill arrives', () => {
+        skillsRef.current = skills;
+
+        useAiSkillsStore.setState({skillsView: 'empty'});
+
+        renderHook(() => useAiSkillsPanel());
+
+        expect(setSkillsViewMock).toHaveBeenCalledWith('list');
+    });
+
+    it('turns the list into the empty view once the last skill goes', () => {
+        renderHook(() => useAiSkillsPanel());
+
+        expect(setSkillsViewMock).toHaveBeenCalledWith('empty');
+    });
+
+    it('leaves the detail view alone', () => {
+        useAiSkillsStore.setState({skillsView: 'detail'});
+
+        renderHook(() => useAiSkillsPanel());
+
+        expect(setSkillsViewMock).not.toHaveBeenCalled();
+    });
+
+    it('closes a detail back to the list rather than closing the panel', () => {
+        useAiSkillsStore.setState({skillsView: 'detail'});
+
+        const {result} = renderHook(() => useAiSkillsPanel());
+
+        result.current.handleClose();
+
+        expect(setSkillsViewMock).toHaveBeenCalledWith('list');
+        expect(setSkillsPanelOpenMock).not.toHaveBeenCalled();
+    });
+
+    it('closes the panel from the list view', () => {
+        skillsRef.current = skills;
+
+        const {result} = renderHook(() => useAiSkillsPanel());
+
+        result.current.handleClose();
+
+        expect(setSkillsPanelOpenMock).toHaveBeenCalledWith(false);
+    });
+
+    it('reports a failed load as a single toast', () => {
+        isErrorRef.current = true;
+
+        const {rerender} = renderHook(() => useAiSkillsPanel());
+
+        rerender();
+
+        expect(toastErrorMock).toHaveBeenCalledTimes(1);
+        expect(toastErrorMock).toHaveBeenCalledWith('Failed to load skills', {id: 'skills-load-error'});
+    });
+});

--- a/client/src/pages/automation/ai/skills/hooks/useAiSkills.ts
+++ b/client/src/pages/automation/ai/skills/hooks/useAiSkills.ts
@@ -1,60 +1,82 @@
 import {useAiSkillsStore} from '@/pages/automation/ai/skills/stores/useAiSkillsStore';
-import {useAiSkillsQuery} from '@/shared/middleware/graphql';
-import {useCallback, useEffect, useMemo, useRef} from 'react';
-import {toast} from 'sonner';
+import getAiSkillsBasePath from '@/pages/automation/ai/skills/utils/getAiSkillsBasePath';
+import invalidateSkillQueries from '@/pages/automation/ai/skills/utils/invalidateSkillQueries';
+import useCopilotPostTurnRegistry from '@/shared/components/copilot/stores/useCopilotPostTurnRegistry';
+import useCopilotStateContributorRegistry from '@/shared/components/copilot/stores/useCopilotStateContributorRegistry';
+import {Source} from '@/shared/components/copilot/stores/useCopilotStore';
+import {useQueryClient} from '@tanstack/react-query';
+import {useCallback, useEffect} from 'react';
+import {useLocation, useNavigate, useParams} from 'react-router-dom';
 
-interface UseAiSkillsOptionsI {
-    enabled?: boolean;
-}
+type AiSkillsRouteType = 'detail' | 'list';
 
-export default function useAiSkills(options?: UseAiSkillsOptionsI) {
-    const enabled = options?.enabled ?? true;
+const determineRoute = (skillId: string | undefined): AiSkillsRouteType => {
+    return skillId ? 'detail' : 'list';
+};
 
-    const {setSkillsPanelOpen, setSkillsView, skillsView} = useAiSkillsStore();
+export default function useAiSkills() {
+    const closeSkillDetail = useAiSkillsStore((state) => state.closeSkillDetail);
+    const openSkillDetail = useAiSkillsStore((state) => state.openSkillDetail);
+    const selectedSkillId = useAiSkillsStore((state) => state.selectedSkillId);
+    const skillsHeaderInfo = useAiSkillsStore((state) => state.skillsHeaderInfo);
+    const skillsView = useAiSkillsStore((state) => state.skillsView);
 
-    const {data: aiSkillsData, isError, isLoading} = useAiSkillsQuery(undefined, {enabled});
+    const registerPostTurn = useCopilotPostTurnRegistry((state) => state.register);
 
-    const skills = useMemo(() => aiSkillsData?.aiSkills ?? [], [aiSkillsData]);
+    const {skillId} = useParams<{skillId?: string}>();
 
-    const previousSkillsLengthRef = useRef(skills.length);
+    const location = useLocation();
+    const navigate = useNavigate();
 
-    const handleClose = useCallback(() => {
-        if (skillsView === 'detail') {
-            setSkillsView('list');
-        } else {
-            setSkillsPanelOpen(false);
-        }
-    }, [setSkillsPanelOpen, setSkillsView, skillsView]);
+    const queryClient = useQueryClient();
 
-    // Sync the store view when the skill list becomes empty or non-empty
+    const route = determineRoute(skillId);
+
+    const isDetailView = route === 'detail';
+
+    const headerTitle = isDetailView ? (skillsHeaderInfo.title ?? 'Skill') : 'AI Skills';
+
+    const showToolbar = route === 'list';
+    const showSearchAndCreate = skillsView !== 'empty';
+
+    const skillsBasePath = getAiSkillsBasePath(location.pathname);
+
+    const handleBack = useCallback(() => navigate(skillsBasePath), [navigate, skillsBasePath]);
+
     useEffect(() => {
-        const wasEmpty = previousSkillsLengthRef.current === 0;
-        const isEmpty = skills.length === 0;
-
-        previousSkillsLengthRef.current = skills.length;
-
-        if (wasEmpty && !isEmpty && skillsView === 'empty') {
-            setSkillsView('list');
-        } else if (!wasEmpty && isEmpty && skillsView === 'list') {
-            setSkillsView('empty');
-        } else if (skillsView === 'empty' && skills.length > 0) {
-            setSkillsView('list');
-        } else if (skillsView === 'list' && skills.length === 0) {
-            setSkillsView('empty');
-        }
-    }, [skills.length, setSkillsView, skillsView]);
+        return registerPostTurn(Source.SKILLS, () => {
+            invalidateSkillQueries(queryClient);
+        });
+    }, [queryClient, registerPostTurn]);
 
     useEffect(() => {
-        if (isError) {
-            toast.error('Failed to load skills', {id: 'skills-load-error'});
+        return useCopilotStateContributorRegistry.getState().register(() => {
+            const {selectedSkillId: activeSkillId, skillsHeaderInfo: activeHeaderInfo} = useAiSkillsStore.getState();
+
+            if (activeSkillId == null) {
+                return {};
+            }
+
+            return {
+                currentSelectedSkillId: activeSkillId,
+                currentSelectedSkillName: activeHeaderInfo.title,
+            };
+        });
+    }, []);
+
+    useEffect(() => {
+        if (route === 'detail' && skillId && selectedSkillId !== skillId) {
+            openSkillDetail(skillId, '');
+        } else if (route === 'list' && skillsView === 'detail') {
+            closeSkillDetail();
         }
-    }, [isError]);
+    }, [closeSkillDetail, openSkillDetail, route, selectedSkillId, skillId, skillsView]);
 
     return {
-        handleClose,
-        isError,
-        isLoading,
-        skills,
-        skillsView,
+        handleBack,
+        headerTitle,
+        isDetailView,
+        showSearchAndCreate,
+        showToolbar,
     };
 }

--- a/client/src/pages/automation/ai/skills/hooks/useAiSkillsPanel.ts
+++ b/client/src/pages/automation/ai/skills/hooks/useAiSkillsPanel.ts
@@ -1,0 +1,60 @@
+import {useAiSkillsStore} from '@/pages/automation/ai/skills/stores/useAiSkillsStore';
+import {useAiSkillsQuery} from '@/shared/middleware/graphql';
+import {useCallback, useEffect, useMemo, useRef} from 'react';
+import {toast} from 'sonner';
+
+interface UseAiSkillsPanelOptionsI {
+    enabled?: boolean;
+}
+
+export default function useAiSkillsPanel(options?: UseAiSkillsPanelOptionsI) {
+    const enabled = options?.enabled ?? true;
+
+    const {setSkillsPanelOpen, setSkillsView, skillsView} = useAiSkillsStore();
+
+    const {data: aiSkillsData, isError, isLoading} = useAiSkillsQuery(undefined, {enabled});
+
+    const skills = useMemo(() => aiSkillsData?.aiSkills ?? [], [aiSkillsData]);
+
+    const previousSkillsLengthRef = useRef(skills.length);
+
+    const handleClose = useCallback(() => {
+        if (skillsView === 'detail') {
+            setSkillsView('list');
+        } else {
+            setSkillsPanelOpen(false);
+        }
+    }, [setSkillsPanelOpen, setSkillsView, skillsView]);
+
+    // Sync the store view when the skill list becomes empty or non-empty
+    useEffect(() => {
+        const wasEmpty = previousSkillsLengthRef.current === 0;
+        const isEmpty = skills.length === 0;
+
+        previousSkillsLengthRef.current = skills.length;
+
+        if (wasEmpty && !isEmpty && skillsView === 'empty') {
+            setSkillsView('list');
+        } else if (!wasEmpty && isEmpty && skillsView === 'list') {
+            setSkillsView('empty');
+        } else if (skillsView === 'empty' && skills.length > 0) {
+            setSkillsView('list');
+        } else if (skillsView === 'list' && skills.length === 0) {
+            setSkillsView('empty');
+        }
+    }, [skills.length, setSkillsView, skillsView]);
+
+    useEffect(() => {
+        if (isError) {
+            toast.error('Failed to load skills', {id: 'skills-load-error'});
+        }
+    }, [isError]);
+
+    return {
+        handleClose,
+        isError,
+        isLoading,
+        skills,
+        skillsView,
+    };
+}

--- a/client/src/pages/automation/connections/components/connection-list/ConnectionList.tsx
+++ b/client/src/pages/automation/connections/components/connection-list/ConnectionList.tsx
@@ -13,7 +13,7 @@ const ConnectionList = ({
     tags: Tag[];
 }) => {
     return (
-        <ul className="w-full self-start p-4 pt-2 3xl:mx-auto 3xl:w-4/5" role="list">
+        <ul className="w-full self-start p-4 pt-0 3xl:mx-auto 3xl:w-4/5" role="list">
             {connections.map((connection) => {
                 const connectionTagIds = connection.tags?.map((tag) => tag.id);
 

--- a/client/src/pages/automation/datatable/DataTable.tsx
+++ b/client/src/pages/automation/datatable/DataTable.tsx
@@ -63,7 +63,7 @@ const DataTable = () => {
             leftSidebarWidth="64"
         >
             <PageLoader errors={[tablesError, rowsError]} loading={tablesLoading || rowsLoading}>
-                <div className="grid p-4 pt-2">
+                <div className="grid p-4 pt-0">
                     <DataGrid
                         aria-description="Data Table"
                         bottomSummaryRows={[{}]}

--- a/client/src/pages/automation/datatables/components/DataTableList.tsx
+++ b/client/src/pages/automation/datatables/components/DataTableList.tsx
@@ -15,7 +15,7 @@ const DataTableList = ({allTags, dataTables, tagsByTableData}: DataTableListProp
     const {sortedTables, tagsByTableMap} = useDataTableList({dataTables, tagsByTableData});
 
     return (
-        <div className="w-full self-start p-4 pt-2 3xl:mx-auto 3xl:w-4/5">
+        <div className="w-full self-start p-4 pt-0 3xl:mx-auto 3xl:w-4/5">
             {sortedTables.map((table) => {
                 const currentTags = tagsByTableMap.get(table.id) || [];
 

--- a/client/src/pages/automation/knowledge-base/KnowledgeBase.tsx
+++ b/client/src/pages/automation/knowledge-base/KnowledgeBase.tsx
@@ -19,7 +19,7 @@ const KnowledgeBase = () => {
         >
             <PageLoader errors={[error]} loading={isLoading}>
                 {knowledgeBase && (
-                    <div className="mx-auto flex h-full w-full max-w-(--breakpoint-lg) flex-col p-4 pt-2">
+                    <div className="mx-auto flex h-full w-full max-w-(--breakpoint-lg) flex-col p-4 pt-0">
                         <KnowledgeBaseInfoCard knowledgeBase={knowledgeBase} />
 
                         <KnowledgeBaseTabs documents={documents} knowledgeBaseId={knowledgeBaseId} />

--- a/client/src/pages/automation/knowledge-bases/components/knowledge-base-list/KnowledgeBaseList.tsx
+++ b/client/src/pages/automation/knowledge-bases/components/knowledge-base-list/KnowledgeBaseList.tsx
@@ -16,7 +16,7 @@ const KnowledgeBaseList = ({allTags, knowledgeBases, tagsByKnowledgeBaseData}: K
     });
 
     return (
-        <div className="w-full self-start p-4 pt-2 3xl:mx-auto 3xl:w-4/5">
+        <div className="w-full self-start p-4 pt-0 3xl:mx-auto 3xl:w-4/5">
             {sortedKnowledgeBases.map((knowledgeBase) => {
                 const currentTags = tagsByKnowledgeBaseMap.get(knowledgeBase.id) || [];
 

--- a/client/src/pages/automation/mcp-servers/components/mcp-server-list/McpServerList.tsx
+++ b/client/src/pages/automation/mcp-servers/components/mcp-server-list/McpServerList.tsx
@@ -36,7 +36,7 @@ const McpServerList = ({mcpServers, tags}: McpServerListProps) => {
     const workflowReadOnlyValue = useMemo(() => ({useGetComponentDefinitionsQuery}), []);
 
     return (
-        <div className="w-full self-start p-4 pt-2 3xl:mx-auto 3xl:w-4/5">
+        <div className="w-full self-start p-4 pt-0 3xl:mx-auto 3xl:w-4/5">
             <WorkflowReadOnlyProvider value={workflowReadOnlyValue}>
                 {sortedMcpServers.map((mcpServer) => {
                     const handleRefresh = createHandleRefresh(mcpServer.id!);

--- a/client/src/pages/automation/project-deployments/ProjectDeployments.tsx
+++ b/client/src/pages/automation/project-deployments/ProjectDeployments.tsx
@@ -189,7 +189,7 @@ const ProjectDeployments = () => {
                 loading={projectsIsLoading || projectDeploymentsIsLoading || tagsIsLoading}
             >
                 {projectDeployments && projectDeployments?.length > 0 ? (
-                    <div className="w-full divide-y divide-border/50 self-start p-4 pt-2 3xl:mx-auto 3xl:w-4/5">
+                    <div className="w-full divide-y divide-border/50 self-start p-4 pt-0 3xl:mx-auto 3xl:w-4/5">
                         <WorkflowReadOnlyProvider
                             value={{
                                 useGetComponentDefinitionsQuery: useGetComponentDefinitionsQuery,

--- a/client/src/pages/automation/projects/Projects.tsx
+++ b/client/src/pages/automation/projects/Projects.tsx
@@ -8,6 +8,7 @@ import {useGetWorkspaceProjectGitConfigurationsQuery} from '@/ee/shared/mutation
 import handleImportProject from '@/pages/automation/project/utils/handleImportProject';
 import ProjectsFilterTitle from '@/pages/automation/projects/components/ProjectsFilterTitle';
 import {useWorkspaceStore} from '@/pages/automation/stores/useWorkspaceStore';
+import useButtonGroupDropdownAlign from '@/shared/hooks/useButtonGroupDropdownAlign';
 import CategoryTagLeftSidebarNav from '@/shared/layout/CategoryTagLeftSidebarNav';
 import Header from '@/shared/layout/Header';
 import LayoutContainer from '@/shared/layout/LayoutContainer';
@@ -42,6 +43,8 @@ const Projects = () => {
     const [searchParams] = useSearchParams();
     const fileInputRef = useRef<HTMLInputElement>(null);
     const navigate = useNavigate();
+
+    const {alignOffset, buttonGroupRef, dropdownMenuTriggerRef, handleOpenChange} = useButtonGroupDropdownAlign();
 
     const queryClient = useQueryClient();
 
@@ -188,21 +191,21 @@ const Projects = () => {
                 ) : (
                     <EmptyList
                         button={
-                            <ButtonGroup className="mx-auto">
+                            <ButtonGroup className="mx-auto" ref={buttonGroupRef}>
                                 <ProjectDialog
                                     onSuccess={(projectId) => projectId && setNewlyCreatedProjectId(projectId)}
                                     project={undefined}
                                     triggerNode={<Button aria-label="Create Project" label="Create Project" />}
                                 />
 
-                                <DropdownMenu>
+                                <DropdownMenu onOpenChange={handleOpenChange}>
                                     <DropdownMenuTrigger asChild>
-                                        <Button>
+                                        <Button ref={dropdownMenuTriggerRef}>
                                             <ChevronDownIcon />
                                         </Button>
                                     </DropdownMenuTrigger>
 
-                                    <DropdownMenuContent align="end">
+                                    <DropdownMenuContent align="start" alignOffset={alignOffset}>
                                         <DropdownMenuItem onClick={() => navigate(`templates`)}>
                                             <LayoutTemplateIcon className="mr-2 size-4" />
                                             From Template

--- a/client/src/pages/automation/projects/components/project-list/ProjectList.tsx
+++ b/client/src/pages/automation/projects/components/project-list/ProjectList.tsx
@@ -33,7 +33,7 @@ const ProjectList = ({
     }, [newlyCreatedProjectId]);
 
     return (
-        <div className="w-full divide-y divide-border/50 self-start p-4 pt-2 3xl:mx-auto 3xl:w-4/5">
+        <div className="w-full divide-y divide-border/50 self-start p-4 pt-0 3xl:mx-auto 3xl:w-4/5">
             {projects.map((project) => {
                 const projectTagIds = project.tags?.map((tag) => tag.id);
 

--- a/client/src/pages/automation/projects/components/project-workflow-list/ProjectWorkflowList.tsx
+++ b/client/src/pages/automation/projects/components/project-workflow-list/ProjectWorkflowList.tsx
@@ -10,6 +10,7 @@ import handleImportWorkflow from '@/pages/automation/project/utils/handleImportW
 import ProjectWorkflowListItem from '@/pages/automation/projects/components/project-workflow-list/ProjectWorkflowListItem';
 import WorkflowDialog from '@/shared/components/workflow/WorkflowDialog';
 import {useAnalytics} from '@/shared/hooks/useAnalytics';
+import useButtonGroupDropdownAlign from '@/shared/hooks/useButtonGroupDropdownAlign';
 import {useHasEnabledAiProvider} from '@/shared/hooks/useHasEnabledAiProvider';
 import {Project} from '@/shared/middleware/automation/configuration';
 import {ComponentDefinitionBasic, TaskDispatcherDefinition} from '@/shared/middleware/platform/configuration';
@@ -37,6 +38,7 @@ const ProjectWorkflowList = ({
     const [showWorkflowDialog, setShowWorkflowDialog] = useState(false);
 
     const {captureProjectWorkflowCreated, captureProjectWorkflowImported} = useAnalytics();
+    const {alignOffset, buttonGroupRef, dropdownMenuTriggerRef, handleOpenChange} = useButtonGroupDropdownAlign();
     const navigate = useNavigate();
 
     const hiddenFileInputRef = useRef<HTMLInputElement>(null);
@@ -164,7 +166,7 @@ const ProjectWorkflowList = ({
                                 createWorkflowMutation={createProjectWorkflowMutation}
                                 parentId={project.id}
                                 triggerNode={
-                                    <ButtonGroup className="mx-auto">
+                                    <ButtonGroup className="mx-auto" ref={buttonGroupRef}>
                                         <Button
                                             onClick={(event) => {
                                                 event.stopPropagation();
@@ -175,7 +177,7 @@ const ProjectWorkflowList = ({
                                             Create Workflow
                                         </Button>
 
-                                        <DropdownMenu>
+                                        <DropdownMenu onOpenChange={handleOpenChange}>
                                             <DropdownMenuTrigger asChild>
                                                 <Button
                                                     icon={
@@ -185,10 +187,15 @@ const ProjectWorkflowList = ({
                                                             <ChevronDownIcon />
                                                         )
                                                     }
+                                                    ref={dropdownMenuTriggerRef}
                                                 ></Button>
                                             </DropdownMenuTrigger>
 
-                                            <DropdownMenuContent align="end" className="p-0">
+                                            <DropdownMenuContent
+                                                align="start"
+                                                alignOffset={alignOffset}
+                                                className="p-0"
+                                            >
                                                 <DropdownMenuItem
                                                     className="dropdown-menu-item"
                                                     onClick={(event) => {

--- a/client/src/pages/automation/workflow-executions/components/WorkflowExecutionsTable.tsx
+++ b/client/src/pages/automation/workflow-executions/components/WorkflowExecutionsTable.tsx
@@ -240,7 +240,7 @@ const WorkflowExecutionsTable = ({workflowExecutions}: WorkflowExecutionsTablePr
     const {expandedJobIds, handleRowClick, handleToggleExpand} = useWorkflowExecutionsTable();
 
     return (
-        <div className="w-full self-start p-4 pt-2 3xl:mx-auto 3xl:w-full">
+        <div className="w-full self-start p-4 pt-0 3xl:mx-auto 3xl:w-full">
             <Table>
                 <ExecutionTableHeader />
 

--- a/client/src/pages/settings/platform/ai-providers/components/AiProviderList.tsx
+++ b/client/src/pages/settings/platform/ai-providers/components/AiProviderList.tsx
@@ -74,7 +74,7 @@ const AiProviderList = ({aiProviders, environment}: {aiProviders: AiProvider[]; 
     }, [aiProviders]);
 
     return (
-        <div className="w-full self-start p-4 pt-2">
+        <div className="w-full self-start p-4 pt-0">
             <Accordion
                 className="w-full rounded-md border"
                 collapsible

--- a/client/src/pages/settings/platform/mcp-server/McpServer.tsx
+++ b/client/src/pages/settings/platform/mcp-server/McpServer.tsx
@@ -27,7 +27,7 @@ const McpServer = () => {
 
     return (
         <LayoutContainer header={<Header centerTitle position="main" title="MCP Server" />} leftSidebarOpen={false}>
-            <div className="max-w-(--breakpoint-lg) self-start p-4 pt-2 3xl:mx-auto 3xl:w-4/5">
+            <div className="max-w-(--breakpoint-lg) self-start p-4 pt-0 3xl:mx-auto 3xl:w-4/5">
                 {mcpServerUrl && <McpServerConfiguration mcpServerUrl={mcpServerUrl} onRefresh={handleRefresh} />}
             </div>
         </LayoutContainer>

--- a/client/src/pages/settings/platform/notifications/components/NotificationsTable.tsx
+++ b/client/src/pages/settings/platform/notifications/components/NotificationsTable.tsx
@@ -11,7 +11,7 @@ const NotificationsTable = ({columns, notifications}: {columns: []; notification
     });
 
     return (
-        <div className="w-full self-start p-4 pt-2 3xl:mx-auto 3xl:w-4/5">
+        <div className="w-full self-start p-4 pt-0 3xl:mx-auto 3xl:w-4/5">
             <Table>
                 <TableHeader>
                     {table.getHeaderGroups().map((headerGroup) => (

--- a/client/src/pages/settings/platform/users/UsersPage.tsx
+++ b/client/src/pages/settings/platform/users/UsersPage.tsx
@@ -51,7 +51,7 @@ export default function UsersPage() {
             }
             leftSidebarOpen={false}
         >
-            <div className="w-full space-y-4 self-start p-4 pt-2 text-sm 3xl:mx-auto 3xl:w-4/5">
+            <div className="w-full space-y-4 self-start p-4 pt-0 text-sm 3xl:mx-auto 3xl:w-4/5">
                 <UsersTable pageNumber={pageNumber} />
             </div>
 

--- a/client/src/shared/hooks/tests/useButtonGroupDropdownAlign.test.ts
+++ b/client/src/shared/hooks/tests/useButtonGroupDropdownAlign.test.ts
@@ -1,0 +1,68 @@
+import {act, renderHook} from '@testing-library/react';
+import {describe, expect, it} from 'vitest';
+
+import useButtonGroupDropdownAlign from '../useButtonGroupDropdownAlign';
+
+const stubLeftEdge = (element: HTMLElement, left: number) => {
+    element.getBoundingClientRect = () => ({left}) as DOMRect;
+};
+
+describe('useButtonGroupDropdownAlign', () => {
+    const renderWithAttachedRefs = (buttonGroupLeft: number, dropdownMenuTriggerLeft: number) => {
+        const {result} = renderHook(() => useButtonGroupDropdownAlign());
+
+        const buttonGroup = document.createElement('div');
+        const dropdownMenuTrigger = document.createElement('button');
+
+        stubLeftEdge(buttonGroup, buttonGroupLeft);
+        stubLeftEdge(dropdownMenuTrigger, dropdownMenuTriggerLeft);
+
+        result.current.buttonGroupRef.current = buttonGroup;
+        result.current.dropdownMenuTriggerRef.current = dropdownMenuTrigger;
+
+        return {buttonGroup, dropdownMenuTrigger, result};
+    };
+
+    it('starts with no offset', () => {
+        const {result} = renderHook(() => useButtonGroupDropdownAlign());
+
+        expect(result.current.alignOffset).toBe(0);
+    });
+
+    it('shifts the menu left by the distance between the group and the trigger when opened', () => {
+        const {result} = renderWithAttachedRefs(100, 260);
+
+        act(() => result.current.handleOpenChange(true));
+
+        expect(result.current.alignOffset).toBe(-160);
+    });
+
+    it('keeps the measured offset when the menu closes', () => {
+        const {result} = renderWithAttachedRefs(100, 260);
+
+        act(() => result.current.handleOpenChange(true));
+        act(() => result.current.handleOpenChange(false));
+
+        expect(result.current.alignOffset).toBe(-160);
+    });
+
+    it('remeasures on every open, so a wider label moves the menu further left', () => {
+        const {dropdownMenuTrigger, result} = renderWithAttachedRefs(100, 260);
+
+        act(() => result.current.handleOpenChange(true));
+
+        stubLeftEdge(dropdownMenuTrigger, 300);
+
+        act(() => result.current.handleOpenChange(true));
+
+        expect(result.current.alignOffset).toBe(-200);
+    });
+
+    it('leaves the offset alone while the refs are unattached', () => {
+        const {result} = renderHook(() => useButtonGroupDropdownAlign());
+
+        act(() => result.current.handleOpenChange(true));
+
+        expect(result.current.alignOffset).toBe(0);
+    });
+});

--- a/client/src/shared/hooks/useButtonGroupDropdownAlign.ts
+++ b/client/src/shared/hooks/useButtonGroupDropdownAlign.ts
@@ -1,0 +1,21 @@
+import {useCallback, useRef, useState} from 'react';
+
+export default function useButtonGroupDropdownAlign() {
+    const [alignOffset, setAlignOffset] = useState(0);
+
+    const buttonGroupRef = useRef<HTMLDivElement>(null);
+    const dropdownMenuTriggerRef = useRef<HTMLButtonElement>(null);
+
+    const handleOpenChange = useCallback((open: boolean) => {
+        if (!open || !buttonGroupRef.current || !dropdownMenuTriggerRef.current) {
+            return;
+        }
+
+        const buttonGroupRect = buttonGroupRef.current.getBoundingClientRect();
+        const dropdownMenuTriggerRect = dropdownMenuTriggerRef.current.getBoundingClientRect();
+
+        setAlignOffset(buttonGroupRect.left - dropdownMenuTriggerRect.left);
+    }, []);
+
+    return {alignOffset, buttonGroupRef, dropdownMenuTriggerRef, handleOpenChange};
+}

--- a/client/src/shared/layout/LayoutContainer.tsx
+++ b/client/src/shared/layout/LayoutContainer.tsx
@@ -96,7 +96,7 @@ const LayoutContainer = ({
                     <nav className="flex h-full flex-col">
                         {leftSidebarHeader}
 
-                        <div className="size-full overflow-y-auto px-2 pt-2 pb-4">{leftSidebarBody}</div>
+                        <div className="size-full overflow-y-auto px-2 pb-4">{leftSidebarBody}</div>
                     </nav>
                 </aside>
             )}


### PR DESCRIPTION
Follows up on #5731, continuing from `3b4b8dd8fff`.

That commit moved the page containers to `p-4 pt-2`, leaving a 8px gap on top of
whatever spacing the header above already contributes. Every page body now uses
`p-4 pt-0` and the left sidebar body drops its `pt-2`, so the header owns the
vertical rhythm and the content below starts on the line the header sets. 39
pages across automation, embedded and settings change identically.

AiSkills picks up the same spacing and, while it was open, its page-level logic
moves out of the component: routing, the header title and the copilot post-turn
and state-contributor registrations now live in `useAiSkills`. The data hook
that previously held that name became `useAiSkillsPanel`, which is what
`AiSkillsPanel` consumes — the rename and its call site move together, since the
two hooks no longer share a return shape. Both hooks get unit tests.

Checked from `client/`: `prettier --check`, `eslint` on the changed files,
`npm run typecheck`, and `vitest run src/pages/automation/ai/skills/hooks/tests`
(6 files, 45 tests) all pass.
