### PR TITLE
5743 Log human readable output to the console and ECS JSON to a file in prod

### DIFF
--- a/server/apps/server-app/src/main/resources/config/application-prod.yml
+++ b/server/apps/server-app/src/main/resources/config/application-prod.yml
@@ -1,10 +1,12 @@
 logging:
+  file:
+    name: /opt/bytechef/server/logs/bytechef.log
   level:
     ROOT: INFO
     com.bytechef: INFO
   structured:
     format:
-      console: ecs
+      file: ecs
 
 server:
   port: 8080

--- a/server/apps/server-app/src/main/resources/logback-file-appender.xml
+++ b/server/apps/server-app/src/main/resources/logback-file-appender.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<included>
+    <include resource="org/springframework/boot/logging/logback/structured-file-appender.xml"/>
+
+    <root>
+        <appender-ref ref="FILE"/>
+    </root>
+</included>

--- a/server/libs/config/logback-config/src/main/resources/logback-spring.xml
+++ b/server/libs/config/logback-config/src/main/resources/logback-spring.xml
@@ -20,7 +20,7 @@
     </SpringProfile>
 
     <SpringProfile name="prod">
-        <include resource="org/springframework/boot/logging/logback/structured-console-appender.xml"/>
+        <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
     </SpringProfile>
 
     <SpringProfile name="!dev &amp; !prod">
@@ -73,6 +73,10 @@
         <appender-ref ref="CONSOLE"/>
         <appender-ref ref="OpenTelemetry"/>
     </root>
+
+    <SpringProfile name="prod">
+        <include optional="true" resource="logback-file-appender.xml"/>
+    </SpringProfile>
 
     <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator">
         <resetJUL>true</resetJUL>


### PR DESCRIPTION
Part of #5743 — the two follow-ups noted at the bottom keep the issue open.

Under `prod` the console carried ECS JSON, so `docker logs` and any terminal
showed machine output. The console goes back to the human-readable pattern and
the structured stream moves to a file.

The file is `/opt/bytechef/server/logs/bytechef.log` — the directory
`server/apps/server-app/Dockerfile` already creates and `docker-entrypoint.sh`
already points Tomcat's access log at, so a container keeps one log location
and the config makes no assumption about a writable `/var/log` or a privileged
process.

`FILE` is defined only inside the `prod` profile block, so an unguarded
`<appender-ref ref="FILE"/>` on the root logger would leave every other profile
— `dev`, and the `!dev & !prod` block that `liquibase` and the tests land in —
logging `Appender named [FILE] could not be found` at startup. That is the same
shape as #5675, milder only because `CONSOLE` still exists there, so nothing
would be silently discarded.

The reference cannot be wrapped where it sits: Spring Boot's
`SpringProfileIfNestedWithinSecondPhaseElementSanityChecker` rejects
`<springProfile>` nested within an `<appender>`, `<logger>` or `<root>` element.
It is attached through a second `<root>` inside the `prod` block instead.
Repeated `<root>` elements accumulate rather than replace — checked against
logback 1.5.38, where `<root level="INFO"><appender-ref ref="CONSOLE"/></root>`
followed by `<root><appender-ref ref="FILE"/></root>` yields root appenders
`[CONSOLE, FILE]` at level `INFO`.

**Not yet booted.** This has been checked at the logback level and for XML
well-formedness, not by starting the server on the `prod` profile. Worth
confirming before merge that the console is readable, the file is ECS JSON, and
no appender warning appears under `dev`, `prod` or `liquibase`.

Two follow-ups stay open on #5743 and are deliberately not in this PR: nothing
mounts `/opt/bytechef/server/logs` in `docker-compose.yml` or the Helm chart, so
the file does not outlive the container; and `logging.logback.rollingpolicy.total-size-cap`
is still Spring Boot's default of `0`, i.e. unlimited gzipped history.
