### PR TITLE
2904 Publish the runtime job app docker image and make it wait for the job to finish

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,7 @@ dependencyManagement {
 
 versionCatalogUpdate {
     keep {
-        versions.addAll("anthropic-java", "checkstyle", "findsecbugs", "gradle-git-properties", "io-modelcontextprotocol-sdk", "jackson", "jacoco", "java", "jib-gradle-plugin", "openai-java", "pmd", "spotbugs", "spring-ai", "spring-boot", "spring-cloud-aws", "spring-cloud-dependencies", "spring-shell", "testcontainers")
+        versions.addAll("anthropic-java", "checkstyle", "findsecbugs", "gradle-git-properties", "io-modelcontextprotocol-sdk", "jackson", "jacoco", "java", "openai-java", "pmd", "spotbugs", "spring-ai", "spring-boot", "spring-cloud-aws", "spring-cloud-dependencies", "spring-shell", "testcontainers")
     }
 }
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -15,7 +15,6 @@ repositories {
 dependencies {
     implementation("com.diffplug.spotless:spotless-plugin-gradle:${libs.plugins.spotless.get().version}")
     implementation("com.github.spotbugs.snom:spotbugs-gradle-plugin:${libs.plugins.spotbugs.get().version}")
-    implementation("com.google.cloud.tools:jib-gradle-plugin:${libs.plugins.jib.get().version}")
     implementation("com.gorylenko.gradle-git-properties:gradle-git-properties:${libs.plugins.gradle.git.properties.get().version}")
     implementation("org.springframework.boot:spring-boot-gradle-plugin:${libs.versions.spring.boot.get()}")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:${libs.versions.jackson.get()}")

--- a/buildSrc/src/main/kotlin/com.bytechef.java-spring-boot-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/com.bytechef.java-spring-boot-conventions.gradle.kts
@@ -6,7 +6,6 @@ plugins {
     // Apply the common convention plugin for shared build configuration between library and application projects.
     id("com.bytechef.java-application-conventions")
 
-    id("com.google.cloud.tools.jib")
     id("com.gorylenko.gradle-git-properties")
     id("org.springframework.boot")
 }
@@ -122,13 +121,4 @@ defaultTasks("bootRun")
 configure<com.gorylenko.GitPropertiesPluginExtension> {
     failOnNoGitDirectory = false
     setKeys(listOf("git.branch", "git.build.version", "git.commit.id", "git.commit.id.abbrev", "git.commit.id.describe"))
-}
-
-configure<com.google.cloud.tools.jib.gradle.JibExtension> {
-    from {
-        image = "ghcr.io/graalvm/graalvm-community:25.0.0"
-    }
-    to {
-        image = "bytechef/bytechef-" + project.name + ":latest"
-    }
 }

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -10,10 +10,18 @@ usage() {
     echo "    \t\t\t  Builds for the host architecture only and loads the images into the local docker image store."
     echo "    --registry-url url\t- optional flag to push image to registry other than dockerhub.io If AWS ECR URL script would attempt AWS login."
     echo "    tag\t\t- arbitrary docker image tag(s). In bytechef we use yyyyMMdd to reflect date of image build."
+    echo ""
+    echo "IMAGES"
+    echo "    bytechef/bytechef-server\t\t- the ByteChef server without the client bundle."
+    echo "    bytechef/bytechef\t\t\t- the ByteChef server with the client bundle."
+    echo "    bytechef/bytechef-runtime-job\t- the standalone runtime job app that executes a single workflow."
 }
+
+root_dir=$(cd "$(dirname "$0")" && pwd)
 
 dckr_img_registry_bytechef_server="bytechef/bytechef-server"
 dckr_img_registry_bytechef="bytechef/bytechef"
+dckr_img_registry_bytechef_runtime_job="bytechef/bytechef-runtime-job"
 
 push_images=true
 tags=""
@@ -120,19 +128,31 @@ else
 fi
 
 echo "Validating Node.js version required for client build..."
-node client/scripts/check-node-version.mjs || exit 1
+node "$root_dir/client/scripts/check-node-version.mjs" || exit 1
 
-cd server/apps/server-app || exit 1
+cd "$root_dir/server/apps/server-app" || exit 1
 
-../../../gradlew clean build -Pprod || exit 1
+"$root_dir/gradlew" clean build -Pprod || exit 1
 
 for tag in $tags; do
-    echo "Building docker image with tag \`$tag\` for platform(s) \`$platforms\`"
+    echo "Building docker image \`$dckr_img_registry_bytechef_server:$tag\` for platform(s) \`$platforms\`"
+
     $docker_build_command --progress=plain --no-cache \
         -t $dckr_img_registry_bytechef_server:$tag . || exit 1
 done
 
-cd ../../../client || exit 1
+cd "$root_dir/server/ee/apps/runtime-job-app" || exit 1
+
+"$root_dir/gradlew" :server:ee:apps:runtime-job-app:clean :server:ee:apps:runtime-job-app:build -Pprod || exit 1
+
+for tag in $tags; do
+    echo "Building docker image \`$dckr_img_registry_bytechef_runtime_job:$tag\` for platform(s) \`$platforms\`"
+
+    $docker_build_command --progress=plain --no-cache \
+        -t $dckr_img_registry_bytechef_runtime_job:$tag . || exit 1
+done
+
+cd "$root_dir/client" || exit 1
 
 rm -rf node_modules
 
@@ -140,10 +160,11 @@ npm install || exit 1
 
 npm run build || exit 1
 
-cd .. || exit 1
+cd "$root_dir" || exit 1
 
 for tag in $tags; do
-    echo "Building docker image with tag \`$tag\` for platform(s) \`$platforms\`"
+    echo "Building docker image \`$dckr_img_registry_bytechef:$tag\` for platform(s) \`$platforms\`"
+
     $docker_build_command --progress=plain --no-cache \
         --build-arg BASE_IMAGE="$dckr_img_registry_bytechef_server:$tag" \
         -t $dckr_img_registry_bytechef:$tag . || exit 1
@@ -156,4 +177,4 @@ if [ "$push_images" = "false" ]; then
     exit 0
 fi
 
-echo "Pushed images to the remote docker registry \`$dckr_img_registry_bytechef\`"
+echo "Pushed images to the remote docker registry"

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -4,17 +4,19 @@ usage() {
     echo "Required argument misses. Please provide at least one docker image tag."
     echo ""
     echo "USAGE"
-    echo "    docker-build.sh [--no-push] [--registry-url url] tag1 [tag2 tag3 ...]"
+    echo "    docker-build.sh [--no-push] [--runtime-job] [--registry-url url] tag1 [tag2 tag3 ...]"
     echo "DESCRIPTION"
     echo "    --no-push\t\t- optional flag to build the images without pushing them to the registry."
+    echo "    --runtime-job\t- optional flag to build only the bytechef/bytechef-runtime-job image instead of"
+    echo "    \t\t\t  the default bytechef/bytechef image."
     echo "    \t\t\t  Builds for the host architecture only and loads the images into the local docker image store."
     echo "    --registry-url url\t- optional flag to push image to registry other than dockerhub.io If AWS ECR URL script would attempt AWS login."
     echo "    tag\t\t- arbitrary docker image tag(s). In bytechef we use yyyyMMdd to reflect date of image build."
     echo ""
     echo "IMAGES"
-    echo "    bytechef/bytechef-server\t\t- the ByteChef server without the client bundle."
-    echo "    bytechef/bytechef\t\t\t- the ByteChef server with the client bundle."
-    echo "    bytechef/bytechef-runtime-job\t- the standalone runtime job app that executes a single workflow."
+    echo "    bytechef/bytechef-server\t\t- the ByteChef server without the client bundle, the base of bytechef/bytechef."
+    echo "    bytechef/bytechef\t\t\t- the ByteChef server with the client bundle. Built by default."
+    echo "    bytechef/bytechef-runtime-job\t- the standalone runtime job app that executes a single workflow. Built with --runtime-job."
 }
 
 root_dir=$(cd "$(dirname "$0")" && pwd)
@@ -23,6 +25,7 @@ dckr_img_registry_bytechef_server="bytechef/bytechef-server"
 dckr_img_registry_bytechef="bytechef/bytechef"
 dckr_img_registry_bytechef_runtime_job="bytechef/bytechef-runtime-job"
 
+build_runtime_job=false
 push_images=true
 tags=""
 
@@ -30,6 +33,11 @@ while [ $# -gt 0 ]; do
     case "$1" in
         --no-push)
             push_images=false
+
+            shift
+        ;;
+        --runtime-job)
+            build_runtime_job=true
 
             shift
         ;;
@@ -127,48 +135,59 @@ else
     docker_build_command="docker build"
 fi
 
-echo "Validating Node.js version required for client build..."
-node "$root_dir/client/scripts/check-node-version.mjs" || exit 1
+build_runtime_job_image() {
+    cd "$root_dir/server/ee/apps/runtime-job-app" || exit 1
 
-cd "$root_dir/server/apps/server-app" || exit 1
+    "$root_dir/gradlew" :server:ee:apps:runtime-job-app:clean :server:ee:apps:runtime-job-app:build -Pprod || exit 1
 
-"$root_dir/gradlew" clean build -Pprod || exit 1
+    for tag in $tags; do
+        echo "Building docker image \`$dckr_img_registry_bytechef_runtime_job:$tag\` for platform(s) \`$platforms\`"
 
-for tag in $tags; do
-    echo "Building docker image \`$dckr_img_registry_bytechef_server:$tag\` for platform(s) \`$platforms\`"
+        $docker_build_command --progress=plain --no-cache \
+            -t $dckr_img_registry_bytechef_runtime_job:$tag . || exit 1
+    done
+}
 
-    $docker_build_command --progress=plain --no-cache \
-        -t $dckr_img_registry_bytechef_server:$tag . || exit 1
-done
+build_bytechef_image() {
+    echo "Validating Node.js version required for client build..."
+    node "$root_dir/client/scripts/check-node-version.mjs" || exit 1
 
-cd "$root_dir/server/ee/apps/runtime-job-app" || exit 1
+    cd "$root_dir/server/apps/server-app" || exit 1
 
-"$root_dir/gradlew" :server:ee:apps:runtime-job-app:clean :server:ee:apps:runtime-job-app:build -Pprod || exit 1
+    "$root_dir/gradlew" clean build -Pprod || exit 1
 
-for tag in $tags; do
-    echo "Building docker image \`$dckr_img_registry_bytechef_runtime_job:$tag\` for platform(s) \`$platforms\`"
+    # bytechef/bytechef is layered on top of bytechef/bytechef-server, so the server image has to exist first.
+    for tag in $tags; do
+        echo "Building docker image \`$dckr_img_registry_bytechef_server:$tag\` for platform(s) \`$platforms\`"
 
-    $docker_build_command --progress=plain --no-cache \
-        -t $dckr_img_registry_bytechef_runtime_job:$tag . || exit 1
-done
+        $docker_build_command --progress=plain --no-cache \
+            -t $dckr_img_registry_bytechef_server:$tag . || exit 1
+    done
 
-cd "$root_dir/client" || exit 1
+    cd "$root_dir/client" || exit 1
 
-rm -rf node_modules
+    rm -rf node_modules
 
-npm install || exit 1
+    npm install || exit 1
 
-npm run build || exit 1
+    npm run build || exit 1
 
-cd "$root_dir" || exit 1
+    cd "$root_dir" || exit 1
 
-for tag in $tags; do
-    echo "Building docker image \`$dckr_img_registry_bytechef:$tag\` for platform(s) \`$platforms\`"
+    for tag in $tags; do
+        echo "Building docker image \`$dckr_img_registry_bytechef:$tag\` for platform(s) \`$platforms\`"
 
-    $docker_build_command --progress=plain --no-cache \
-        --build-arg BASE_IMAGE="$dckr_img_registry_bytechef_server:$tag" \
-        -t $dckr_img_registry_bytechef:$tag . || exit 1
-done
+        $docker_build_command --progress=plain --no-cache \
+            --build-arg BASE_IMAGE="$dckr_img_registry_bytechef_server:$tag" \
+            -t $dckr_img_registry_bytechef:$tag . || exit 1
+    done
+}
+
+if [ "$build_runtime_job" = "true" ]; then
+    build_runtime_job_image
+else
+    build_bytechef_image
+fi
 
 if [ "$push_images" = "false" ]; then
     echo "Built \`$platforms\` images into the local docker image store"

--- a/docs/content/docs/platform/use-bytechef/self-hosted/runtime-job.mdx
+++ b/docs/content/docs/platform/use-bytechef/self-hosted/runtime-job.mdx
@@ -43,13 +43,14 @@ workflow itself sent it.
 
 ## Exit codes
 
-The process exit code is the workflow outcome. A `JobStatusApplicationEvent` listener shuts the
-Spring context down as soon as the job reaches a terminal status:
+The process exit code is the workflow outcome. The app blocks until the job reaches a terminal
+status, then shuts the Spring context down and exits:
 
 | Exit code | Meaning |
 |---|---|
 | `0` | The job completed. |
-| non-zero | The job failed, or the app could not start - missing `--workflow`, unparseable `--parameters` / `--connections` JSON, or a workflow the configured sources cannot resolve. |
+| `1` | The job failed or was stopped, or `--timeout` elapsed before the job finished. |
+| non-zero | The app could not start - missing `--workflow`, unparseable `--parameters` / `--connections` JSON, or a workflow the configured sources cannot resolve. |
 
 This is what makes the app composable with external orchestrators: a Kubernetes `Job` with
 `restartPolicy: Never` retries per its `backoffLimit`, Airflow marks the task failed, a CI step goes
@@ -59,9 +60,10 @@ red - all driven by the exit code alone.
 
 | Argument | Required | Description |
 |---|---|---|
-| `--workflow=<file>` | Yes | The workflow file. Only the base name without its extension is used to look the workflow up, so `--workflow=/workflows/daily-sync.json` and `--workflow=daily-sync.json` resolve identically. The file itself must be discoverable through one of the configured [workflow sources](#workflow-sources). |
+| `--workflow=<file>` | Yes | A lookup key, not a path. The directory part is discarded and the base name minus the extension becomes the workflow id, so `--workflow=/anything/at/all/daily-sync.json` and `--workflow=daily-sync.json` are equivalent. Passing a host path does **not** make the file reachable - it must be discoverable through one of the configured [workflow sources](#workflow-sources). |
 | `--parameters=<json>` | No | JSON object of the workflow's input values, e.g. `'{"batchDate": "2026-07-09"}'`. |
 | `--connections=<json>` | No | JSON object mapping connection names to their parameters - see [Connections](#connections). |
+| `--timeout=<duration>` | No | Give up and exit `1` if the job has not finished within this duration, e.g. `30s`, `15m`, `1h`. Without it the app waits indefinitely, which for a wedged job means a pod that never terminates. |
 
 ```bash
 java -jar runtime-job-app.jar \
@@ -79,7 +81,7 @@ java -jar runtime-job-app.jar \
 ./gradlew :server:ee:apps:runtime-job-app:build
 
 # Run
-java -jar server/ee/apps/runtime-job-app/build/libs/runtime-job-app-*.jar \
+java -jar server/ee/apps/runtime-job-app/build/libs/runtime-job-app.jar \
   --workflow=workflow.json \
   --parameters='{"message": "Processing batch job"}' \
   --connections='{"openAi": {"token": "sk-your-openai-token"}}'
@@ -94,26 +96,38 @@ java -jar server/ee/apps/runtime-job-app/build/libs/runtime-job-app-*.jar \
 
 ### Docker
 
-There is **no published image** for the Runtime Job app - build it yourself from the Dockerfile
-shipped with the app and, for Kubernetes, push it to your own registry.
+The app is published as `bytechef/bytechef-runtime-job`. Tags follow the same `yyyyMMdd` scheme as
+the other ByteChef images.
 
 ```bash
-# Build the application and the image
-./gradlew :server:ee:apps:runtime-job-app:build
-docker build -t bytechef-runtime-job server/ee/apps/runtime-job-app/
-
 # Run a workflow, mounting the workflows directory
 docker run --rm \
   -v $(pwd)/workflows:/workflows \
   -e BYTECHEF_WORKFLOW_REPOSITORY_FILESYSTEM_LOCATION_PATTERN='/workflows/*.json' \
-  bytechef-runtime-job \
+  bytechef/bytechef-runtime-job \
   --workflow=daily-sync.json \
   --connections='{"openAi": {"token": "sk-..."}}'
 
 echo $?   # 0 on success, non-zero on failure
+```
 
-# For Kubernetes: tag and push to your own registry
-docker tag bytechef-runtime-job your-registry.example.com/bytechef-runtime-job:latest
+Without the location-pattern override the app reads its default filesystem location, which inside the
+container is `/root/bytechef/data/workflows`. Mounting there works just as well:
+
+```bash
+docker run --rm \
+  -v $(pwd)/workflows:/root/bytechef/data/workflows \
+  bytechef/bytechef-runtime-job \
+  --workflow=daily-sync.json
+```
+
+To build the image yourself instead, for a private registry or a patched build:
+
+```bash
+./gradlew :server:ee:apps:runtime-job-app:build
+docker build -t bytechef/bytechef-runtime-job server/ee/apps/runtime-job-app/
+
+docker tag bytechef/bytechef-runtime-job your-registry.example.com/bytechef-runtime-job:latest
 docker push your-registry.example.com/bytechef-runtime-job:latest
 ```
 
@@ -136,8 +150,21 @@ The app resolves the workflow by base name against the repositories enabled in c
   `BYTECHEF_WORKFLOW_REPOSITORY_GIT_ENABLED=true` plus `..._GIT_URL`, `..._GIT_BRANCH`,
   `..._GIT_SEARCH_PATHS`, `..._GIT_USERNAME`, `..._GIT_PASSWORD`.
 
+At startup each enabled repository is scanned and every file it finds is indexed under
+`base64(base name without extension)`; `--workflow` looks that id up. When nothing matches, the run
+fails with `Workflow with id: <base64> does not exist` - which in a container almost always means
+the directory was never mounted, or was mounted somewhere the location pattern does not cover.
+
 Subworkflows reached through the `subflow` dispatcher resolve through the same sources as the main
 workflow.
+
+<Callout type="warn">
+  **Export workflows from the editor rather than hand-writing them.** Component property defaults are
+  written into the workflow JSON by the editor as a node is added - nothing applies them at execution
+  time. A hand-written file, or one exported before a component gained a new required property, fails
+  mid-run with `Unknown value for : <property>`. Re-exporting from a current ByteChef instance fills
+  the gaps in; editing the JSON by hand invites the next one.
+</Callout>
 
 ## Connections
 
@@ -219,11 +246,12 @@ spec:
       restartPolicy: Never
       containers:
         - name: runtime-job
-          image: your-registry.example.com/bytechef-runtime-job:latest
+          image: bytechef/bytechef-runtime-job:latest
           args:
             - --workflow=daily-sync.json
             - --parameters={"batchDate": "2026-07-09"}
             - --connections=$(CONNECTIONS)
+            - --timeout=30m
           env:
             - name: SPRING_PROFILES_ACTIVE
               value: prod
@@ -242,6 +270,11 @@ spec:
           configMap:
             name: daily-sync-workflow
 ```
+
+`--timeout` matters more here than it looks: `backoffLimit` retries a pod that *failed*, and does
+nothing for one that is merely stuck. Without it a wedged workflow holds the pod open indefinitely.
+`activeDeadlineSeconds` is the blunter Kubernetes-side equivalent, but it kills the pod rather than
+letting the app exit `1` on its own.
 
 Wrap the same template in a `CronJob` for recurring batch runs - the external scheduler owns the
 cadence; ByteChef owns the execution.
@@ -267,12 +300,25 @@ Deliberately absent, because a single-shot process has no use for them:
 
 Observability is thinner here than on the server, and worth checking before you rely on it. Spring
 Boot Actuator is on the classpath, so the health and `/actuator/metrics` endpoints exist for the life
-of the process. What is **not** there: no Micrometer Prometheus registry ships with the app, so there
-is no `/actuator/prometheus` endpoint and the `management.prometheus.*` keys in its configuration have
-nothing to act on; and unlike the server, the app maps no `bytechef.observability.*` block onto the
-`management.*` OTLP keys, so no signal is exported by default. To export from a run, set the Spring
-Boot `management.*` OTLP properties directly - see
-[Observability](/platform/use-bytechef/self-hosted/management/observability) for their names.
+of the process. No Micrometer Prometheus registry ships with the app, so there is no
+`/actuator/prometheus` endpoint and the `management.prometheus.*` keys in its configuration have
+nothing to act on.
+
+The app does ship the Micrometer OTLP registry, but export is **off by default**, exactly as on the
+server. The app maps the same `bytechef.observability.*` block onto the Spring Boot `management.*`
+OTLP keys, so metrics, tracing and logging export are each disabled until you turn them on:
+
+| Environment variable | Default | Purpose |
+|---|---|---|
+| `BYTECHEF_OBSERVABILITY_METRICS_ENABLED` | `false` | Export metrics over OTLP. |
+| `BYTECHEF_OBSERVABILITY_METRICS_ENDPOINT` | `http://localhost:4318/v1/metrics` | Collector endpoint for metrics. |
+| `BYTECHEF_OBSERVABILITY_TRACING_ENABLED` | `false` | Export traces over OTLP. |
+| `BYTECHEF_OBSERVABILITY_TRACING_ENDPOINT` | `http://localhost:4318/v1/traces` | Collector endpoint for traces. |
+| `BYTECHEF_OBSERVABILITY_LOGGING_ENABLED` | `false` | Export logs over OTLP. |
+| `BYTECHEF_OBSERVABILITY_LOGGING_ENDPOINT` | `http://localhost:4318/v1/logs` | Collector endpoint for logs. |
+
+See [Observability](/platform/use-bytechef/self-hosted/management/observability) for the wider
+picture.
 
 In practice a run is over before a scrape interval elapses, which is why the container log and the
 exit code are the record.
@@ -282,6 +328,12 @@ exit code are the record.
 The process exits non-zero when the `--workflow` argument is missing, when the workflow file cannot
 be found or parsed, when a task fails for want of a connection it needs, or when workflow execution
 fails for any other reason. Pair that with your CI's failure handling: a non-zero exit fails the step.
+
+| Symptom | Cause |
+|---|---|
+| `Workflow with id: <base64> does not exist` | No repository indexed a file under that name. Check the volume is mounted, that the extension matches the location pattern, and remember the directory part of `--workflow` is ignored. |
+| `Unknown value for : <property>` | The workflow JSON omits a component property the action requires - re-export it from the editor. |
+| The run never finishes | The app waits indefinitely for a terminal status. Bound it with `--timeout`. |
 
 Raise the log level for a single run without changing the image:
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -78,7 +78,6 @@ org-zeroturnaround-zt-exec = "org.zeroturnaround:zt-exec:1.12"
 [plugins]
 com-github-ben-manes-versions = "com.github.ben-manes.versions:0.54.0"
 gradle-git-properties = "com.gorylenko.gradle-git-properties:4.0.1"
-jib = "com.google.cloud.tools.jib:3.5.3"
 nl-littlerobots-version-catalog-update = "nl.littlerobots.version-catalog-update:1.1.0"
 org-graalvm-buildtools-native = "org.graalvm.buildtools.native:1.1.1"
 org-openapi-generator = "org.openapi.generator:7.22.0"

--- a/server/ee/apps/runtime-job-app/Dockerfile
+++ b/server/ee/apps/runtime-job-app/Dockerfile
@@ -12,11 +12,13 @@ WORKDIR /opt/bytechef
 
 COPY build/libs/runtime-job-app.jar runtime-job/
 
-ENTRYPOINT exec \
-     java \
-     -Dfile.encoding=UTF-8 -Duser.timezone=GMT \
-     -Djava.io.tmpdir=/opt/bytechef/runtime-job/tmp \
-     -jar runtime-job/runtime-job-app.jar \
-     "$@"
+ENTRYPOINT [ \
+    "java", \
+    "-Dfile.encoding=UTF-8", \
+    "-Duser.timezone=GMT", \
+    "-Djava.io.tmpdir=/opt/bytechef/runtime-job/tmp", \
+    "-jar", \
+    "runtime-job/runtime-job-app.jar" \
+]
 
 FROM bytechef-runtime-job-base AS bytechef-runtime-job

--- a/server/ee/apps/runtime-job-app/README.md
+++ b/server/ee/apps/runtime-job-app/README.md
@@ -22,14 +22,54 @@ The application accepts the following command line arguments:
 
 ### Required Arguments
 
-- `--workflow=<workflow_file>`: Path to the workflow JSON file to execute
+- `--workflow=<workflow_file>`: The workflow to run, given as a file name with its extension, e.g. `my-workflow.json`.
+
+  This is a **lookup key, not a path**. The directory part of the value is discarded and the
+  remaining base name, minus the extension, is base64-encoded into the workflow id - so
+  `--workflow=/anything/at/all/my-workflow.json` and `--workflow=my-workflow.json` are equivalent.
+  The file itself must be discoverable through one of the configured workflow repositories, see
+  [Where workflows are loaded from](#where-workflows-are-loaded-from).
 
 ### Optional Arguments
 
 - `--parameters=<json_string>`: JSON string containing workflow input parameters
 - `--connections=<json_string>`: JSON string containing connection configurations
+- `--timeout=<duration>`: Maximum time to wait for the workflow to finish, e.g. `30s`, `15m`, `1h`. When it elapses the job is abandoned and the process exits with code `1`. Without it the app waits indefinitely.
+
+## Where Workflows Are Loaded From
+
+At startup the app scans the enabled workflow repositories and indexes every file it finds under
+`base64(file name without extension)`. `--workflow` then looks that id up. If nothing was indexed
+under the id, the run fails with `Workflow with id: <base64> does not exist`.
+
+| Repository | Enabled by default | Location |
+|---|---|---|
+| Filesystem | Yes | `${user.home}/bytechef/data/workflows/*.{json\|yml\|yaml}` - inside the container that is `/root/bytechef/data/workflows`, since the image runs as root |
+| Classpath | Yes | `workflows/*.{json\|yml\|yaml}` from inside the JAR |
+| Git | No | `BYTECHEF_WORKFLOW_REPOSITORY_GIT_ENABLED=true` plus the `..._GIT_URL` / `..._GIT_BRANCH` / `..._GIT_SEARCH_PATHS` settings |
+
+Override the filesystem location with `BYTECHEF_WORKFLOW_REPOSITORY_FILESYSTEM_LOCATIONPATTERN`
+(the `..._LOCATION_PATTERN` spelling binds too). So to run a file that lives somewhere else:
+
+```bash
+BYTECHEF_WORKFLOW_REPOSITORY_FILESYSTEM_LOCATIONPATTERN='/tmp/my-workflows/*.json' \
+  java -jar runtime-job-app.jar --workflow=my-workflow.json
+```
+
+## Exit Codes
+
+The app blocks until the job reaches a terminal status, then shuts down and exits:
+
+| Exit code | Meaning |
+|---|---|
+| `0` | The job completed |
+| `1` | The job failed or was stopped, or `--timeout` elapsed before the job finished |
+| non-zero | The app could not start - missing `--workflow`, unparseable `--parameters` / `--connections` JSON, or a workflow that cannot be resolved |
 
 ## Usage Examples
+
+These assume the workflow file sits in `~/bytechef/data/workflows/`, the default filesystem
+location. See [Where workflows are loaded from](#where-workflows-are-loaded-from) otherwise.
 
 ### Basic Workflow Execution
 
@@ -63,6 +103,12 @@ java -jar runtime-job-app.jar \
 ```
 
 ## Workflow File Format
+
+> **Export workflows from the ByteChef editor rather than hand-writing them.** Component property
+> defaults are materialized into the workflow JSON by the editor when a node is added; nothing fills
+> them in at execution time. A hand-written or outdated file that omits a required property fails
+> mid-run with `Unknown value for : <property>` - for example an `openAi/v1/ask` task missing
+> `"format": "SIMPLE"` or `"format": "ADVANCED"`.
 
 Workflows must be in JSON format with the following structure:
 
@@ -197,8 +243,8 @@ This allows you to have different connection configurations for different tasks 
 ./gradlew :server:ee:apps:runtime-job-app:build
 
 # Run the application
-java -jar server/ee/apps/runtime-job-app/build/libs/runtime-job-app-*.jar \
-  --workflow=path/to/workflow.json \
+java -jar server/ee/apps/runtime-job-app/build/libs/runtime-job-app.jar \
+  --workflow=workflow.json \
   --parameters='{"key": "value"}' \
   --connections='{"service": {"token": "your-token"}}'
 ```
@@ -211,47 +257,72 @@ java -jar server/ee/apps/runtime-job-app/build/libs/runtime-job-app-*.jar \
 
 ### Using Docker
 
-First, build the Docker image:
+The app is published as `bytechef/bytechef-runtime-job`.
 
-```bash
-# Build the application and Docker image
-./gradlew :server:ee:apps:runtime-job-app:build
-docker build -t bytechef-runtime-job server/ee/apps/runtime-job-app/
-```
+#### Where the container looks for workflows
 
-Then run the container with your workflow and arguments:
+The `--workflow` value is resolved to a workflow id from the file name alone, so the
+directory part of the value is ignored and the extension is required. The file itself
+must be discoverable through one of the configured workflow repository locations. Point
+the filesystem location at your mount:
 
 ```bash
 # Basic workflow execution
 docker run --rm \
-  -v /path/to/your/workflows:/workflows \
-  bytechef-runtime-job \
-  --workflow=/workflows/my-workflow.json
+  -v $(pwd)/workflows:/workflows \
+  -e BYTECHEF_WORKFLOW_REPOSITORY_FILESYSTEM_LOCATION_PATTERN='/workflows/*.json' \
+  bytechef/bytechef-runtime-job \
+  --workflow=my-workflow.json
 
 # Workflow with parameters
 docker run --rm \
-  -v /path/to/your/workflows:/workflows \
-  bytechef-runtime-job \
-  --workflow=/workflows/my-workflow.json \
+  -v $(pwd)/workflows:/workflows \
+  -e BYTECHEF_WORKFLOW_REPOSITORY_FILESYSTEM_LOCATION_PATTERN='/workflows/*.json' \
+  bytechef/bytechef-runtime-job \
+  --workflow=my-workflow.json \
   --parameters='{"inputValue": "Hello World", "count": 5}'
 
 # Workflow with connections
 docker run --rm \
-  -v /path/to/your/workflows:/workflows \
-  bytechef-runtime-job \
-  --workflow=/workflows/my-workflow.json \
+  -v $(pwd)/workflows:/workflows \
+  -e BYTECHEF_WORKFLOW_REPOSITORY_FILESYSTEM_LOCATION_PATTERN='/workflows/*.json' \
+  bytechef/bytechef-runtime-job \
+  --workflow=my-workflow.json \
   --connections='{"openAi": {"token": "your-api-key"}}'
-
-# Complete example with all arguments
-docker run --rm \
-  -v /path/to/your/workflows:/workflows \
-  bytechef-runtime-job \
-  --workflow=/workflows/workflow1.json \
-  --parameters='{"message": "Processing batch job"}' \
-  --connections='{"openAi": {"token": "sk-your-openai-token"}}'
 ```
 
-**Note**: The `-v` flag mounts your local workflow directory into the container so the application can access your workflow files.
+Without the override the app reads its default filesystem location, which inside the
+container is `/root/bytechef/data/workflows`. Mounting there works just as well:
+
+```bash
+docker run --rm \
+  -v $(pwd)/workflows:/root/bytechef/data/workflows \
+  bytechef/bytechef-runtime-job \
+  --workflow=my-workflow.json
+```
+
+#### Building the image yourself
+
+```bash
+./gradlew :server:ee:apps:runtime-job-app:build
+docker build -t bytechef/bytechef-runtime-job server/ee/apps/runtime-job-app/
+```
+
+The release script at the repository root builds and pushes this image alongside the
+server images:
+
+```bash
+./docker-build.sh 20260909
+```
+
+**Note**: To add JVM options, set `JAVA_TOOL_OPTIONS` on the container, for example
+`docker run --rm -e JAVA_TOOL_OPTIONS=-Xmx2g bytechef/bytechef-runtime-job --workflow=my-workflow.json`.
+
+**Note**: The image is built with the `prod` profile, so it logs in ECS structured JSON format.
+OTLP export is **off by default** for metrics, tracing and logging alike; turn it on per signal with
+`BYTECHEF_OBSERVABILITY_METRICS_ENABLED` / `..._TRACING_ENABLED` / `..._LOGGING_ENABLED`. See the
+[Runtime Job Runner](https://docs.bytechef.io/platform/use-bytechef/self-hosted/runtime-job)
+documentation for the full environment variable reference.
 
 ## Environment Configuration
 
@@ -279,9 +350,17 @@ The application will exit with an error if:
 ### Common Issues
 
 1. **"Workflow name is required"**: Ensure the `--workflow` argument is provided
-2. **Connection errors**: Verify connection parameters and network connectivity
-3. **JSON parsing errors**: Validate JSON format for parameters and connections
-4. **Workflow file not found**: Check file paths and permissions
+2. **`Workflow with id: <base64> does not exist`**: no repository indexed a file under that name.
+   The id is `base64(file name without extension)`. Check that the file really sits in the
+   configured location - inside a container, that the directory is actually mounted - that its
+   extension matches the location pattern, and remember that the directory part of `--workflow` is
+   ignored, so passing a host path does not make the file reachable.
+3. **`Unknown value for : <property>`**: the workflow JSON omits a component property the action
+   requires. Re-export the workflow from the ByteChef editor rather than adding the key by hand.
+4. **Connection errors**: Verify connection parameters and network connectivity
+5. **JSON parsing errors**: Validate JSON format for parameters and connections
+6. **The run never finishes**: the app waits indefinitely for a terminal status. Pass `--timeout`
+   to bound it.
 
 ### Debug Mode
 

--- a/server/ee/apps/runtime-job-app/README.md
+++ b/server/ee/apps/runtime-job-app/README.md
@@ -308,11 +308,11 @@ docker run --rm \
 docker build -t bytechef/bytechef-runtime-job server/ee/apps/runtime-job-app/
 ```
 
-The release script at the repository root builds and pushes this image alongside the
-server images:
+The release script at the repository root builds and pushes this image when given the
+`--runtime-job` flag (without it, the script builds the `bytechef/bytechef` image instead):
 
 ```bash
-./docker-build.sh 20260909
+./docker-build.sh --runtime-job 20260909
 ```
 
 **Note**: To add JVM options, set `JAVA_TOOL_OPTIONS` on the container, for example

--- a/server/ee/apps/runtime-job-app/src/main/java/com/bytechef/runtime/job/RuntimeJobApplication.java
+++ b/server/ee/apps/runtime-job-app/src/main/java/com/bytechef/runtime/job/RuntimeJobApplication.java
@@ -9,14 +9,20 @@ package com.bytechef.runtime.job;
 
 import com.bytechef.commons.util.JsonUtils;
 import com.bytechef.runtime.job.executor.JobRunner;
+import com.bytechef.runtime.job.listener.JobStatusApplicationEventListener;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.convert.DurationStyle;
+import org.springframework.context.ConfigurableApplicationContext;
 
 /**
  * @version ee
@@ -30,32 +36,54 @@ public class RuntimeJobApplication implements ApplicationRunner {
     private static final Logger log = LoggerFactory.getLogger(RuntimeJobApplication.class);
 
     private final JobRunner jobRunner;
+    private final JobStatusApplicationEventListener jobStatusApplicationEventListener;
 
-    public RuntimeJobApplication(JobRunner jobRunner) {
+    @SuppressFBWarnings("EI")
+    public RuntimeJobApplication(
+        JobRunner jobRunner, JobStatusApplicationEventListener jobStatusApplicationEventListener) {
+
         this.jobRunner = jobRunner;
+        this.jobStatusApplicationEventListener = jobStatusApplicationEventListener;
     }
 
     public static void main(String[] args) {
-        SpringApplication.run(RuntimeJobApplication.class, args);
+        ConfigurableApplicationContext context = SpringApplication.run(RuntimeJobApplication.class, args);
+
+        System.exit(SpringApplication.exit(context));
     }
 
     @Override
-    public void run(ApplicationArguments args) {
-        List<String> workflow = args.getOptionValues("workflow");
+    public void run(ApplicationArguments args) throws InterruptedException {
+        String workflow = getOptionValue(args, "workflow");
 
         if (workflow == null) {
             throw new IllegalArgumentException("Workflow name is required");
         }
 
-        List<String> parameters = args.getOptionValues("parameters");
-        List<String> connections = args.getOptionValues("connections");
+        String parameters = getOptionValue(args, "parameters");
+        String connections = getOptionValue(args, "connections");
+        String timeout = getOptionValue(args, "timeout");
+
+        Duration timeoutDuration = timeout == null ? null : DurationStyle.detectAndParse(timeout);
+        Map<String, ?> jobParameters = parameters == null ? Map.of() : JsonUtils.readMap(parameters);
 
         log.info(
             "Running workflow: {} with parameters: {} and connections: {}",
             workflow, parameters == null ? "{}" : parameters, connections == null ? "{}" : connections);
 
-        Map<String, ?> jobParameters = parameters == null ? Map.of() : JsonUtils.readMap(parameters.getFirst());
+        long jobId = jobRunner.run(workflow, jobParameters);
 
-        jobRunner.run(workflow.getFirst(), jobParameters);
+        jobStatusApplicationEventListener.awaitTermination(jobId, timeoutDuration);
+    }
+
+    @Nullable
+    private static String getOptionValue(ApplicationArguments args, String name) {
+        List<String> optionValues = args.getOptionValues(name);
+
+        if (optionValues == null || optionValues.isEmpty()) {
+            return null;
+        }
+
+        return optionValues.getFirst();
     }
 }

--- a/server/ee/apps/runtime-job-app/src/main/java/com/bytechef/runtime/job/executor/JobRunner.java
+++ b/server/ee/apps/runtime-job-app/src/main/java/com/bytechef/runtime/job/executor/JobRunner.java
@@ -29,11 +29,11 @@ public class JobRunner {
         this.jobFacade = jobFacade;
     }
 
-    public void run(String workflowName, Map<String, ?> jobParameters) {
+    public long run(String workflowName, Map<String, ?> jobParameters) {
         String substring = workflowName.substring(workflowName.lastIndexOf("/") + 1, workflowName.lastIndexOf('.'));
 
         String id = EncodingUtils.base64EncodeToString(substring);
 
-        jobFacade.createJob(new JobParametersDTO(id, jobParameters));
+        return jobFacade.createJob(new JobParametersDTO(id, jobParameters));
     }
 }

--- a/server/ee/apps/runtime-job-app/src/main/java/com/bytechef/runtime/job/listener/JobStatusApplicationEventListener.java
+++ b/server/ee/apps/runtime-job-app/src/main/java/com/bytechef/runtime/job/listener/JobStatusApplicationEventListener.java
@@ -11,9 +11,16 @@ import com.bytechef.atlas.coordinator.event.ApplicationEvent;
 import com.bytechef.atlas.coordinator.event.JobStatusApplicationEvent;
 import com.bytechef.atlas.coordinator.event.listener.ApplicationEventListener;
 import com.bytechef.atlas.execution.domain.Job;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import org.springframework.boot.SpringApplication;
-import org.springframework.context.ConfigurableApplicationContext;
+import java.time.Duration;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.ExitCodeGenerator;
 import org.springframework.stereotype.Component;
 
 /**
@@ -22,23 +29,77 @@ import org.springframework.stereotype.Component;
  * @author Ivica Cardic
  */
 @Component
-public class JobStatusApplicationEventListener implements ApplicationEventListener {
+public class JobStatusApplicationEventListener implements ApplicationEventListener, ExitCodeGenerator {
 
-    private final ConfigurableApplicationContext context;
+    private static final int EXIT_CODE_FAILURE = 1;
+    private static final int EXIT_CODE_SUCCESS = 0;
 
-    @SuppressFBWarnings("EI")
-    public JobStatusApplicationEventListener(ConfigurableApplicationContext context) {
-        this.context = context;
-    }
+    private static final Set<Job.Status> TERMINAL_STATUSES =
+        EnumSet.of(Job.Status.COMPLETED, Job.Status.FAILED, Job.Status.STOPPED);
+
+    private static final Logger log = LoggerFactory.getLogger(JobStatusApplicationEventListener.class);
+
+    private final AtomicInteger exitCode = new AtomicInteger(EXIT_CODE_SUCCESS);
+    private final Object monitor = new Object();
+    private final Map<Long, Job.Status> terminalStatuses = new HashMap<>();
 
     @Override
     public void onApplicationEvent(ApplicationEvent applicationEvent) {
-        if (applicationEvent instanceof JobStatusApplicationEvent jobStatusApplicationEvent) {
-            if (jobStatusApplicationEvent.getStatus() == Job.Status.COMPLETED) {
-                SpringApplication.exit(context, () -> 0);
-            } else if (jobStatusApplicationEvent.getStatus() == Job.Status.FAILED) {
-                SpringApplication.exit(context, () -> -1);
-            }
+        if (!(applicationEvent instanceof JobStatusApplicationEvent jobStatusApplicationEvent)) {
+            return;
         }
+
+        Job.Status status = jobStatusApplicationEvent.getStatus();
+
+        if (!TERMINAL_STATUSES.contains(status)) {
+            return;
+        }
+
+        long jobId = jobStatusApplicationEvent.getJobId();
+
+        log.info("Job id={} finished with status={}", jobId, status);
+
+        synchronized (monitor) {
+            terminalStatuses.put(jobId, status);
+
+            monitor.notifyAll();
+        }
+    }
+
+    public void awaitTermination(long jobId, @Nullable Duration timeout) throws InterruptedException {
+        long deadline = timeout == null ? 0 : System.currentTimeMillis() + timeout.toMillis();
+
+        Job.Status status;
+
+        synchronized (monitor) {
+            while (!terminalStatuses.containsKey(jobId)) {
+                if (timeout == null) {
+                    monitor.wait();
+
+                    continue;
+                }
+
+                long remaining = deadline - System.currentTimeMillis();
+
+                if (remaining <= 0) {
+                    log.error("Job id={} did not reach a terminal status within {}, giving up", jobId, timeout);
+
+                    exitCode.set(EXIT_CODE_FAILURE);
+
+                    return;
+                }
+
+                monitor.wait(remaining);
+            }
+
+            status = terminalStatuses.get(jobId);
+        }
+
+        exitCode.set(status == Job.Status.COMPLETED ? EXIT_CODE_SUCCESS : EXIT_CODE_FAILURE);
+    }
+
+    @Override
+    public int getExitCode() {
+        return exitCode.get();
     }
 }

--- a/server/ee/apps/runtime-job-app/src/main/resources/config/application-bytechef.yml
+++ b/server/ee/apps/runtime-job-app/src/main/resources/config/application-bytechef.yml
@@ -1,0 +1,60 @@
+bytechef:
+  async:
+    # Upper bound on concurrent @Async tasks on the default executor. There is no queue: a submitter waits for a
+    # permit. Workflow task and trigger execution are bounded separately by bytechef.worker.task.*.
+    concurrency-limit: 200
+  cache:
+    # Cache provider (redis | caffeine) default: caffeine
+    provider: caffeine
+  data-storage:
+    # Data storage provider
+    provider: filesystem
+  # Edition (CE - Community Edition | EE - Enterprise Edition) default: EE
+  edition: EE
+  # Encryption key provider (filesystem - the key generated on filesystem, property - the key read from property) default: filesystem
+  encryption:
+    provider: filesystem
+  file-storage:
+    # File storage provider (aws(ee) | filesystem | jdbc) default: filesystem
+    provider: filesystem
+    filesystem:
+      basedir: ${user.home}/bytechef/data/file-storage
+  mail:
+    base-url: ${bytechef.public-url}
+    from: noreply@app.bytechef.io
+    host:
+    port: 25
+  message-broker:
+    # Messaging provider between Coordinator and Workers (memory) default: memory
+    provider: memory
+  observability:
+    logging:
+      enabled: false
+      endpoint: http://localhost:4318/v1/logs
+    metrics:
+      enabled: false
+      endpoint: http://localhost:4318/v1/metrics
+    tracing:
+      enabled: false
+      endpoint: http://localhost:4318/v1/traces
+  # When the worker is enabled, subscribe to the default "default" queue with 10 concurrent consumers.
+  # You may also route workflow tasks to other arbitrarily named task queues by specifying the "node"
+  # property on any given task.
+  # E.g. node: captions will route to the captions queue which a worker would subscribe to with workflow.worker.subscriptions.captions.
+  # Note: queue must be created before tasks can be routed to it. ByteChef will create the queue if it isn't already there when the worker
+  # bootstraps.
+  worker:
+    task:
+      subscriptions:
+        default: 10
+  workflow:
+    output-storage:
+      # Output storage provider for workflow output data
+      provider: filesystem
+    repository:
+      filesystem:
+        enabled: true
+        location-pattern: ${user.home}/bytechef/data/workflows/*.{json|yml|yaml}
+      classpath:
+        enabled: true
+        location-pattern: workflows/*.{json|yml|yaml}

--- a/server/ee/apps/runtime-job-app/src/main/resources/config/application-prod.yml
+++ b/server/ee/apps/runtime-job-app/src/main/resources/config/application-prod.yml
@@ -2,6 +2,9 @@ logging:
   level:
     ROOT: INFO
     com.bytechef: INFO
+  structured:
+    format:
+      console: ecs
 
 management:
   prometheus:

--- a/server/ee/apps/runtime-job-app/src/main/resources/config/application.yml
+++ b/server/ee/apps/runtime-job-app/src/main/resources/config/application.yml
@@ -52,6 +52,8 @@ management:
         step: 60
 
 spring:
+  config:
+    import: classpath:config/application-bytechef.yml
   application:
     name: runtime-job-app
   cache:
@@ -84,66 +86,3 @@ spring:
   threads:
     virtual:
       enabled: true
-
-#####
-
-bytechef:
-  async:
-    # Upper bound on concurrent @Async tasks on the default executor. There is no queue: a submitter waits for a
-    # permit. Workflow task and trigger execution are bounded separately by bytechef.worker.task.*.
-    concurrency-limit: 200
-  cache:
-    # Cache provider (redis | caffeine) default: caffeine
-    provider: caffeine
-  data-storage:
-    # Data storage provider
-    provider: filesystem
-  # Edition (CE - Community Edition | EE - Enterprise Edition) default: EE
-  edition: EE
-  # Encryption key provider (filesystem - the key generated on filesystem, property - the key read from property) default: filesystem
-  encryption:
-    provider: filesystem
-  file-storage:
-    # File storage provider (aws(ee) | filesystem | jdbc) default: filesystem
-    provider: filesystem
-    filesystem:
-      basedir: ${user.home}/bytechef/data/file-storage
-  mail:
-    base-url: ${bytechef.public-url}
-    from: noreply@app.bytechef.io
-    host:
-    port: 25
-  message-broker:
-    # Messaging provider between Coordinator and Workers (memory) default: memory
-    provider: memory
-  observability:
-    logging:
-      enabled: false
-      endpoint: http://localhost:4318/v1/logs
-    metrics:
-      enabled: false
-      endpoint: http://localhost:4318/v1/metrics
-    tracing:
-      enabled: false
-      endpoint: http://localhost:4318/v1/traces
-  # When the worker is enabled, subscribe to the default "default" queue with 10 concurrent consumers.
-  # You may also route workflow tasks to other arbitrarily named task queues by specifying the "node"
-  # property on any given task.
-  # E.g. node: captions will route to the captions queue which a worker would subscribe to with workflow.worker.subscriptions.captions.
-  # Note: queue must be created before tasks can be routed to it. ByteChef will create the queue if it isn't already there when the worker
-  # bootstraps.
-  worker:
-    task:
-      subscriptions:
-        default: 10
-  workflow:
-    output-storage:
-      # Output storage provider for workflow output data
-      provider: filesystem
-    repository:
-      filesystem:
-        enabled: true
-        location-pattern: ${user.home}/bytechef/data/workflows/*.{json|yml|yaml}
-      classpath:
-        enabled: true
-        location-pattern: workflows/*.{json|yml|yaml}

--- a/server/ee/apps/runtime-job-app/src/main/resources/config/application.yml
+++ b/server/ee/apps/runtime-job-app/src/main/resources/config/application.yml
@@ -21,6 +21,29 @@ management:
   observations:
     key-values:
       application: ${spring.application.name}
+  opentelemetry:
+    tracing:
+      export:
+        otlp:
+          endpoint: ${bytechef.observability.tracing.endpoint}
+    logging:
+      export:
+        otlp:
+          endpoint: ${bytechef.observability.logging.endpoint}
+  logging:
+    export:
+      enabled: ${bytechef.observability.logging.enabled}
+  tracing:
+    export:
+      enabled: ${bytechef.observability.tracing.enabled}
+    sampling:
+      probability: 1.0
+  otlp:
+    metrics:
+      export:
+        enabled: ${bytechef.observability.metrics.enabled}
+        step: 10s
+        url: ${bytechef.observability.metrics.endpoint}
   # Prometheus is the default metrics backend
   prometheus:
     metrics:
@@ -93,6 +116,16 @@ bytechef:
   message-broker:
     # Messaging provider between Coordinator and Workers (memory) default: memory
     provider: memory
+  observability:
+    logging:
+      enabled: false
+      endpoint: http://localhost:4318/v1/logs
+    metrics:
+      enabled: false
+      endpoint: http://localhost:4318/v1/metrics
+    tracing:
+      enabled: false
+      endpoint: http://localhost:4318/v1/traces
   # When the worker is enabled, subscribe to the default "default" queue with 10 concurrent consumers.
   # You may also route workflow tasks to other arbitrarily named task queues by specifying the "node"
   # property on any given task.

--- a/server/ee/apps/runtime-job-app/src/test/java/com/bytechef/runtime/job/RuntimeJobApplicationTest.java
+++ b/server/ee/apps/runtime-job-app/src/test/java/com/bytechef/runtime/job/RuntimeJobApplicationTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2025 ByteChef
+ *
+ * Licensed under the ByteChef Enterprise license (the "Enterprise License");
+ * you may not use this file except in compliance with the Enterprise License.
+ */
+
+package com.bytechef.runtime.job;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.bytechef.atlas.coordinator.event.JobStatusApplicationEvent;
+import com.bytechef.atlas.execution.domain.Job;
+import com.bytechef.runtime.job.executor.JobRunner;
+import com.bytechef.runtime.job.listener.JobStatusApplicationEventListener;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.ApplicationArguments;
+
+/**
+ * @version ee
+ *
+ * @author Ivica Cardic
+ */
+class RuntimeJobApplicationTest {
+
+    private ApplicationArguments applicationArguments;
+    private JobRunner jobRunner;
+    private JobStatusApplicationEventListener jobStatusApplicationEventListener;
+    private RuntimeJobApplication runtimeJobApplication;
+
+    @BeforeEach
+    void beforeEach() {
+        applicationArguments = mock(ApplicationArguments.class);
+        jobRunner = mock(JobRunner.class);
+        jobStatusApplicationEventListener = new JobStatusApplicationEventListener();
+
+        when(applicationArguments.getOptionValues("workflow")).thenReturn(List.of("/workflows/workflow1.json"));
+
+        runtimeJobApplication = new RuntimeJobApplication(jobRunner, jobStatusApplicationEventListener);
+    }
+
+    /**
+     * Job execution is fully asynchronous, so the runner must not return until the job reaches a terminal status.
+     * Returning early lets Spring Boot close the application context while tasks are still being dispatched, which
+     * makes every remaining {@code @Async} hop fail with "SimpleAsyncTaskExecutor is not active".
+     */
+    @Test
+    void testRunBlocksUntilJobReachesTerminalStatus() throws InterruptedException {
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        CountDownLatch jobSubmitted = new CountDownLatch(1);
+        CountDownLatch runReturned = new CountDownLatch(1);
+
+        doAnswer(invocation -> {
+            jobSubmitted.countDown();
+
+            return 1L;
+        }).when(jobRunner)
+            .run(anyString(), any());
+
+        Thread thread = Thread.ofVirtual()
+            .start(() -> {
+                try {
+                    runtimeJobApplication.run(applicationArguments);
+                } catch (Throwable throwable) {
+                    failure.set(throwable);
+                }
+
+                runReturned.countDown();
+            });
+
+        assertTrue(jobSubmitted.await(5, TimeUnit.SECONDS), "the job was never submitted");
+        assertFalse(
+            runReturned.await(200, TimeUnit.MILLISECONDS), "run() returned before the job reached a terminal status");
+
+        jobStatusApplicationEventListener.onApplicationEvent(new JobStatusApplicationEvent(1L, Job.Status.COMPLETED));
+
+        assertTrue(runReturned.await(5, TimeUnit.SECONDS), "run() did not return after the job completed");
+
+        thread.join();
+
+        assertNull(failure.get(), () -> "run() failed: " + failure.get());
+        assertEquals(0, jobStatusApplicationEventListener.getExitCode());
+    }
+
+    @Test
+    void testRunGivesUpOnceTheTimeoutElapses() throws InterruptedException {
+        when(applicationArguments.getOptionValues("timeout")).thenReturn(List.of("100ms"));
+
+        runtimeJobApplication.run(applicationArguments);
+
+        assertEquals(1, jobStatusApplicationEventListener.getExitCode());
+    }
+
+    /**
+     * An unparseable argument must be rejected before anything is submitted. Submitting first would start a workflow
+     * and then tear the context down around it.
+     */
+    @Test
+    void testRunRejectsAnInvalidTimeoutBeforeSubmittingTheJob() {
+        when(applicationArguments.getOptionValues("timeout")).thenReturn(List.of("bogus"));
+
+        assertThrows(IllegalArgumentException.class, () -> runtimeJobApplication.run(applicationArguments));
+
+        verifyNoInteractions(jobRunner);
+    }
+
+    /**
+     * {@code ApplicationArguments} returns an empty list for an option passed without a value, such as
+     * {@code --parameters}, so the runner must not blindly take the first element.
+     */
+    @Test
+    void testRunAcceptsOptionsPassedWithoutAValue() throws InterruptedException {
+        when(applicationArguments.getOptionValues("parameters")).thenReturn(List.of());
+        when(applicationArguments.getOptionValues("connections")).thenReturn(List.of());
+        when(jobRunner.run(anyString(), any())).thenReturn(1L);
+
+        jobStatusApplicationEventListener.onApplicationEvent(new JobStatusApplicationEvent(1L, Job.Status.COMPLETED));
+
+        runtimeJobApplication.run(applicationArguments);
+
+        verify(jobRunner).run("/workflows/workflow1.json", Map.of());
+    }
+}

--- a/server/ee/apps/runtime-job-app/src/test/java/com/bytechef/runtime/job/listener/JobStatusApplicationEventListenerTest.java
+++ b/server/ee/apps/runtime-job-app/src/test/java/com/bytechef/runtime/job/listener/JobStatusApplicationEventListenerTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2025 ByteChef
+ *
+ * Licensed under the ByteChef Enterprise license (the "Enterprise License");
+ * you may not use this file except in compliance with the Enterprise License.
+ */
+
+package com.bytechef.runtime.job.listener;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.bytechef.atlas.coordinator.event.JobStatusApplicationEvent;
+import com.bytechef.atlas.execution.domain.Job;
+import java.time.Duration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @version ee
+ *
+ * @author Ivica Cardic
+ */
+class JobStatusApplicationEventListenerTest {
+
+    private JobStatusApplicationEventListener jobStatusApplicationEventListener;
+
+    @BeforeEach
+    void beforeEach() {
+        jobStatusApplicationEventListener = new JobStatusApplicationEventListener();
+    }
+
+    @Test
+    void testExitCodeIsSuccessOnCompletedStatus() throws InterruptedException {
+        jobStatusApplicationEventListener.onApplicationEvent(
+            new JobStatusApplicationEvent(1L, Job.Status.COMPLETED));
+
+        jobStatusApplicationEventListener.awaitTermination(1L, null);
+
+        assertEquals(0, jobStatusApplicationEventListener.getExitCode());
+    }
+
+    @Test
+    void testExitCodeIsFailureOnFailedStatus() throws InterruptedException {
+        jobStatusApplicationEventListener.onApplicationEvent(new JobStatusApplicationEvent(1L, Job.Status.FAILED));
+
+        jobStatusApplicationEventListener.awaitTermination(1L, null);
+
+        assertEquals(1, jobStatusApplicationEventListener.getExitCode());
+    }
+
+    @Test
+    void testExitCodeIsFailureOnStoppedStatus() throws InterruptedException {
+        jobStatusApplicationEventListener.onApplicationEvent(new JobStatusApplicationEvent(1L, Job.Status.STOPPED));
+
+        jobStatusApplicationEventListener.awaitTermination(1L, null);
+
+        assertEquals(1, jobStatusApplicationEventListener.getExitCode());
+    }
+
+    @Test
+    void testExitCodeIsFailureWhenTimeoutElapses() throws InterruptedException {
+        jobStatusApplicationEventListener.awaitTermination(1L, Duration.ofMillis(50));
+
+        assertEquals(1, jobStatusApplicationEventListener.getExitCode());
+    }
+
+    /**
+     * A subflow publishes a terminal event for its child job before the parent continues, so a terminal status for any
+     * job other than the one being waited on must not release the runner.
+     */
+    @Test
+    void testTerminalStatusOfAnotherJobDoesNotTerminate() throws InterruptedException {
+        jobStatusApplicationEventListener.onApplicationEvent(
+            new JobStatusApplicationEvent(2L, Job.Status.COMPLETED));
+
+        jobStatusApplicationEventListener.awaitTermination(1L, Duration.ofMillis(50));
+
+        assertEquals(1, jobStatusApplicationEventListener.getExitCode());
+    }
+
+    @Test
+    void testTerminalStatusRecordedBeforeAwaitIsNotMissed() throws InterruptedException {
+        jobStatusApplicationEventListener.onApplicationEvent(
+            new JobStatusApplicationEvent(1L, Job.Status.COMPLETED));
+
+        jobStatusApplicationEventListener.awaitTermination(1L, Duration.ofMillis(50));
+
+        assertEquals(0, jobStatusApplicationEventListener.getExitCode());
+    }
+
+    @Test
+    void testNonTerminalStatusDoesNotTerminate() throws InterruptedException {
+        jobStatusApplicationEventListener.onApplicationEvent(new JobStatusApplicationEvent(1L, Job.Status.CREATED));
+        jobStatusApplicationEventListener.onApplicationEvent(new JobStatusApplicationEvent(1L, Job.Status.STARTED));
+
+        jobStatusApplicationEventListener.awaitTermination(1L, Duration.ofMillis(50));
+
+        assertEquals(1, jobStatusApplicationEventListener.getExitCode());
+    }
+}

--- a/server/libs/atlas/atlas-coordinator/atlas-coordinator-impl/src/main/java/com/bytechef/atlas/coordinator/TaskCoordinator.java
+++ b/server/libs/atlas/atlas-coordinator/atlas-coordinator-impl/src/main/java/com/bytechef/atlas/coordinator/TaskCoordinator.java
@@ -246,6 +246,8 @@ public class TaskCoordinator {
     private void handleJobExecutionException(Job job, Exception exception) {
         long jobId = Validate.notNull(job.getId(), "id");
 
+        log.error("Job id={} execution failed", jobId, exception);
+
         String errorMessage = resolveErrorMessage(exception);
 
         Optional<TaskExecution> taskExecutionOptional = taskExecutionService.fetchLastJobTaskExecution(jobId);


### PR DESCRIPTION
Publishes the runtime job app as a Docker image, and makes a run's exit code mean what an external orchestrator already assumes it means.

- **Published image.** `docker-build.sh` builds and pushes `bytechef/bytechef-runtime-job` alongside the server images, on the same `yyyyMMdd` tag scheme. The unused Jib plugin goes — images come from the Dockerfiles.
- **Waits for the job.** The app blocks in its `ApplicationRunner` until the job reaches a terminal status, instead of exiting from inside the status event listener. Exit `0` on completion, `1` on failure, stop, or timeout — failure was `-1`, which a shell reports as `255`.
- **`--timeout=<duration>` added.** Without it a wedged workflow holds a pod open indefinitely, and `backoffLimit` does nothing for a pod that is merely stuck.
- **Container arguments reach the JVM.** `ENTRYPOINT` moves to exec form, so `--workflow=…` passed to `docker run` is forwarded rather than swallowed by the shell.
- **OTLP export off by default**, per signal, the same `bytechef.observability.*` mapping the server uses; the `prod` profile logs structured JSON.
- **Docs and README** rewritten around what actually trips people up: `--workflow` is a lookup key, not a path — the directory part is discarded and the base name becomes the workflow id, so mounting the file is what makes it reachable. Adds where-workflows-load-from and troubleshooting tables.

Stacked on #5741.

Closes #2904

